### PR TITLE
feat: upstream model health monitoring

### DIFF
--- a/internal/api/admin/dashboard.go
+++ b/internal/api/admin/dashboard.go
@@ -34,6 +34,15 @@ type dashboardStatsResponse struct {
 	Tokens24h       int64           `json:"tokens_24h"`
 	CostEstimate24h float64         `json:"cost_estimate_24h"`
 	BudgetWarnings  []budgetWarning `json:"budget_warnings,omitempty"`
+	// ModelsHealthy is the count of registered models whose current health
+	// status is "healthy". Zero when health monitoring is not enabled.
+	ModelsHealthy int `json:"models_healthy"`
+	// ModelsUnhealthy is the count of registered models whose current health
+	// status is "unhealthy". Zero when health monitoring is not enabled.
+	ModelsUnhealthy int `json:"models_unhealthy"`
+	// ModelsDegraded is the count of registered models whose current health
+	// status is "degraded". Zero when health monitoring is not enabled.
+	ModelsDegraded int `json:"models_degraded"`
 }
 
 // DashboardStats handles GET /api/v1/dashboard/stats.
@@ -220,6 +229,19 @@ func (h *Handler) DashboardStats(c fiber.Ctx) error {
 					Usage:       monthlyUsage,
 					PercentUsed: pct,
 				})
+			}
+		}
+	}
+
+	if h.HealthChecker != nil {
+		for _, mh := range h.HealthChecker.GetAllHealth() {
+			switch mh.Status {
+			case "healthy":
+				resp.ModelsHealthy++
+			case "unhealthy":
+				resp.ModelsUnhealthy++
+			case "degraded":
+				resp.ModelsDegraded++
 			}
 		}
 	}

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -14,11 +14,19 @@ import (
 	"github.com/voidmind-io/voidllm/internal/cache"
 	"github.com/voidmind-io/voidllm/internal/config"
 	"github.com/voidmind-io/voidllm/internal/db"
+	"github.com/voidmind-io/voidllm/internal/health"
 	"github.com/voidmind-io/voidllm/internal/license"
 	"github.com/voidmind-io/voidllm/internal/proxy"
 	voidredis "github.com/voidmind-io/voidllm/internal/redis"
 	"github.com/voidmind-io/voidllm/internal/sso"
 )
+
+// ModelHealthProvider provides upstream model health status for the admin API.
+// It is implemented by *health.Checker and may be nil when health monitoring
+// is not enabled.
+type ModelHealthProvider interface {
+	GetAllHealth() []health.ModelHealth
+}
 
 // Handler holds shared dependencies for all admin API handlers.
 type Handler struct {
@@ -38,6 +46,9 @@ type Handler struct {
 	SSOProvider *sso.Provider
 	// SSOConfig holds the SSO configuration passed from the application config.
 	SSOConfig config.SSOConfig
+	// HealthChecker provides upstream model health status. Nil when health
+	// monitoring is not enabled.
+	HealthChecker ModelHealthProvider
 }
 
 // swaggerErrorResponse is the standard API error envelope used in OpenAPI docs.

--- a/internal/api/admin/models.go
+++ b/internal/api/admin/models.go
@@ -673,6 +673,26 @@ func (h *Handler) DeactivateModel(c fiber.Ctx) error {
 	return c.JSON(modelToResponse(m))
 }
 
+// GetModelHealth handles GET /api/v1/models/health.
+// It returns the most recent health probe results for all registered models.
+// When health monitoring is not enabled, an empty list is returned.
+//
+// @Summary      Get upstream model health
+// @Description  Returns the latest health check results for all registered models. Requires member role or above.
+// @Tags         models
+// @Produce      json
+// @Success      200  {object}  map[string]any
+// @Failure      401  {object}  swaggerErrorResponse
+// @Failure      403  {object}  swaggerErrorResponse
+// @Security     BearerAuth
+// @Router       /models/health [get]
+func (h *Handler) GetModelHealth(c fiber.Ctx) error {
+	if h.HealthChecker == nil {
+		return c.JSON(fiber.Map{"models": []any{}})
+	}
+	return c.JSON(fiber.Map{"models": h.HealthChecker.GetAllHealth()})
+}
+
 // testConnectionRequest is the JSON body accepted by TestModelConnection.
 type testConnectionRequest struct {
 	Provider string `json:"provider"`

--- a/internal/api/admin/routes.go
+++ b/internal/api/admin/routes.go
@@ -101,8 +101,9 @@ func RegisterRoutes(app *fiber.App, handler *Handler, keyCache *cache.Cache[stri
 	// Models — global resources managed by system admins only.
 	// An org_admin in a multi-org deployment must not be able to add or modify
 	// models that are visible to all organisations.
-	// test-connection is registered before /:model_id so Fiber does not treat
-	// "test-connection" as a model_id parameter value.
+	// Static sub-paths (health, test-connection) are registered before
+	// /:model_id so Fiber does not treat them as model_id parameter values.
+	api.Get("/models/health", auth.RequireRole(auth.RoleMember), handler.GetModelHealth)
 	api.Post("/models/test-connection", auth.RequireRole(auth.RoleSystemAdmin), handler.TestModelConnection)
 	api.Post("/models", auth.RequireRole(auth.RoleSystemAdmin), handler.CreateModel)
 	api.Get("/models", auth.RequireRole(auth.RoleSystemAdmin), handler.ListModels)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -32,6 +32,7 @@ import (
 	"github.com/voidmind-io/voidllm/internal/config"
 	"github.com/voidmind-io/voidllm/internal/db"
 	"github.com/voidmind-io/voidllm/internal/docs"
+	"github.com/voidmind-io/voidllm/internal/health"
 	"github.com/voidmind-io/voidllm/internal/license"
 	"github.com/voidmind-io/voidllm/internal/metrics"
 	voidotel "github.com/voidmind-io/voidllm/internal/otel"
@@ -64,10 +65,11 @@ type Application struct {
 	accessCache *proxy.ModelAccessCache
 	aliasCache  *proxy.AliasCache
 
-	rateLimiter  ratelimit.Checker
-	tokenCounter *ratelimit.TokenCounter
-	usageLogger  *usage.Logger
-	auditLogger  *audit.Logger
+	rateLimiter    ratelimit.Checker
+	tokenCounter   *ratelimit.TokenCounter
+	usageLogger    *usage.Logger
+	auditLogger    *audit.Logger
+	healthChecker  *health.Checker
 
 	shutdownState *shutdown.State
 	proxyHandler  *proxy.ProxyHandler
@@ -453,6 +455,19 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 		}
 	}
 
+	// Build the health checker when at least one probe level is enabled.
+	var healthChecker *health.Checker
+	hcCfg := cfg.Settings.HealthCheck
+	if hcCfg.Health.Enabled || hcCfg.Models.Enabled || hcCfg.Functional.Enabled {
+		healthChecker = health.NewChecker(registry, hcCfg, log)
+	}
+	if hcCfg.Functional.Enabled {
+		log.LogAttrs(ctx, slog.LevelWarn,
+			"functional health probe enabled — sends billable requests to upstream providers",
+			slog.Duration("interval", hcCfg.Functional.Interval),
+		)
+	}
+
 	proxyHandler := proxy.NewProxyHandler(registry, log)
 	proxyHandler.AccessCache = accessCache
 	proxyHandler.AliasCache = aliasCache
@@ -481,6 +496,12 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 		SSOProvider:   ssoProvider,
 		SSOConfig:     cfg.Settings.SSO,
 	}
+	// Only assign the health checker when it was actually created — a typed nil
+	// (*health.Checker)(nil) satisfies the interface but is NOT == nil when
+	// checked as ModelHealthProvider, causing nil-pointer panics.
+	if healthChecker != nil {
+		adminHandler.HealthChecker = healthChecker
+	}
 
 	success = true
 	return &Application{
@@ -500,6 +521,7 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 		tokenCounter:  tokenCounter,
 		usageLogger:   usageLogger,
 		auditLogger:   auditLogger,
+		healthChecker: healthChecker,
 		shutdownState: shutdownState,
 		proxyHandler:  proxyHandler,
 		adminHandler:  adminHandler,
@@ -559,6 +581,11 @@ func (a *Application) Start() error {
 	// TTL-keyed counters that self-expire, so no eviction goroutine is needed.
 	if memRL, ok := a.rateLimiter.(*ratelimit.RateLimiter); ok {
 		a.stopFuncs = append(a.stopFuncs, startTicker(5*time.Minute, memRL.EvictStale))
+	}
+
+	// Start upstream model health monitoring when at least one probe is enabled.
+	if a.healthChecker != nil {
+		a.stopFuncs = append(a.stopFuncs, a.healthChecker.Start())
 	}
 
 	// Start heartbeat if a license key was configured, even if it has expired.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -237,6 +237,25 @@ func (s SSOConfig) LogValue() slog.Value {
 	)
 }
 
+// HealthCheckConfig holds configuration for the upstream model health monitoring subsystem.
+type HealthCheckConfig struct {
+	// Health configures the lightweight GET / reachability probe.
+	Health HealthProbeConfig `yaml:"health"`
+	// Models configures the GET /models API availability probe.
+	Models HealthProbeConfig `yaml:"models"`
+	// Functional configures the POST /chat/completions end-to-end probe.
+	Functional HealthProbeConfig `yaml:"functional"`
+}
+
+// HealthProbeConfig holds the enable flag and polling interval for a single
+// health probe level.
+type HealthProbeConfig struct {
+	// Enabled controls whether this probe level is active.
+	Enabled bool `yaml:"enabled"`
+	// Interval is how often the probe is executed for each registered model.
+	Interval time.Duration `yaml:"interval"`
+}
+
 // SettingsConfig holds application-level settings.
 type SettingsConfig struct {
 	AdminKey      string          `yaml:"admin_key" json:"-"`
@@ -254,6 +273,7 @@ type SettingsConfig struct {
 	SSO           SSOConfig       `yaml:"sso"`
 	TokenCounting TokenCountingConfig `yaml:"token_counting"`
 	CircuitBreaker CircuitBreakerConfig `yaml:"circuit_breaker"`
+	HealthCheck   HealthCheckConfig    `yaml:"health_check"`
 	// SoftLimitThreshold uses *float64 so that an explicit 0.0 can be
 	// distinguished from the zero value after unmarshalling. Use
 	// GetSoftLimitThreshold to read the value.
@@ -494,6 +514,29 @@ func (c *Config) setDefaults() {
 	}
 	if c.Settings.SSO.GroupClaim == "" {
 		c.Settings.SSO.GroupClaim = "groups"
+	}
+
+	// Health check — only set interval defaults when the probe is explicitly
+	// enabled; never auto-enable a probe that the user has not opted into.
+	if c.Settings.HealthCheck.Health.Enabled && c.Settings.HealthCheck.Health.Interval == 0 {
+		c.Settings.HealthCheck.Health.Interval = 30 * time.Second
+	}
+	if c.Settings.HealthCheck.Models.Enabled && c.Settings.HealthCheck.Models.Interval == 0 {
+		c.Settings.HealthCheck.Models.Interval = 60 * time.Second
+	}
+	if c.Settings.HealthCheck.Functional.Enabled && c.Settings.HealthCheck.Functional.Interval == 0 {
+		c.Settings.HealthCheck.Functional.Interval = 5 * time.Minute
+	}
+
+	// Enforce minimum polling intervals to prevent accidental DoS of upstreams.
+	if c.Settings.HealthCheck.Health.Enabled && c.Settings.HealthCheck.Health.Interval < 10*time.Second {
+		c.Settings.HealthCheck.Health.Interval = 10 * time.Second
+	}
+	if c.Settings.HealthCheck.Models.Enabled && c.Settings.HealthCheck.Models.Interval < 10*time.Second {
+		c.Settings.HealthCheck.Models.Interval = 10 * time.Second
+	}
+	if c.Settings.HealthCheck.Functional.Enabled && c.Settings.HealthCheck.Functional.Interval < 60*time.Second {
+		c.Settings.HealthCheck.Functional.Interval = 60 * time.Second
 	}
 
 	// Logging

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -1,0 +1,440 @@
+// Package health implements periodic upstream model health monitoring.
+// It probes registered models at three configurable levels and exposes the
+// results via GetHealth / GetAllHealth for the admin API and Prometheus metrics.
+package health
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/voidmind-io/voidllm/internal/config"
+	"github.com/voidmind-io/voidllm/internal/metrics"
+	"github.com/voidmind-io/voidllm/internal/proxy"
+)
+
+// probeLevel identifies which probe produced a result so that the correct
+// field on ModelHealth can be updated.
+type probeLevel int
+
+const (
+	levelHealth     probeLevel = iota
+	levelModels
+	levelFunctional
+)
+
+// probeTimeout is the per-request context deadline for all probe types.
+const probeTimeout = 10 * time.Second
+
+// ModelHealth holds the most recent health state for a single upstream model.
+type ModelHealth struct {
+	// ModelName is the canonical registry name of the model.
+	ModelName string `json:"name"`
+	// Status is the overall health classification derived from all enabled
+	// probe results: "healthy", "degraded", "unhealthy", or "unknown".
+	Status string `json:"status"`
+	// LastCheck is the UTC timestamp of the most recent probe cycle.
+	LastCheck time.Time `json:"last_check"`
+	// LastError holds the error message from the most recently failed probe,
+	// or is empty when all probes passed.
+	LastError string `json:"last_error,omitempty"`
+	// LatencyMs is the round-trip time of the most recent successful probe
+	// in milliseconds. Zero when no probe has succeeded yet.
+	LatencyMs int64 `json:"latency_ms"`
+	// HealthOK is nil when the health probe is disabled; otherwise it reflects
+	// whether the last GET / probe could reach the server.
+	HealthOK *bool `json:"health_ok"`
+	// ModelsOK is nil when the models probe is disabled; otherwise it reflects
+	// whether the last GET /models probe returned a 2xx response.
+	ModelsOK *bool `json:"models_ok"`
+	// FunctionalOK is nil when the functional probe is disabled; otherwise it
+	// reflects whether the last POST /chat/completions probe returned a 2xx
+	// response.
+	FunctionalOK *bool `json:"functional_ok"`
+}
+
+// Checker periodically probes all models registered in the proxy.Registry at
+// up to three configurable levels and stores the results in memory. All methods
+// are safe for concurrent use.
+type Checker struct {
+	registry *proxy.Registry
+	results  sync.Map // map[string]*ModelHealth — keyed by model name, replaced atomically
+	cfg      config.HealthCheckConfig
+	client   *http.Client
+	log      *slog.Logger
+}
+
+// NewChecker constructs a Checker that will probe the models in registry
+// according to cfg. The http.Client used for probes relies on per-request
+// context timeouts (probeTimeout) and does not follow redirects.
+func NewChecker(registry *proxy.Registry, cfg config.HealthCheckConfig, log *slog.Logger) *Checker {
+	return &Checker{
+		registry: registry,
+		cfg:      cfg,
+		client: &http.Client{
+			Transport: &http.Transport{
+				TLSHandshakeTimeout: 10 * time.Second,
+				IdleConnTimeout:     90 * time.Second,
+			},
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		log: log,
+	}
+}
+
+// GetHealth returns the most recent health state for the model identified by
+// name. It returns nil and false when the model has not yet been probed or
+// does not exist in the registry. The returned pointer is safe to read without
+// further synchronization — stored values are never mutated after being placed
+// in the map.
+func (c *Checker) GetHealth(modelName string) (*ModelHealth, bool) {
+	v, ok := c.results.Load(modelName)
+	if !ok {
+		return nil, false
+	}
+	return v.(*ModelHealth), true
+}
+
+// GetAllHealth returns a snapshot of health state for every model that has
+// been probed at least once. The returned slice follows the registry ordering
+// (sorted by name).
+func (c *Checker) GetAllHealth() []ModelHealth {
+	models := c.registry.List()
+	result := make([]ModelHealth, 0, len(models))
+	for _, m := range models {
+		if v, ok := c.results.Load(m.Name); ok {
+			mh := v.(*ModelHealth)
+			result = append(result, *mh)
+		}
+	}
+	return result
+}
+
+// Start launches the enabled probe tickers. It immediately runs a first probe
+// cycle for all models before waiting for the first tick interval. The returned
+// function stops all tickers and waits for their goroutines to exit.
+func (c *Checker) Start() func() {
+	var stopFuncs []func()
+
+	if c.cfg.Health.Enabled {
+		c.runAll(levelHealth)
+		stopFuncs = append(stopFuncs, c.startTicker(c.cfg.Health.Interval, func() {
+			c.runAll(levelHealth)
+		}))
+	}
+
+	if c.cfg.Models.Enabled {
+		c.runAll(levelModels)
+		stopFuncs = append(stopFuncs, c.startTicker(c.cfg.Models.Interval, func() {
+			c.runAll(levelModels)
+		}))
+	}
+
+	if c.cfg.Functional.Enabled {
+		c.runAll(levelFunctional)
+		stopFuncs = append(stopFuncs, c.startTicker(c.cfg.Functional.Interval, func() {
+			c.runAll(levelFunctional)
+		}))
+	}
+
+	return func() {
+		for _, stop := range stopFuncs {
+			stop()
+		}
+	}
+}
+
+// runAll executes the probe identified by level for every model in the registry.
+func (c *Checker) runAll(level probeLevel) {
+	models := c.registry.List()
+	for _, m := range models {
+		c.runOne(m, level)
+	}
+}
+
+// runOne executes a single probe for model m at the given level and atomically
+// replaces the stored ModelHealth using copy-on-write to avoid data races.
+func (c *Checker) runOne(m proxy.Model, level probeLevel) {
+	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
+	defer cancel()
+
+	latencyMs, err := execProbe(ctx, c.client, m, level)
+
+	// Load existing or create a zero value to copy from.
+	existing, _ := c.results.LoadOrStore(m.Name, &ModelHealth{ModelName: m.Name, Status: "unknown"})
+	old := existing.(*ModelHealth)
+
+	// Copy-on-write: mutate the copy, then store atomically. This eliminates
+	// the data race that would occur if multiple probe-level goroutines
+	// mutated the same *ModelHealth in place.
+	updated := *old
+	updated.LastCheck = time.Now().UTC()
+
+	ok := err == nil
+	if ok {
+		updated.LatencyMs = latencyMs
+		updated.LastError = ""
+	} else {
+		updated.LastError = sanitizeError(err)
+		c.log.LogAttrs(ctx, slog.LevelDebug, "health probe failed",
+			slog.String("model", m.Name),
+			slog.String("error", updated.LastError),
+		)
+	}
+
+	switch level {
+	case levelHealth:
+		updated.HealthOK = &ok
+		if ok {
+			updated.LatencyMs = latencyMs
+		}
+	case levelModels:
+		updated.ModelsOK = &ok
+	case levelFunctional:
+		updated.FunctionalOK = &ok
+	}
+
+	updated.Status = deriveStatus(&updated)
+	c.results.Store(m.Name, &updated)
+
+	updateMetrics(m.Name, &updated)
+}
+
+// execProbe dispatches to the appropriate probe function for the given level.
+func execProbe(ctx context.Context, client *http.Client, m proxy.Model, level probeLevel) (int64, error) {
+	switch level {
+	case levelHealth:
+		return probeHealth(ctx, client, m)
+	case levelModels:
+		return probeModels(ctx, client, m)
+	case levelFunctional:
+		return probeFunctional(ctx, client, m)
+	default:
+		return 0, fmt.Errorf("unknown probe level %d", level)
+	}
+}
+
+// sanitizeError converts a raw error message to a safe, low-information string
+// that does not expose internal URLs, IP addresses, or stack details.
+func sanitizeError(err error) string {
+	msg := err.Error()
+	if strings.Contains(msg, "connection refused") {
+		return "connection refused"
+	}
+	if strings.Contains(msg, "connection reset") {
+		return "connection reset"
+	}
+	if strings.Contains(msg, "timeout") || strings.Contains(msg, "deadline exceeded") {
+		return "request timeout"
+	}
+	if strings.Contains(msg, "no such host") {
+		return "dns resolution failed"
+	}
+	if strings.Contains(msg, "tls") || strings.Contains(msg, "certificate") {
+		return "tls error"
+	}
+	if strings.HasPrefix(msg, "http ") {
+		// e.g. "http 401" — safe to surface, contains no internal details.
+		return msg
+	}
+	return "probe failed"
+}
+
+// serverRoot extracts the scheme + host from a base URL, stripping any path
+// like "/v1". This gives us the actual server root for health pings.
+func serverRoot(baseURL string) string {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return strings.TrimRight(baseURL, "/")
+	}
+	return u.Scheme + "://" + u.Host
+}
+
+// probeHealth performs a GET to the model's server root. Any HTTP response —
+// even 4xx or 5xx — is treated as success because receiving a response means
+// the server is reachable. Only connection-level errors (refused, timeout,
+// DNS failure) indicate an unhealthy host.
+func probeHealth(ctx context.Context, client *http.Client, m proxy.Model) (int64, error) {
+	rawURL := serverRoot(m.BaseURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	setAuthHeaders(req, m)
+
+	start := time.Now()
+	resp, err := client.Do(req)
+	latencyMs := time.Since(start).Milliseconds()
+	if latencyMs == 0 {
+		latencyMs = 1 // sub-millisecond response, show as 1ms rather than 0
+	}
+	if err != nil {
+		return 0, fmt.Errorf("connection failed: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	// Any HTTP response means the server is reachable — healthy.
+	return latencyMs, nil
+}
+
+// probeModels performs a GET to <base_url>/models and returns success on any
+// 2xx HTTP response.
+func probeModels(ctx context.Context, client *http.Client, m proxy.Model) (int64, error) {
+	rawURL := strings.TrimRight(m.BaseURL, "/") + "/models"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("build request: %w", err)
+	}
+
+	setAuthHeaders(req, m)
+
+	start := time.Now()
+	resp, err := client.Do(req)
+	latencyMs := time.Since(start).Milliseconds()
+	if err != nil {
+		return 0, fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return 0, fmt.Errorf("http %d", resp.StatusCode)
+	}
+	return latencyMs, nil
+}
+
+// probeFunctional performs a minimal POST /chat/completions request with a
+// single-token max to verify end-to-end functionality of the upstream model.
+// For Azure models the deployment name is used as the model identifier.
+func probeFunctional(ctx context.Context, client *http.Client, m proxy.Model) (int64, error) {
+	rawURL := strings.TrimRight(m.BaseURL, "/") + "/chat/completions"
+
+	upstreamModel := m.Name
+	if m.Provider == "azure" && m.AzureDeployment != "" {
+		upstreamModel = m.AzureDeployment
+	}
+
+	payload := map[string]any{
+		"model":      upstreamModel,
+		"messages":   []map[string]string{{"role": "user", "content": "hi"}},
+		"max_tokens": 1,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return 0, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
+	if err != nil {
+		return 0, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	setAuthHeaders(req, m)
+
+	start := time.Now()
+	resp, err := client.Do(req)
+	latencyMs := time.Since(start).Milliseconds()
+	if err != nil {
+		return 0, fmt.Errorf("do request: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return 0, fmt.Errorf("http %d", resp.StatusCode)
+	}
+	return latencyMs, nil
+}
+
+// setAuthHeaders adds the appropriate authentication headers to req based on
+// the model's provider. Anthropic uses the x-api-key header scheme; all other
+// providers use Bearer token authorization.
+func setAuthHeaders(req *http.Request, m proxy.Model) {
+	if m.APIKey == "" {
+		return
+	}
+	if m.Provider == "anthropic" {
+		req.Header.Set("x-api-key", m.APIKey)
+		req.Header.Set("anthropic-version", "2023-06-01")
+	} else {
+		req.Header.Set("Authorization", "Bearer "+m.APIKey)
+	}
+}
+
+// deriveStatus computes the overall status from the individual probe results.
+func deriveStatus(h *ModelHealth) string {
+	// If the health (reachability) probe was checked and failed → unhealthy.
+	if h.HealthOK != nil && !*h.HealthOK {
+		return "unhealthy"
+	}
+	// If any checked probe failed → degraded.
+	if (h.ModelsOK != nil && !*h.ModelsOK) || (h.FunctionalOK != nil && !*h.FunctionalOK) {
+		return "degraded"
+	}
+	// If at least one probe was checked and all passed → healthy.
+	if h.HealthOK != nil || h.ModelsOK != nil || h.FunctionalOK != nil {
+		return "healthy"
+	}
+	return "unknown"
+}
+
+// updateMetrics refreshes the Prometheus gauges for the given model after a
+// probe cycle completes. All status label values are reset to zero before
+// setting the current status to avoid stale time series.
+func updateMetrics(modelName string, mh *ModelHealth) {
+	// Reset all status labels to avoid stale series from previous status values.
+	for _, s := range []string{"healthy", "degraded", "unhealthy", "unknown"} {
+		metrics.ModelHealthStatus.WithLabelValues(modelName, s).Set(0)
+	}
+
+	var val float64
+	switch mh.Status {
+	case "healthy":
+		val = 1
+	case "degraded":
+		val = 0.5
+	default: // "unhealthy" or "unknown"
+		val = 0
+	}
+	metrics.ModelHealthStatus.WithLabelValues(modelName, mh.Status).Set(val)
+
+	if mh.LatencyMs > 0 {
+		metrics.ModelHealthLatencySeconds.WithLabelValues(modelName).Set(float64(mh.LatencyMs) / 1000)
+	}
+}
+
+// startTicker runs fn on the given interval and returns a stop function that
+// signals the goroutine to exit and waits for it to finish.
+func (c *Checker) startTicker(interval time.Duration, fn func()) func() {
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				fn()
+			case <-done:
+				return
+			}
+		}
+	}()
+	return func() { close(done); wg.Wait() }
+}

--- a/internal/health/checker_test.go
+++ b/internal/health/checker_test.go
@@ -1,0 +1,483 @@
+package health_test
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/voidmind-io/voidllm/internal/config"
+	"github.com/voidmind-io/voidllm/internal/health"
+	"github.com/voidmind-io/voidllm/internal/proxy"
+)
+
+// newRegistry builds a one-model Registry pointing at the supplied base URL.
+// It uses config.ModelConfig so the full NewRegistry path is exercised.
+func newRegistry(t *testing.T, baseURL string) *proxy.Registry {
+	t.Helper()
+	reg, err := proxy.NewRegistry([]config.ModelConfig{
+		{
+			Name:     "test-model",
+			Provider: "openai",
+			BaseURL:  baseURL,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	return reg
+}
+
+// newLogger returns a discard slog.Logger so probe debug lines don't clutter
+// test output.
+func newLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// boolPtr is a small helper so tests can write boolPtr(true) instead of &v.
+func boolPtr(v bool) *bool { return &v }
+
+// cfg constructs a HealthCheckConfig with only the requested level enabled and
+// a long tick interval so the ticker never fires during the test.
+func cfg(health, models, functional bool) config.HealthCheckConfig {
+	const neverTick = 24 * time.Hour
+	return config.HealthCheckConfig{
+		Health:     config.HealthProbeConfig{Enabled: health, Interval: neverTick},
+		Models:     config.HealthProbeConfig{Enabled: models, Interval: neverTick},
+		Functional: config.HealthProbeConfig{Enabled: functional, Interval: neverTick},
+	}
+}
+
+// TestProbeHealth_Success verifies that a 200 response from the upstream marks
+// HealthOK=true and status=healthy.
+func TestProbeHealth_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	reg := newRegistry(t, srv.URL)
+	c := health.NewChecker(reg, cfg(true, false, false), newLogger())
+	stop := c.Start()
+	t.Cleanup(stop)
+
+	mh, ok := c.GetHealth("test-model")
+	if !ok {
+		t.Fatal("GetHealth returned false; probe did not run")
+	}
+	if mh.HealthOK == nil || !*mh.HealthOK {
+		t.Errorf("HealthOK = %v, want true", mh.HealthOK)
+	}
+	if mh.Status != "healthy" {
+		t.Errorf("Status = %q, want %q", mh.Status, "healthy")
+	}
+}
+
+// TestProbeHealth_AnyHTTPResponseIsHealthy verifies that any HTTP response —
+// including 500 — is treated as healthy by the health probe, because receiving
+// a response means the server is reachable. Only connection errors are unhealthy.
+func TestProbeHealth_AnyHTTPResponseIsHealthy(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	reg := newRegistry(t, srv.URL)
+	c := health.NewChecker(reg, cfg(true, false, false), newLogger())
+	stop := c.Start()
+	t.Cleanup(stop)
+
+	mh, ok := c.GetHealth("test-model")
+	if !ok {
+		t.Fatal("GetHealth returned false; probe did not run")
+	}
+	// A 500 response still means the server is reachable — health probe passes.
+	if mh.HealthOK == nil || !*mh.HealthOK {
+		t.Errorf("HealthOK = %v, want true (any HTTP response = reachable)", mh.HealthOK)
+	}
+	if mh.Status != "healthy" {
+		t.Errorf("Status = %q, want %q", mh.Status, "healthy")
+	}
+}
+
+// TestProbeHealth_Unreachable verifies that an unreachable URL marks
+// HealthOK=false and status=unhealthy.
+func TestProbeHealth_Unreachable(t *testing.T) {
+	t.Parallel()
+
+	// Use a URL that refuses connections immediately.
+	reg := newRegistry(t, "http://127.0.0.1:1")
+	c := health.NewChecker(reg, cfg(true, false, false), newLogger())
+	stop := c.Start()
+	t.Cleanup(stop)
+
+	mh, ok := c.GetHealth("test-model")
+	if !ok {
+		t.Fatal("GetHealth returned false; probe did not run")
+	}
+	if mh.HealthOK == nil || *mh.HealthOK {
+		t.Errorf("HealthOK = %v, want false", mh.HealthOK)
+	}
+	if mh.Status != "unhealthy" {
+		t.Errorf("Status = %q, want %q", mh.Status, "unhealthy")
+	}
+}
+
+// TestProbeModels_Success verifies that a 200 from GET /models marks
+// ModelsOK=true and status=healthy.
+func TestProbeModels_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/models" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"object":"list","data":[]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	reg := newRegistry(t, srv.URL)
+	c := health.NewChecker(reg, cfg(false, true, false), newLogger())
+	stop := c.Start()
+	t.Cleanup(stop)
+
+	mh, ok := c.GetHealth("test-model")
+	if !ok {
+		t.Fatal("GetHealth returned false; probe did not run")
+	}
+	if mh.ModelsOK == nil || !*mh.ModelsOK {
+		t.Errorf("ModelsOK = %v, want true", mh.ModelsOK)
+	}
+	if mh.Status != "healthy" {
+		t.Errorf("Status = %q, want %q", mh.Status, "healthy")
+	}
+}
+
+// TestProbeModels_AuthFailure verifies that a 401 from GET /models marks
+// ModelsOK=false and status=degraded (health probe is not run, so the
+// upstream is still considered reachable).
+func TestProbeModels_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/models" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	reg := newRegistry(t, srv.URL)
+	// Only the models probe is enabled; the health probe is off, so HealthOK
+	// stays nil. A failing models probe should produce "degraded", not "unhealthy".
+	c := health.NewChecker(reg, cfg(false, true, false), newLogger())
+	stop := c.Start()
+	t.Cleanup(stop)
+
+	mh, ok := c.GetHealth("test-model")
+	if !ok {
+		t.Fatal("GetHealth returned false; probe did not run")
+	}
+	if mh.ModelsOK == nil || *mh.ModelsOK {
+		t.Errorf("ModelsOK = %v, want false", mh.ModelsOK)
+	}
+	if mh.HealthOK != nil {
+		t.Errorf("HealthOK = %v, want nil (probe disabled)", mh.HealthOK)
+	}
+	if mh.Status != "degraded" {
+		t.Errorf("Status = %q, want %q", mh.Status, "degraded")
+	}
+}
+
+// TestProbeFunctional_Success verifies that a 200 from POST /chat/completions
+// marks FunctionalOK=true and status=healthy.
+func TestProbeFunctional_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/chat/completions" && r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"hi"}}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	reg := newRegistry(t, srv.URL)
+	c := health.NewChecker(reg, cfg(false, false, true), newLogger())
+	stop := c.Start()
+	t.Cleanup(stop)
+
+	mh, ok := c.GetHealth("test-model")
+	if !ok {
+		t.Fatal("GetHealth returned false; probe did not run")
+	}
+	if mh.FunctionalOK == nil || !*mh.FunctionalOK {
+		t.Errorf("FunctionalOK = %v, want true", mh.FunctionalOK)
+	}
+	if mh.Status != "healthy" {
+		t.Errorf("Status = %q, want %q", mh.Status, "healthy")
+	}
+}
+
+// TestProbeFunctional_Failure verifies that a 500 from POST /chat/completions
+// marks FunctionalOK=false and status=degraded.
+func TestProbeFunctional_Failure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/chat/completions" && r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	reg := newRegistry(t, srv.URL)
+	c := health.NewChecker(reg, cfg(false, false, true), newLogger())
+	stop := c.Start()
+	t.Cleanup(stop)
+
+	mh, ok := c.GetHealth("test-model")
+	if !ok {
+		t.Fatal("GetHealth returned false; probe did not run")
+	}
+	if mh.FunctionalOK == nil || *mh.FunctionalOK {
+		t.Errorf("FunctionalOK = %v, want false", mh.FunctionalOK)
+	}
+	if mh.Status != "degraded" {
+		t.Errorf("Status = %q, want %q", mh.Status, "degraded")
+	}
+}
+
+// TestDeriveStatus_AllHealthy exercises the Checker with all three probes
+// enabled against a server that succeeds everywhere, expecting status=healthy.
+func TestDeriveStatus_AllHealthy(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	reg := newRegistry(t, srv.URL)
+	allEnabled := config.HealthCheckConfig{
+		Health:     config.HealthProbeConfig{Enabled: true, Interval: 24 * time.Hour},
+		Models:     config.HealthProbeConfig{Enabled: true, Interval: 24 * time.Hour},
+		Functional: config.HealthProbeConfig{Enabled: true, Interval: 24 * time.Hour},
+	}
+	c := health.NewChecker(reg, allEnabled, newLogger())
+	stop := c.Start()
+	t.Cleanup(stop)
+
+	mh, ok := c.GetHealth("test-model")
+	if !ok {
+		t.Fatal("GetHealth returned false; probe did not run")
+	}
+	if mh.Status != "healthy" {
+		t.Errorf("Status = %q, want %q", mh.Status, "healthy")
+	}
+	if mh.HealthOK == nil || !*mh.HealthOK {
+		t.Errorf("HealthOK = %v, want true", mh.HealthOK)
+	}
+	if mh.ModelsOK == nil || !*mh.ModelsOK {
+		t.Errorf("ModelsOK = %v, want true", mh.ModelsOK)
+	}
+	if mh.FunctionalOK == nil || !*mh.FunctionalOK {
+		t.Errorf("FunctionalOK = %v, want true", mh.FunctionalOK)
+	}
+}
+
+// TestDeriveStatus_HealthFailed verifies that when the health probe cannot
+// reach the server (connection refused) the status is unhealthy regardless of
+// other probe results. The functional probe is configured but never fires
+// because both probe levels use the same (unreachable) base URL.
+func TestDeriveStatus_HealthFailed(t *testing.T) {
+	t.Parallel()
+
+	// Port 1 refuses connections immediately — this triggers a connection-level
+	// error, which is the only way to make the health probe report HealthOK=false
+	// after Fix 2 (any HTTP response = reachable).
+	reg := newRegistry(t, "http://127.0.0.1:1")
+	c := health.NewChecker(reg, cfg(true, false, false), newLogger())
+	stop := c.Start()
+	t.Cleanup(stop)
+
+	mh, ok := c.GetHealth("test-model")
+	if !ok {
+		t.Fatal("GetHealth returned false; probe did not run")
+	}
+	if mh.HealthOK == nil || *mh.HealthOK {
+		t.Errorf("HealthOK = %v, want false", mh.HealthOK)
+	}
+	if mh.Status != "unhealthy" {
+		t.Errorf("Status = %q, want %q", mh.Status, "unhealthy")
+	}
+}
+
+// TestDeriveStatus_Degraded verifies that when health passes but the models
+// probe fails the status is degraded.
+func TestDeriveStatus_Degraded(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/models" {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	reg := newRegistry(t, srv.URL)
+	c := health.NewChecker(reg, cfg(true, true, false), newLogger())
+	stop := c.Start()
+	t.Cleanup(stop)
+
+	mh, ok := c.GetHealth("test-model")
+	if !ok {
+		t.Fatal("GetHealth returned false; probe did not run")
+	}
+	if mh.HealthOK == nil || !*mh.HealthOK {
+		t.Errorf("HealthOK = %v, want true", mh.HealthOK)
+	}
+	if mh.ModelsOK == nil || *mh.ModelsOK {
+		t.Errorf("ModelsOK = %v, want false", mh.ModelsOK)
+	}
+	if mh.Status != "degraded" {
+		t.Errorf("Status = %q, want %q", mh.Status, "degraded")
+	}
+}
+
+// TestDeriveStatus_Unknown verifies that when no probe has been run for a
+// model, GetHealth returns false (no result stored yet).
+func TestDeriveStatus_Unknown(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	reg := newRegistry(t, srv.URL)
+	// All probes disabled — Start() runs no initial probe cycle.
+	noneEnabled := config.HealthCheckConfig{}
+	c := health.NewChecker(reg, noneEnabled, newLogger())
+	stop := c.Start()
+	t.Cleanup(stop)
+
+	_, ok := c.GetHealth("test-model")
+	if ok {
+		t.Error("GetHealth returned true; expected false because no probe was run")
+	}
+}
+
+// TestStartStop verifies that calling Start then immediately calling the
+// returned stop function does not panic or deadlock.
+func TestStartStop(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	reg := newRegistry(t, srv.URL)
+	allEnabled := config.HealthCheckConfig{
+		Health:     config.HealthProbeConfig{Enabled: true, Interval: 24 * time.Hour},
+		Models:     config.HealthProbeConfig{Enabled: true, Interval: 24 * time.Hour},
+		Functional: config.HealthProbeConfig{Enabled: true, Interval: 24 * time.Hour},
+	}
+	c := health.NewChecker(reg, allEnabled, newLogger())
+
+	stop := c.Start()
+	stop() // must not panic, race, or deadlock
+}
+
+// TestGetAllHealth verifies that GetAllHealth returns results for every
+// model that has been probed at least once.
+func TestGetAllHealth(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	reg, err := proxy.NewRegistry([]config.ModelConfig{
+		{Name: "alpha", Provider: "openai", BaseURL: srv.URL},
+		{Name: "beta", Provider: "openai", BaseURL: srv.URL},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	c := health.NewChecker(reg, cfg(true, false, false), newLogger())
+	stop := c.Start()
+	t.Cleanup(stop)
+
+	all := c.GetAllHealth()
+	if len(all) != 2 {
+		t.Fatalf("GetAllHealth returned %d results, want 2", len(all))
+	}
+	for _, mh := range all {
+		if mh.Status != "healthy" {
+			t.Errorf("model %q: Status = %q, want %q", mh.ModelName, mh.Status, "healthy")
+		}
+	}
+}
+
+// TestGetAllHealth_NoneProbed verifies that GetAllHealth returns an empty slice
+// when no probe has run yet.
+func TestGetAllHealth_NoneProbed(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	reg := newRegistry(t, srv.URL)
+	c := health.NewChecker(reg, config.HealthCheckConfig{}, newLogger())
+	stop := c.Start()
+	t.Cleanup(stop)
+
+	all := c.GetAllHealth()
+	if len(all) != 0 {
+		t.Errorf("GetAllHealth = %d entries, want 0", len(all))
+	}
+}
+
+// TestSanitizeError_ConnectionRefused verifies that the sanitizer maps a
+// connection-refused error (which contains the upstream IP) to a safe string.
+func TestSanitizeError_ConnectionRefused(t *testing.T) {
+	t.Parallel()
+
+	// A connection-refused error will contain "connection refused" and the
+	// URL — the sanitized output must not leak the URL.
+	reg := newRegistry(t, "http://127.0.0.1:1")
+	c := health.NewChecker(reg, cfg(true, false, false), newLogger())
+	stop := c.Start()
+	t.Cleanup(stop)
+
+	mh, ok := c.GetHealth("test-model")
+	if !ok {
+		t.Fatal("GetHealth returned false; probe did not run")
+	}
+	if mh.LastError != "connection refused" {
+		t.Errorf("LastError = %q, want %q", mh.LastError, "connection refused")
+	}
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -84,6 +84,31 @@ var CacheSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Help: "Number of entries in each in-memory cache.",
 }, []string{"cache"})
 
+// ModelHealthStatus tracks the current health status of each upstream model as
+// a gauge value: 1 = healthy, 0.5 = degraded, 0 = unhealthy or unknown.
+// The "status" label carries the string status ("healthy", "degraded",
+// "unhealthy", "unknown") alongside the numeric value for easy querying.
+var ModelHealthStatus = promauto.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: "voidllm",
+		Name:      "model_health_status",
+		Help:      "Current health status of upstream models (1=healthy, 0.5=degraded, 0=unhealthy).",
+	},
+	[]string{"model", "status"},
+)
+
+// ModelHealthLatencySeconds tracks the most recently observed health check
+// round-trip latency in seconds, labelled by model name. Updated after each
+// successful probe cycle.
+var ModelHealthLatencySeconds = promauto.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Namespace: "voidllm",
+		Name:      "model_health_latency_seconds",
+		Help:      "Last health check latency in seconds per model.",
+	},
+	[]string{"model"},
+)
+
 // RegisterDBCollectors registers database connection pool metrics against the
 // default Prometheus registry. The gauges are implemented as GaugeFuncs that
 // read live values from sql.DB.Stats() on each scrape, so they always reflect

--- a/ui/src/hooks/useDashboardStats.ts
+++ b/ui/src/hooks/useDashboardStats.ts
@@ -18,6 +18,9 @@ export interface DashboardStats {
   tokens_24h: number
   cost_estimate_24h: number
   budget_warnings?: BudgetWarning[]
+  models_healthy: number
+  models_unhealthy: number
+  models_degraded: number
 }
 
 export function useDashboardStats() {

--- a/ui/src/hooks/useModelHealth.ts
+++ b/ui/src/hooks/useModelHealth.ts
@@ -1,0 +1,25 @@
+import { useQuery } from '@tanstack/react-query'
+import apiClient from '../api/client'
+
+export interface ModelHealthInfo {
+  name: string
+  status: 'healthy' | 'degraded' | 'unhealthy' | 'unknown'
+  latency_ms: number
+  last_check: string
+  last_error?: string
+  health_ok: boolean | null
+  models_ok: boolean | null
+  functional_ok: boolean | null
+}
+
+interface ModelHealthResponse {
+  models: ModelHealthInfo[]
+}
+
+export function useModelHealth() {
+  return useQuery({
+    queryKey: ['model-health'],
+    queryFn: () => apiClient<ModelHealthResponse>('/models/health'),
+    refetchInterval: 15_000, // refresh every 15s for near-realtime health
+  })
+}

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -14,6 +14,8 @@ import { useTopModels } from '../hooks/useTopModels'
 import type { UsageDataPoint } from '../hooks/useTopModels'
 import { useUsage } from '../hooks/useUsage'
 import { useOrg } from '../hooks/useOrg'
+import { useModelHealth } from '../hooks/useModelHealth'
+import type { ModelHealthInfo } from '../hooks/useModelHealth'
 import { formatTokens, formatCost, formatNumber } from '../lib/utils'
 
 // ---------------------------------------------------------------------------
@@ -126,17 +128,18 @@ function TimeRangePills({
 // ---------------------------------------------------------------------------
 
 function PerfBadge({ ms }: { ms: number }) {
-  if (ms < 500) {
+  if (ms <= 0) return null
+  if (ms < 100) {
     return (
       <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-success/10 text-success">
         Fast
       </span>
     )
   }
-  if (ms < 2000) {
+  if (ms < 500) {
     return (
       <span className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-warning/10 text-warning">
-        Moderate
+        Normal
       </span>
     )
   }
@@ -148,10 +151,32 @@ function PerfBadge({ ms }: { ms: number }) {
 }
 
 // ---------------------------------------------------------------------------
-// MiniTable column definitions
+// MiniTable column definitions — uses health check latency (server ping)
+// instead of avg request duration which is misleading for streaming.
 // ---------------------------------------------------------------------------
 
-const performanceColumns: MiniTableColumn<UsageDataPoint>[] = [
+interface PerfRow {
+  group_key: string
+  health_latency_ms: number
+  tps: number
+}
+
+function buildPerfRows(topModels: UsageDataPoint[], healthData: ModelHealthInfo[]): PerfRow[] {
+  const healthMap = new Map(healthData.map((h) => [h.name, h]))
+  return topModels.map((m) => {
+    const h = healthMap.get(m.group_key)
+    const tps = m.total_requests > 0 && m.avg_duration_ms > 0
+      ? Math.round((m.total_tokens / m.total_requests) / (m.avg_duration_ms / 1000))
+      : 0
+    return {
+      group_key: m.group_key,
+      health_latency_ms: h?.latency_ms ?? 0,
+      tps,
+    }
+  })
+}
+
+const performanceColumns: MiniTableColumn<PerfRow>[] = [
   {
     key: 'model',
     header: 'Model',
@@ -161,23 +186,26 @@ const performanceColumns: MiniTableColumn<UsageDataPoint>[] = [
   },
   {
     key: 'latency',
-    header: 'Avg Latency',
+    header: 'Latency',
     align: 'right',
     render: (row) => (
       <div className="flex items-center justify-end gap-2">
-        <span className="text-text-secondary tabular-nums">{Math.round(row.avg_duration_ms)}ms</span>
-        <PerfBadge ms={row.avg_duration_ms} />
+        <span className="text-text-secondary tabular-nums">
+          {row.health_latency_ms > 0 ? `${row.health_latency_ms}ms` : '—'}
+        </span>
+        <PerfBadge ms={row.health_latency_ms} />
       </div>
     ),
   },
   {
-    key: 'tpr',
-    header: 'Tokens/Req',
+    key: 'tps',
+    header: 'Throughput',
     align: 'right',
-    render: (row) => {
-      const tpr = row.total_requests > 0 ? Math.round(row.total_tokens / row.total_requests) : 0
-      return <span className="text-text-secondary tabular-nums">{formatNumber(tpr)}</span>
-    },
+    render: (row) => (
+      <span className="text-text-secondary tabular-nums">
+        {row.tps > 0 ? `${formatNumber(row.tps)} tok/s` : '—'}
+      </span>
+    ),
   },
 ]
 
@@ -220,6 +248,35 @@ function IconKey() {
   )
 }
 
+function IconHeartPulse() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z" />
+      <path d="M3.22 12H9.5l1.5-3 2 4.5 1.5-3h5.27" />
+    </svg>
+  )
+}
+
+function IconAlertTriangle() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3Z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  )
+}
+
+function IconXCircle() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <line x1="15" y1="9" x2="9" y2="15" />
+      <line x1="9" y1="9" x2="15" y2="15" />
+    </svg>
+  )
+}
+
 // ---------------------------------------------------------------------------
 // DashboardPage
 // ---------------------------------------------------------------------------
@@ -241,6 +298,13 @@ export default function DashboardPage() {
   const { data: topModels, isLoading: modelsLoading } = useTopModels(
     orgId,
     canViewOrgUsage,
+  )
+  const { data: modelHealth } = useModelHealth()
+
+  // Performance rows combining usage data with health check latency
+  const perfRows = useMemo(
+    () => buildPerfRows(topModels?.data ?? [], modelHealth?.models ?? []),
+    [topModels?.data, modelHealth?.models],
   )
 
   // Time-series data for the area chart
@@ -346,6 +410,36 @@ export default function DashboardPage() {
             iconColor="pink"
           />
         </div>
+
+        {/* Model Health summary — only shown when at least one model has health data */}
+        {!statsLoading &&
+          (stats?.models_healthy ?? 0) + (stats?.models_degraded ?? 0) + (stats?.models_unhealthy ?? 0) > 0 && (
+            <div>
+              <h2 className="text-sm font-medium text-text-tertiary uppercase tracking-wider mb-3">
+                Model Health
+              </h2>
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                <StatCard
+                  label="Healthy"
+                  value={stats?.models_healthy ?? 0}
+                  icon={<IconHeartPulse />}
+                  iconColor="green"
+                />
+                <StatCard
+                  label="Degraded"
+                  value={stats?.models_degraded ?? 0}
+                  icon={<IconAlertTriangle />}
+                  iconColor="yellow"
+                />
+                <StatCard
+                  label="Unhealthy"
+                  value={stats?.models_unhealthy ?? 0}
+                  icon={<IconXCircle />}
+                  iconColor="red"
+                />
+              </div>
+            </div>
+          )}
 
         {/* Token budget section */}
         {me?.org_id != null && !statsLoading && (
@@ -462,10 +556,10 @@ export default function DashboardPage() {
                     <div key={i} className="h-8 bg-bg-tertiary rounded animate-pulse" />
                   ))}
                 </div>
-              ) : (topModels?.data?.length ?? 0) > 0 ? (
-                <MiniTable<UsageDataPoint>
+              ) : perfRows.length > 0 ? (
+                <MiniTable<PerfRow>
                   columns={performanceColumns}
-                  data={topModels?.data ?? []}
+                  data={perfRows}
                 />
               ) : (
                 <p className="text-sm text-text-tertiary">No model data available</p>

--- a/ui/src/pages/ModelsPage.tsx
+++ b/ui/src/pages/ModelsPage.tsx
@@ -17,6 +17,8 @@ import {
   useToggleModel,
 } from '../hooks/useModels'
 import type { ModelResponse, CreateModelParams, UpdateModelParams } from '../hooks/useModels'
+import { useModelHealth } from '../hooks/useModelHealth'
+import type { ModelHealthInfo } from '../hooks/useModelHealth'
 import { useToast } from '../hooks/useToast'
 import { providerBadgeVariant, isKnownProvider } from '../lib/providers'
 import type { ProviderKey } from '../lib/providers'
@@ -104,6 +106,49 @@ function IconTrash() {
       <path d="M14 11v6" />
       <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
     </svg>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// HealthBadge
+// ---------------------------------------------------------------------------
+
+const healthConfig: Record<
+  ModelHealthInfo['status'],
+  { dotClass: string; label: string }
+> = {
+  healthy:   { dotClass: 'bg-success',         label: 'Healthy' },
+  degraded:  { dotClass: 'bg-warning',          label: 'Degraded' },
+  unhealthy: { dotClass: 'bg-error',            label: 'Unhealthy' },
+  unknown:   { dotClass: 'bg-text-tertiary',    label: 'Unknown' },
+}
+
+interface HealthBadgeProps {
+  info: ModelHealthInfo | undefined
+}
+
+function HealthBadge({ info }: HealthBadgeProps) {
+  if (info === undefined) {
+    return (
+      <div className="flex items-center gap-1.5">
+        <span className="w-2 h-2 rounded-full bg-text-tertiary opacity-40 shrink-0" aria-hidden="true" />
+        <span className="text-text-tertiary text-sm">Unknown</span>
+      </div>
+    )
+  }
+
+  const { dotClass, label } = healthConfig[info.status]
+
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex items-center gap-1.5">
+        <span className={cn('w-2 h-2 rounded-full shrink-0', dotClass)} aria-hidden="true" />
+        <span className="text-text-secondary text-sm">{label}</span>
+      </div>
+      {info.latency_ms > 0 && (
+        <span className="text-text-tertiary text-xs tabular-nums">{info.latency_ms}ms</span>
+      )}
+    </div>
   )
 }
 
@@ -612,6 +657,7 @@ export default function ModelsPage() {
   const [deleteModelId, setDeleteModelId] = useState<string | null>(null)
 
   const { data: models, isLoading } = useModels()
+  const { data: healthData } = useModelHealth()
   const deleteModel = useDeleteModel()
   const toggleModel = useToggleModel()
   const { toast } = useToast()
@@ -619,6 +665,15 @@ export default function ModelsPage() {
   const allModels = models?.data ?? []
   const activeCount = allModels.filter((m) => m.is_active).length
   const inactiveCount = allModels.length - activeCount
+
+  // Build O(1) lookup: model name → health info
+  const healthByName = React.useMemo(() => {
+    const map = new Map<string, ModelHealthInfo>()
+    for (const h of healthData?.models ?? []) {
+      map.set(h.name, h)
+    }
+    return map
+  }, [healthData])
 
   const columns: Column<ModelResponse>[] = [
     {
@@ -639,6 +694,11 @@ export default function ModelsPage() {
           </Badge>
         )
       },
+    },
+    {
+      key: 'health',
+      header: 'Health',
+      render: (row) => <HealthBadge info={healthByName.get(row.name)} />,
     },
     {
       key: 'aliases',


### PR DESCRIPTION
## Summary

Proactive upstream model health monitoring with 3 configurable probe levels.

### Health Check Levels

| Level | Probe | Default |
|---|---|---|
| `health` | GET server root (any HTTP response = healthy) | On, 30s |
| `models` | GET /models (2xx = ok) | Off, 60s |
| `functional` | POST /chat/completions with 1 token | Off, 5m |

### Backend
- New `internal/health/` package with Checker, 3 probe types
- Copy-on-write for thread-safe concurrent results
- Error sanitization (no internal URLs/IPs leaked)
- Minimum interval enforcement (10s health/models, 60s functional)
- Prometheus gauges: `model_health_status` + `model_health_latency_seconds`
- API: `GET /api/v1/models/health`
- Dashboard stats: `models_healthy` / `models_unhealthy` / `models_degraded`
- 15 health checker tests

### Frontend
- Health badges on Models page (green/yellow/red dots)
- Model Health section on Dashboard
- Model Performance table uses health latency + TPS (not misleading avg duration)
- `useModelHealth` hook with 15s polling

### Config
```yaml
settings:
  health_check:
    health:
      enabled: true
      interval: 30s
```

## Test plan
- [x] `go test ./... -race` 17/17 passed
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm run test -- --run` 305/305 passed
- [x] Manual: dolphin-mistral shows "healthy" with 1ms latency
- [x] Manual: unreachable models show "unhealthy"