### PR TITLE
feat: default config fallback + Railway one-click deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,3 @@ VOLUME ["/data"]
 EXPOSE 8080 8443
 USER voidllm
 ENTRYPOINT ["voidllm"]
-CMD ["--config", "/etc/voidllm/voidllm.yaml"]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ docker run -p 8080:8080 \
 
 Open `http://localhost:8080` — log in, create keys, start proxying.
 
+### One-Click Deploy
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/new/template?template=https://github.com/voidmind-io/voidllm)
+
+Set `VOIDLLM_ENCRYPTION_KEY` in Railway's environment variables. VoidLLM starts with sensible defaults — add models through the UI after deploy.
+
 ```bash
 # Your apps just point here instead of the provider
 curl http://localhost:8080/v1/chat/completions \

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -337,7 +337,8 @@ func Load(path string) (*Config, error) {
 		var err error
 		path, err = findConfigFile()
 		if err != nil {
-			return nil, fmt.Errorf("config: locate config file: %w", err)
+			slog.Info("no config file found, using environment variables and built-in defaults")
+			return loadDefaults()
 		}
 	}
 
@@ -393,6 +394,21 @@ func findConfigFile() (string, error) {
 	}
 
 	return "", fmt.Errorf("no config file found; set VOIDLLM_CONFIG or place voidllm.yaml in the current directory")
+}
+
+// loadDefaults returns a Config populated entirely from environment
+// variables and built-in defaults. It is used when no configuration
+// file is found.
+func loadDefaults() (*Config, error) {
+	var cfg Config
+	cfg.Settings.AdminKey = os.Getenv("VOIDLLM_ADMIN_KEY")
+	cfg.Settings.EncryptionKey = os.Getenv("VOIDLLM_ENCRYPTION_KEY")
+	cfg.Settings.License = os.Getenv("VOIDLLM_LICENSE")
+	cfg.setDefaults()
+	if err := cfg.validate(); err != nil {
+		return nil, fmt.Errorf("config: %w", err)
+	}
+	return &cfg, nil
 }
 
 // setDefaults populates zero-value fields with their documented defaults.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -822,26 +822,87 @@ func TestLoad_VoidllmConfigEnvVar(t *testing.T) {
 	}
 }
 
-func TestLoad_NoPathNoEnvVarNoFile(t *testing.T) {
-	// t.Setenv and os.Chdir require sequential execution; no t.Parallel() here.
-
-	// Ensure VOIDLLM_CONFIG is not set and no ./voidllm.yaml exists in the
-	// current working directory. We change to a fresh temp dir for this test.
+// isolateFromFilesystem changes into a fresh temp directory so that no
+// ./voidllm.yaml is present, clears VOIDLLM_CONFIG, and also clears the two
+// env-based secrets so each sub-test starts from a known baseline.
+// It restores everything via t.Cleanup.
+func isolateFromFilesystem(t *testing.T) {
+	t.Helper()
 	dir := t.TempDir()
 	original, err := os.Getwd()
 	if err != nil {
-		t.Fatalf("Getwd: %v", err)
+		t.Fatalf("isolateFromFilesystem: Getwd: %v", err)
 	}
 	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("Chdir: %v", err)
+		t.Fatalf("isolateFromFilesystem: Chdir: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chdir(original) })
-
 	t.Setenv("VOIDLLM_CONFIG", "")
+	t.Setenv("VOIDLLM_ENCRYPTION_KEY", "")
+	t.Setenv("VOIDLLM_ADMIN_KEY", "")
+}
 
-	_, err = config.Load("")
+// TestLoad_NoPathNoEnvVarNoFile tests the new loadDefaults() fallback path.
+// When no config file is found Load("") now calls loadDefaults(), which reads
+// secrets from environment variables and runs validate(). Without an encryption
+// key the validation error must mention "settings.encryption_key".
+func TestLoad_NoPathNoEnvVarNoFile(t *testing.T) {
+	// t.Setenv and os.Chdir require sequential execution; no t.Parallel() here.
+	isolateFromFilesystem(t)
+
+	_, err := config.Load("")
 	if err == nil {
-		t.Fatal("Load(\"\") expected error when no config file found, got nil")
+		t.Fatal("Load(\"\") with no encryption key: expected validation error, got nil")
+	}
+	if !strings.Contains(err.Error(), "settings.encryption_key") {
+		t.Errorf("Load(\"\") error = %q, want it to mention %q", err.Error(), "settings.encryption_key")
+	}
+}
+
+// TestLoad_FallbackToDefaultsWithEncryptionKey verifies that Load("") succeeds
+// and returns a fully-defaulted Config (proxy port 8080) when no config file
+// exists but VOIDLLM_ENCRYPTION_KEY is present in the environment.
+func TestLoad_FallbackToDefaultsWithEncryptionKey(t *testing.T) {
+	// t.Setenv and os.Chdir require sequential execution; no t.Parallel() here.
+	isolateFromFilesystem(t)
+	t.Setenv("VOIDLLM_ENCRYPTION_KEY", "test-encryption-key-32chars-long!")
+
+	cfg, err := config.Load("")
+	if err != nil {
+		t.Fatalf("Load(\"\") with VOIDLLM_ENCRYPTION_KEY set: unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("Load(\"\") returned nil config")
+	}
+	if cfg.Server.Proxy.Port != 8080 {
+		t.Errorf("Server.Proxy.Port = %d, want 8080", cfg.Server.Proxy.Port)
+	}
+	if cfg.Settings.EncryptionKey != "test-encryption-key-32chars-long!" {
+		t.Errorf("Settings.EncryptionKey = %q, want %q", cfg.Settings.EncryptionKey, "test-encryption-key-32chars-long!")
+	}
+}
+
+// TestLoad_FallbackToDefaultsPicksUpAdminKey verifies that Load("") populates
+// both Settings.EncryptionKey and Settings.AdminKey from the environment when
+// no config file is present.
+func TestLoad_FallbackToDefaultsPicksUpAdminKey(t *testing.T) {
+	// t.Setenv and os.Chdir require sequential execution; no t.Parallel() here.
+	isolateFromFilesystem(t)
+	t.Setenv("VOIDLLM_ENCRYPTION_KEY", "test-encryption-key-32chars-long!")
+	t.Setenv("VOIDLLM_ADMIN_KEY", "vl_sa_testsecretadminkey")
+
+	cfg, err := config.Load("")
+	if err != nil {
+		t.Fatalf("Load(\"\") with both env keys set: unexpected error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("Load(\"\") returned nil config")
+	}
+	if cfg.Settings.EncryptionKey != "test-encryption-key-32chars-long!" {
+		t.Errorf("Settings.EncryptionKey = %q, want %q", cfg.Settings.EncryptionKey, "test-encryption-key-32chars-long!")
+	}
+	if cfg.Settings.AdminKey != "vl_sa_testsecretadminkey" {
+		t.Errorf("Settings.AdminKey = %q, want %q", cfg.Settings.AdminKey, "vl_sa_testsecretadminkey")
 	}
 }
 

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "dockerImage": "ghcr.io/voidmind-io/voidllm:latest"
+  },
+  "deploy": {
+    "healthcheckPath": "/healthz",
+    "healthcheckTimeout": 10,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}


### PR DESCRIPTION
## Summary

- VoidLLM now starts with built-in defaults when no config file is found, reading `VOIDLLM_ENCRYPTION_KEY`, `VOIDLLM_ADMIN_KEY`, and `VOIDLLM_LICENSE` from environment variables
- Removes hardcoded `--config` CMD from Dockerfile — auto-discovery finds mounted configs, falls back to defaults
- Adds Railway one-click deploy button to README

## Test plan

- [ ] `go test ./internal/config/... -race` passes (3 new test cases for loadDefaults)
- [ ] `VOIDLLM_ENCRYPTION_KEY=test go run ./cmd/voidllm` starts without config file
- [ ] `go run ./cmd/voidllm` without env vars fails with clear `settings.encryption_key` error
- [ ] Existing docker-compose with mounted config still works