### PR TITLE
test: comprehensive admin API test coverage

### DIFF
--- a/internal/api/admin/invites_test.go
+++ b/internal/api/admin/invites_test.go
@@ -1,0 +1,636 @@
+package admin_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/voidmind-io/voidllm/internal/auth"
+	"github.com/voidmind-io/voidllm/internal/db"
+	"github.com/voidmind-io/voidllm/pkg/keygen"
+)
+
+// invitesURL returns the base invites URL for an org.
+func invitesURL(orgID string) string {
+	return "/api/v1/orgs/" + orgID + "/invites"
+}
+
+// inviteItemURL returns the URL for a specific invite within an org.
+func inviteItemURL(orgID, inviteID string) string {
+	return "/api/v1/orgs/" + orgID + "/invites/" + inviteID
+}
+
+// mustCreateInviteViaAPI calls CreateInvite through the HTTP handler and
+// returns the parsed response body. It fatals the test if the status is not 201.
+func mustCreateInviteViaAPI(t *testing.T, app *fiber.App, orgID, callerKey, email, role string) map[string]any {
+	t.Helper()
+	body := map[string]any{"email": email, "role": role}
+	req := httptest.NewRequest("POST", invitesURL(orgID), bodyJSON(t, body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+callerKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("mustCreateInviteViaAPI: app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusCreated {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("mustCreateInviteViaAPI: status = %d, want 201; body: %s", resp.StatusCode, b)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+	return got
+}
+
+// mustCreateInviteDB inserts an invite token directly via the DB for test setup.
+func mustCreateInviteDB(t *testing.T, database *db.DB, orgID, email, role, createdBy string) *db.InviteToken {
+	t.Helper()
+	plaintext, err := keygen.Generate(keygen.KeyTypeInvite)
+	if err != nil {
+		t.Fatalf("mustCreateInviteDB: generate token: %v", err)
+	}
+	tokenHash := keygen.Hash(plaintext, testHMACSecret)
+	tokenHint := keygen.Hint(plaintext)
+	invite, err := database.CreateInviteToken(context.Background(), db.CreateInviteTokenParams{
+		TokenHash: tokenHash,
+		TokenHint: tokenHint,
+		OrgID:     orgID,
+		Email:     email,
+		Role:      role,
+		ExpiresAt: "2099-01-01T00:00:00Z",
+		CreatedBy: createdBy,
+	})
+	if err != nil {
+		t.Fatalf("mustCreateInviteDB(%q, %q): %v", orgID, email, err)
+	}
+	return invite
+}
+
+// ---- POST /api/v1/orgs/:org_id/invites --------------------------------------
+
+func TestCreateInvite(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		role       string
+		sameOrg    bool
+		body       any
+		wantStatus int
+		checkField string
+	}{
+		{
+			name:       "org_admin creates member invite",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			body:       map[string]any{"email": "newmember@example.com", "role": "member"},
+			wantStatus: fiber.StatusCreated,
+			checkField: "token",
+		},
+		{
+			name:       "system_admin creates member invite",
+			role:       auth.RoleSystemAdmin,
+			sameOrg:    false,
+			body:       map[string]any{"email": "sysadmin-invite@example.com", "role": "member"},
+			wantStatus: fiber.StatusCreated,
+			checkField: "token",
+		},
+		{
+			name:       "system_admin creates org_admin invite",
+			role:       auth.RoleSystemAdmin,
+			sameOrg:    false,
+			body:       map[string]any{"email": "orgadmin-invite@example.com", "role": "org_admin"},
+			wantStatus: fiber.StatusCreated,
+			checkField: "token",
+		},
+		{
+			name:       "missing email returns 400",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			body:       map[string]any{"role": "member"},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "invalid email no at-sign returns 400",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			body:       map[string]any{"email": "notanemail", "role": "member"},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "invalid role returns 400",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			body:       map[string]any{"email": "x@example.com", "role": "superuser"},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "org_admin cannot invite org_admin returns 403",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			body:       map[string]any{"email": "promo@example.com", "role": "org_admin"},
+			wantStatus: fiber.StatusForbidden,
+		},
+		{
+			name:       "member returns 403 from route middleware",
+			role:       auth.RoleMember,
+			sameOrg:    true,
+			body:       map[string]any{"email": "member-try@example.com", "role": "member"},
+			wantStatus: fiber.StatusForbidden,
+		},
+		{
+			name:       "org_admin of different org returns 403",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    false,
+			body:       map[string]any{"email": "cross-org@example.com", "role": "member"},
+			wantStatus: fiber.StatusForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dsn := fmt.Sprintf("file:TestCreateInvite_%s?mode=memory&cache=private", strings.ReplaceAll(tc.name, " ", "_"))
+			app, database, keyCache := setupTestApp(t, dsn)
+
+			org := mustCreateOrg(t, database, "Invite Org", "invite-org-ci-"+strings.ReplaceAll(tc.name, " ", "-"))
+			creator := mustCreateUser(t, database, "creator-ci-"+strings.ReplaceAll(tc.name, " ", "-")+"@example.com", "Creator")
+
+			keyOrgID := "00000000-0000-0000-0000-000000000000"
+			if tc.sameOrg {
+				keyOrgID = org.ID
+			}
+			testKey := addTestKeyWithUser(t, keyCache, tc.role, keyOrgID, creator.ID)
+
+			req := httptest.NewRequest("POST", invitesURL(org.ID), bodyJSON(t, tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testKey)
+
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+			if err != nil {
+				t.Fatalf("app.Test: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				b, _ := io.ReadAll(resp.Body)
+				t.Errorf("status = %d, want %d; body: %s", resp.StatusCode, tc.wantStatus, b)
+				return
+			}
+
+			if tc.checkField != "" {
+				var got map[string]any
+				decodeBody(t, resp.Body, &got)
+				if v, ok := got[tc.checkField]; !ok || v == "" {
+					t.Errorf("response missing non-empty field %q; got: %v", tc.checkField, got)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateInvite_NoAuth(t *testing.T) {
+	t.Parallel()
+
+	app, database, _ := setupTestApp(t, "file:TestCreateInvite_NoAuth?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Auth Org", "auth-org-invite-noauth")
+
+	req := httptest.NewRequest("POST", invitesURL(org.ID),
+		bodyJSON(t, map[string]any{"email": "x@x.com", "role": "member"}))
+	req.Header.Set("Content-Type", "application/json")
+	// No Authorization header.
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", resp.StatusCode, fiber.StatusUnauthorized)
+	}
+}
+
+func TestCreateInvite_DefaultRole(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestCreateInvite_DefaultRole?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Default Role Org", "default-role-org")
+	creator := mustCreateUser(t, database, "creator-dr@example.com", "Creator DR")
+	testKey := addTestKeyWithUser(t, keyCache, auth.RoleOrgAdmin, org.ID, creator.ID)
+
+	// Send without role — should default to "member".
+	req := httptest.NewRequest("POST", invitesURL(org.ID),
+		bodyJSON(t, map[string]any{"email": "default-role@example.com"}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusCreated {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 201; body: %s", resp.StatusCode, b)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+	if got["role"] != "member" {
+		t.Errorf("role = %q, want %q", got["role"], "member")
+	}
+}
+
+func TestCreateInvite_ResponseFields(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestCreateInvite_ResponseFields?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Fields Org", "fields-org-invite")
+	creator := mustCreateUser(t, database, "creator-rf@example.com", "Creator RF")
+	testKey := addTestKeyWithUser(t, keyCache, auth.RoleOrgAdmin, org.ID, creator.ID)
+
+	req := httptest.NewRequest("POST", invitesURL(org.ID),
+		bodyJSON(t, map[string]any{"email": "fields@example.com", "role": "member"}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusCreated {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 201; body: %s", resp.StatusCode, b)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+
+	for _, field := range []string{"id", "token", "token_hint", "email", "role", "org_id", "expires_at", "created_at"} {
+		if v, ok := got[field]; !ok || v == "" {
+			t.Errorf("response missing non-empty field %q; got: %v", field, got)
+		}
+	}
+	if got["email"] != "fields@example.com" {
+		t.Errorf("email = %q, want %q", got["email"], "fields@example.com")
+	}
+	if got["org_id"] != org.ID {
+		t.Errorf("org_id = %q, want %q", got["org_id"], org.ID)
+	}
+	// Token must start with the invite prefix.
+	token, _ := got["token"].(string)
+	if !strings.HasPrefix(token, keygen.PrefixInvite) {
+		t.Errorf("token = %q, want prefix %q", token, keygen.PrefixInvite)
+	}
+}
+
+func TestCreateInvite_ReplacesExistingUnredeemed(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestCreateInvite_Replaces?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Replace Org", "replace-org-invite")
+	creator := mustCreateUser(t, database, "creator-repl@example.com", "Creator Repl")
+	testKey := addTestKeyWithUser(t, keyCache, auth.RoleOrgAdmin, org.ID, creator.ID)
+	const email = "replace@example.com"
+
+	// First invite.
+	first := mustCreateInviteViaAPI(t, app, org.ID, testKey, email, "member")
+	firstID := first["id"].(string)
+
+	// Second invite for same email — should succeed (first is revoked).
+	second := mustCreateInviteViaAPI(t, app, org.ID, testKey, email, "member")
+	secondID := second["id"].(string)
+
+	if firstID == secondID {
+		t.Errorf("expected new invite ID, got same ID %q", firstID)
+	}
+}
+
+// ---- GET /api/v1/orgs/:org_id/invites ----------------------------------------
+
+func TestListInvites(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestListInvites?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "List Invites Org", "list-invites-org")
+	// addTestKey uses "test-key-id-<role>" as the key ID; use a real user ID for created_by.
+	creator := mustCreateUser(t, database, "creator-li@example.com", "Creator LI")
+	testKey := addTestKeyWithUser(t, keyCache, auth.RoleOrgAdmin, org.ID, creator.ID)
+
+	mustCreateInviteDB(t, database, org.ID, "a@example.com", "member", creator.ID)
+	mustCreateInviteDB(t, database, org.ID, "b@example.com", "member", creator.ID)
+
+	req := httptest.NewRequest("GET", invitesURL(org.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, b)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+
+	data, ok := got["data"].([]any)
+	if !ok {
+		t.Fatalf("data is not an array: %v", got["data"])
+	}
+	if len(data) != 2 {
+		t.Errorf("len(data) = %d, want 2", len(data))
+	}
+
+	// Each entry must have a status field — never a raw token (plaintext).
+	for i, raw := range data {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			t.Errorf("data[%d] is not an object", i)
+			continue
+		}
+		if _, ok := entry["status"]; !ok {
+			t.Errorf("data[%d] missing 'status' field", i)
+		}
+		if _, ok := entry["token"]; ok {
+			t.Errorf("data[%d] must not expose 'token' field", i)
+		}
+	}
+}
+
+func TestListInvites_EmptyOrg(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestListInvites_Empty?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Empty Invites Org", "empty-invites-org")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	req := httptest.NewRequest("GET", invitesURL(org.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, b)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+
+	data, ok := got["data"].([]any)
+	if !ok {
+		t.Fatalf("data is not an array: %v", got["data"])
+	}
+	if len(data) != 0 {
+		t.Errorf("len(data) = %d, want 0", len(data))
+	}
+}
+
+func TestListInvites_RBAC(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		role       string
+		sameOrg    bool
+		wantStatus int
+	}{
+		{
+			name:       "system_admin can list",
+			role:       auth.RoleSystemAdmin,
+			sameOrg:    false,
+			wantStatus: fiber.StatusOK,
+		},
+		{
+			name:       "org_admin of same org can list",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			wantStatus: fiber.StatusOK,
+		},
+		{
+			name:       "member of same org returns 403 from route middleware",
+			role:       auth.RoleMember,
+			sameOrg:    true,
+			wantStatus: fiber.StatusForbidden,
+		},
+		{
+			name:       "org_admin of different org returns 403",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    false,
+			wantStatus: fiber.StatusForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dsn := fmt.Sprintf("file:TestListInvites_RBAC_%s?mode=memory&cache=private", strings.ReplaceAll(tc.name, " ", "_"))
+			app, database, keyCache := setupTestApp(t, dsn)
+
+			org := mustCreateOrg(t, database, "RBAC Org", "rbac-org-li-"+strings.ReplaceAll(tc.name, " ", "-"))
+
+			keyOrgID := "00000000-0000-0000-0000-000000000000"
+			if tc.sameOrg {
+				keyOrgID = org.ID
+			}
+			testKey := addTestKey(t, keyCache, tc.role, keyOrgID)
+
+			req := httptest.NewRequest("GET", invitesURL(org.ID), nil)
+			req.Header.Set("Authorization", "Bearer "+testKey)
+
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+			if err != nil {
+				t.Fatalf("app.Test: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				b, _ := io.ReadAll(resp.Body)
+				t.Errorf("status = %d, want %d; body: %s", resp.StatusCode, tc.wantStatus, b)
+			}
+		})
+	}
+}
+
+// ---- DELETE /api/v1/orgs/:org_id/invites/:invite_id --------------------------
+
+func TestRevokeInvite(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestRevokeInvite?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Revoke Org", "revoke-org-invite")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+	creator := mustCreateUser(t, database, "creator-rv@example.com", "Creator RV")
+
+	invite := mustCreateInviteDB(t, database, org.ID, "revoke@example.com", "member", creator.ID)
+
+	req := httptest.NewRequest("DELETE", inviteItemURL(org.ID, invite.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusNoContent {
+		b, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 204; body: %s", resp.StatusCode, b)
+	}
+}
+
+func TestRevokeInvite_NotFound(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestRevokeInvite_NotFound?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "NF Revoke Org", "nf-revoke-org-invite")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	req := httptest.NewRequest("DELETE", inviteItemURL(org.ID, "00000000-0000-0000-0000-000000000099"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusNotFound {
+		b, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 404; body: %s", resp.StatusCode, b)
+	}
+}
+
+func TestRevokeInvite_RBAC(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		role       string
+		sameOrg    bool
+		wantStatus int
+	}{
+		{
+			name:       "system_admin can revoke",
+			role:       auth.RoleSystemAdmin,
+			sameOrg:    false,
+			wantStatus: fiber.StatusNoContent,
+		},
+		{
+			name:       "org_admin of same org can revoke",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			wantStatus: fiber.StatusNoContent,
+		},
+		{
+			name:       "member of same org returns 403 from route middleware",
+			role:       auth.RoleMember,
+			sameOrg:    true,
+			wantStatus: fiber.StatusForbidden,
+		},
+		{
+			name:       "org_admin of different org returns 403",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    false,
+			wantStatus: fiber.StatusForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dsn := fmt.Sprintf("file:TestRevokeInvite_RBAC_%s?mode=memory&cache=private", strings.ReplaceAll(tc.name, " ", "_"))
+			app, database, keyCache := setupTestApp(t, dsn)
+
+			org := mustCreateOrg(t, database, "RBAC Revoke Org", "rbac-revoke-"+strings.ReplaceAll(tc.name, " ", "-"))
+			creator := mustCreateUser(t, database, "creator-rbac-rv-"+strings.ReplaceAll(tc.name, " ", "-")+"@example.com", "Creator")
+			invite := mustCreateInviteDB(t, database, org.ID, "rbac-revoke@example.com", "member", creator.ID)
+
+			keyOrgID := "00000000-0000-0000-0000-000000000000"
+			if tc.sameOrg {
+				keyOrgID = org.ID
+			}
+			testKey := addTestKey(t, keyCache, tc.role, keyOrgID)
+
+			req := httptest.NewRequest("DELETE", inviteItemURL(org.ID, invite.ID), nil)
+			req.Header.Set("Authorization", "Bearer "+testKey)
+
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+			if err != nil {
+				t.Fatalf("app.Test: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				b, _ := io.ReadAll(resp.Body)
+				t.Errorf("status = %d, want %d; body: %s", resp.StatusCode, tc.wantStatus, b)
+			}
+		})
+	}
+}
+
+func TestRevokeInvite_ThenListShowsGone(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestRevokeInvite_ThenList?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Gone Org", "gone-org-invite")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+	creator := mustCreateUser(t, database, "creator-tl@example.com", "Creator TL")
+
+	invite := mustCreateInviteDB(t, database, org.ID, "gone@example.com", "member", creator.ID)
+
+	// Delete it.
+	delReq := httptest.NewRequest("DELETE", inviteItemURL(org.ID, invite.ID), nil)
+	delReq.Header.Set("Authorization", "Bearer "+testKey)
+	delResp, err := app.Test(delReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test DELETE: %v", err)
+	}
+	defer delResp.Body.Close()
+
+	if delResp.StatusCode != fiber.StatusNoContent {
+		b, _ := io.ReadAll(delResp.Body)
+		t.Fatalf("DELETE status = %d, want 204; body: %s", delResp.StatusCode, b)
+	}
+
+	// List should now be empty.
+	listReq := httptest.NewRequest("GET", invitesURL(org.ID), nil)
+	listReq.Header.Set("Authorization", "Bearer "+testKey)
+	listResp, err := app.Test(listReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test GET after DELETE: %v", err)
+	}
+	defer listResp.Body.Close()
+
+	var got map[string]any
+	if err := json.NewDecoder(listResp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode list response: %v", err)
+	}
+	data, _ := got["data"].([]any)
+	if len(data) != 0 {
+		t.Errorf("len(data) = %d after revoke, want 0", len(data))
+	}
+}

--- a/internal/api/admin/model_access_test.go
+++ b/internal/api/admin/model_access_test.go
@@ -1,0 +1,630 @@
+package admin_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/voidmind-io/voidllm/internal/auth"
+	"github.com/voidmind-io/voidllm/internal/db"
+)
+
+// orgModelAccessURL returns the org model-access URL.
+func orgModelAccessURL(orgID string) string {
+	return "/api/v1/orgs/" + orgID + "/model-access"
+}
+
+// teamModelAccessURL returns the team model-access URL.
+func teamModelAccessURL(orgID, teamID string) string {
+	return "/api/v1/orgs/" + orgID + "/teams/" + teamID + "/model-access"
+}
+
+// ---- GET /api/v1/orgs/:org_id/model-access ----------------------------------
+
+func TestGetOrgModelAccess_Empty(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestGetOrgModelAccess_Empty?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Access Org", "access-org-get-empty")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	req := httptest.NewRequest("GET", orgModelAccessURL(org.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, b)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+
+	models, ok := got["models"].([]any)
+	if !ok {
+		t.Fatalf("models is not an array: %v", got["models"])
+	}
+	if len(models) != 0 {
+		t.Errorf("len(models) = %d, want 0 (empty allowlist = all allowed)", len(models))
+	}
+}
+
+func TestGetOrgModelAccess_RBAC(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		role       string
+		sameOrg    bool
+		wantStatus int
+	}{
+		{
+			name:       "system_admin can get",
+			role:       auth.RoleSystemAdmin,
+			sameOrg:    false,
+			wantStatus: fiber.StatusOK,
+		},
+		{
+			name:       "org_admin of same org can get",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			wantStatus: fiber.StatusOK,
+		},
+		{
+			name:       "member of same org returns 403 from route middleware",
+			role:       auth.RoleMember,
+			sameOrg:    true,
+			wantStatus: fiber.StatusForbidden,
+		},
+		{
+			name:       "org_admin of different org returns 403",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    false,
+			wantStatus: fiber.StatusForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dsn := fmt.Sprintf("file:TestGetOrgModelAccess_RBAC_%s?mode=memory&cache=private", strings.ReplaceAll(tc.name, " ", "_"))
+			app, database, keyCache := setupTestAppWithRegistry(t, dsn)
+
+			org := mustCreateOrg(t, database, "RBAC Access Org", "rbac-access-org-"+strings.ReplaceAll(tc.name, " ", "-"))
+
+			keyOrgID := "00000000-0000-0000-0000-000000000000"
+			if tc.sameOrg {
+				keyOrgID = org.ID
+			}
+			testKey := addTestKey(t, keyCache, tc.role, keyOrgID)
+
+			req := httptest.NewRequest("GET", orgModelAccessURL(org.ID), nil)
+			req.Header.Set("Authorization", "Bearer "+testKey)
+
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+			if err != nil {
+				t.Fatalf("app.Test: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				b, _ := io.ReadAll(resp.Body)
+				t.Errorf("status = %d, want %d; body: %s", resp.StatusCode, tc.wantStatus, b)
+			}
+		})
+	}
+}
+
+// ---- PUT /api/v1/orgs/:org_id/model-access ----------------------------------
+
+func TestSetOrgModelAccess(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		role       string
+		sameOrg    bool
+		models     []string
+		wantStatus int
+		wantModels []string
+	}{
+		{
+			name:       "org_admin sets allowlist",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			models:     []string{testModelName},
+			wantStatus: fiber.StatusOK,
+			wantModels: []string{testModelName},
+		},
+		{
+			name:       "system_admin sets allowlist",
+			role:       auth.RoleSystemAdmin,
+			sameOrg:    false,
+			models:     []string{testModelName, testConflictModelName},
+			wantStatus: fiber.StatusOK,
+			wantModels: []string{testModelName, testConflictModelName},
+		},
+		{
+			name:       "empty array clears allowlist",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			models:     []string{},
+			wantStatus: fiber.StatusOK,
+			wantModels: []string{},
+		},
+		{
+			name:       "unknown model returns 400",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			models:     []string{"nonexistent-model"},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "multiple valid models succeeds",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			models:     []string{testModelName, testConflictModelName},
+			wantStatus: fiber.StatusOK,
+			wantModels: []string{testModelName, testConflictModelName},
+		},
+		{
+			name:       "org_admin of different org returns 403",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    false,
+			models:     []string{testModelName},
+			wantStatus: fiber.StatusForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dsn := fmt.Sprintf("file:TestSetOrgModelAccess_%s?mode=memory&cache=private", strings.ReplaceAll(tc.name, " ", "_"))
+			app, database, keyCache := setupTestAppWithRegistry(t, dsn)
+
+			org := mustCreateOrg(t, database, "Set Access Org", "set-access-org-"+strings.ReplaceAll(tc.name, " ", "-"))
+
+			keyOrgID := "00000000-0000-0000-0000-000000000000"
+			if tc.sameOrg {
+				keyOrgID = org.ID
+			}
+			testKey := addTestKey(t, keyCache, tc.role, keyOrgID)
+
+			req := httptest.NewRequest("PUT", orgModelAccessURL(org.ID),
+				bodyJSON(t, map[string]any{"models": tc.models}))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testKey)
+
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+			if err != nil {
+				t.Fatalf("app.Test: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				b, _ := io.ReadAll(resp.Body)
+				t.Errorf("status = %d, want %d; body: %s", resp.StatusCode, tc.wantStatus, b)
+				return
+			}
+
+			if tc.wantModels != nil {
+				var got map[string]any
+				decodeBody(t, resp.Body, &got)
+				models, ok := got["models"].([]any)
+				if !ok {
+					t.Fatalf("models is not an array: %v", got["models"])
+				}
+				if len(models) != len(tc.wantModels) {
+					t.Errorf("len(models) = %d, want %d", len(models), len(tc.wantModels))
+				}
+			}
+		})
+	}
+}
+
+func TestSetAndGetOrgModelAccess_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestSetGetOrgModelAccess?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Round Trip Org", "round-trip-org-access")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	// Set allowlist.
+	setReq := httptest.NewRequest("PUT", orgModelAccessURL(org.ID),
+		bodyJSON(t, map[string]any{"models": []string{testModelName}}))
+	setReq.Header.Set("Content-Type", "application/json")
+	setReq.Header.Set("Authorization", "Bearer "+testKey)
+	setResp, err := app.Test(setReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	setResp.Body.Close()
+	if setResp.StatusCode != fiber.StatusOK {
+		t.Fatalf("PUT status = %d, want 200", setResp.StatusCode)
+	}
+
+	// GET back and verify.
+	getReq := httptest.NewRequest("GET", orgModelAccessURL(org.ID), nil)
+	getReq.Header.Set("Authorization", "Bearer "+testKey)
+	getResp, err := app.Test(getReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer getResp.Body.Close()
+
+	if getResp.StatusCode != fiber.StatusOK {
+		b, _ := io.ReadAll(getResp.Body)
+		t.Fatalf("GET status = %d; body: %s", getResp.StatusCode, b)
+	}
+
+	var got map[string]any
+	decodeBody(t, getResp.Body, &got)
+
+	models, ok := got["models"].([]any)
+	if !ok {
+		t.Fatalf("models is not an array: %v", got["models"])
+	}
+	if len(models) != 1 {
+		t.Fatalf("len(models) = %d, want 1", len(models))
+	}
+	if models[0] != testModelName {
+		t.Errorf("models[0] = %q, want %q", models[0], testModelName)
+	}
+}
+
+func TestSetOrgModelAccess_EmptyAllowlistMeansAll(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestSetOrgEmpty?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Empty Access Org", "empty-access-org")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	// Set then clear.
+	setReq := httptest.NewRequest("PUT", orgModelAccessURL(org.ID),
+		bodyJSON(t, map[string]any{"models": []string{testModelName}}))
+	setReq.Header.Set("Content-Type", "application/json")
+	setReq.Header.Set("Authorization", "Bearer "+testKey)
+	setResp, err := app.Test(setReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("first PUT: %v", err)
+	}
+	setResp.Body.Close()
+
+	clearReq := httptest.NewRequest("PUT", orgModelAccessURL(org.ID),
+		bodyJSON(t, map[string]any{"models": []string{}}))
+	clearReq.Header.Set("Content-Type", "application/json")
+	clearReq.Header.Set("Authorization", "Bearer "+testKey)
+	clearResp, err := app.Test(clearReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("clear PUT: %v", err)
+	}
+	defer clearResp.Body.Close()
+
+	if clearResp.StatusCode != fiber.StatusOK {
+		b, _ := io.ReadAll(clearResp.Body)
+		t.Fatalf("clear PUT status = %d; body: %s", clearResp.StatusCode, b)
+	}
+
+	var got map[string]any
+	decodeBody(t, clearResp.Body, &got)
+	models, _ := got["models"].([]any)
+	if len(models) != 0 {
+		t.Errorf("len(models) = %d after clear, want 0", len(models))
+	}
+}
+
+// ---- GET /api/v1/orgs/:org_id/teams/:team_id/model-access -------------------
+
+func TestGetTeamModelAccess_Empty(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestGetTeamModelAccess_Empty?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Team Access Org", "team-access-org-get")
+	team := mustCreateTeam(t, database, org.ID, "Access Team", "access-team-get")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	req := httptest.NewRequest("GET", teamModelAccessURL(org.ID, team.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, b)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+
+	models, ok := got["models"].([]any)
+	if !ok {
+		t.Fatalf("models is not an array: %v", got["models"])
+	}
+	if len(models) != 0 {
+		t.Errorf("len(models) = %d, want 0", len(models))
+	}
+}
+
+func TestGetTeamModelAccess_WrongOrg(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestGetTeamModelAccess_WrongOrg?mode=memory&cache=private")
+	orgA := mustCreateOrg(t, database, "Org A TA", "org-a-ta-gtma")
+	orgB := mustCreateOrg(t, database, "Org B TA", "org-b-ta-gtma")
+	teamB := mustCreateTeam(t, database, orgB.ID, "Team B TA", "team-b-ta-gtma")
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	// Access teamB via orgA — must 404.
+	req := httptest.NewRequest("GET", teamModelAccessURL(orgA.ID, teamB.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusNotFound {
+		b, _ := io.ReadAll(resp.Body)
+		t.Errorf("cross-org GET status = %d, want 404; body: %s", resp.StatusCode, b)
+	}
+}
+
+// ---- PUT /api/v1/orgs/:org_id/teams/:team_id/model-access -------------------
+
+func TestSetTeamModelAccess(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		role       string
+		sameOrg    bool
+		orgModels  []string // set on org first (empty = no org allowlist)
+		teamModels []string
+		wantStatus int
+	}{
+		{
+			name:       "org_admin sets team allowlist (no org restriction)",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			orgModels:  nil,
+			teamModels: []string{testModelName},
+			wantStatus: fiber.StatusOK,
+		},
+		{
+			name:       "team model within org allowlist succeeds",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			orgModels:  []string{testModelName},
+			teamModels: []string{testModelName},
+			wantStatus: fiber.StatusOK,
+		},
+		{
+			name:       "team model not in org allowlist returns 400",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			orgModels:  []string{testModelName},
+			teamModels: []string{testConflictModelName},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "empty array clears team allowlist",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			orgModels:  nil,
+			teamModels: []string{},
+			wantStatus: fiber.StatusOK,
+		},
+		{
+			name:       "unknown model returns 400",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			orgModels:  nil,
+			teamModels: []string{"ghost-model"},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "org_admin of different org returns 403",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    false,
+			orgModels:  nil,
+			teamModels: []string{testModelName},
+			wantStatus: fiber.StatusForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dsn := fmt.Sprintf("file:TestSetTeamModelAccess_%s?mode=memory&cache=private", strings.ReplaceAll(tc.name, " ", "_"))
+			app, database, keyCache := setupTestAppWithRegistry(t, dsn)
+
+			org := mustCreateOrg(t, database, "Set Team Access Org", "set-team-access-"+strings.ReplaceAll(tc.name, " ", "-"))
+			team := mustCreateTeam(t, database, org.ID, "Access Team", "access-team-sta-"+strings.ReplaceAll(tc.name, " ", "-"))
+
+			keyOrgID := "00000000-0000-0000-0000-000000000000"
+			if tc.sameOrg {
+				keyOrgID = org.ID
+			}
+			adminKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+			testKey := addTestKey(t, keyCache, tc.role, keyOrgID)
+
+			// Set org-level access if requested.
+			if len(tc.orgModels) > 0 {
+				orgReq := httptest.NewRequest("PUT", orgModelAccessURL(org.ID),
+					bodyJSON(t, map[string]any{"models": tc.orgModels}))
+				orgReq.Header.Set("Content-Type", "application/json")
+				orgReq.Header.Set("Authorization", "Bearer "+adminKey)
+				orgResp, err := app.Test(orgReq, fiber.TestConfig{Timeout: testTimeout})
+				if err != nil {
+					t.Fatalf("set org access: %v", err)
+				}
+				orgResp.Body.Close()
+				if orgResp.StatusCode != fiber.StatusOK {
+					t.Fatalf("set org access: status = %d, want 200", orgResp.StatusCode)
+				}
+			}
+
+			// Now set team access.
+			req := httptest.NewRequest("PUT", teamModelAccessURL(org.ID, team.ID),
+				bodyJSON(t, map[string]any{"models": tc.teamModels}))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testKey)
+
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+			if err != nil {
+				t.Fatalf("app.Test: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				b, _ := io.ReadAll(resp.Body)
+				t.Errorf("status = %d, want %d; body: %s", resp.StatusCode, tc.wantStatus, b)
+			}
+		})
+	}
+}
+
+func TestSetAndGetTeamModelAccess_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestSetGetTeamModelAccess?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "RT Team Org", "rt-team-org-access")
+	team := mustCreateTeam(t, database, org.ID, "RT Team", "rt-team-access")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	// Set.
+	setReq := httptest.NewRequest("PUT", teamModelAccessURL(org.ID, team.ID),
+		bodyJSON(t, map[string]any{"models": []string{testModelName}}))
+	setReq.Header.Set("Content-Type", "application/json")
+	setReq.Header.Set("Authorization", "Bearer "+testKey)
+	setResp, err := app.Test(setReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("PUT: %v", err)
+	}
+	setResp.Body.Close()
+	if setResp.StatusCode != fiber.StatusOK {
+		t.Fatalf("PUT status = %d, want 200", setResp.StatusCode)
+	}
+
+	// GET back.
+	getReq := httptest.NewRequest("GET", teamModelAccessURL(org.ID, team.ID), nil)
+	getReq.Header.Set("Authorization", "Bearer "+testKey)
+	getResp, err := app.Test(getReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer getResp.Body.Close()
+
+	if getResp.StatusCode != fiber.StatusOK {
+		b, _ := io.ReadAll(getResp.Body)
+		t.Fatalf("GET status = %d; body: %s", getResp.StatusCode, b)
+	}
+
+	var got map[string]any
+	decodeBody(t, getResp.Body, &got)
+
+	models, ok := got["models"].([]any)
+	if !ok {
+		t.Fatalf("models is not an array: %v", got["models"])
+	}
+	if len(models) != 1 {
+		t.Fatalf("len(models) = %d, want 1", len(models))
+	}
+	if models[0] != testModelName {
+		t.Errorf("models[0] = %q, want %q", models[0], testModelName)
+	}
+}
+
+func TestGetTeamModelAccess_NonMemberReturnsNotFound(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestGetTeamModelAccess_NonMember?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "NM Team Access Org", "nm-team-access-org")
+	team := mustCreateTeam(t, database, org.ID, "NM Team", "nm-team-access")
+
+	// A team_admin who is in the org but not the team.
+	// (Route requires team_admin; handler does additional membership check for non-org-admins.)
+	user := mustCreateUser(t, database, "nonmember@example.com", "Non Member")
+	_, err := database.CreateOrgMembership(context.Background(), db.CreateOrgMembershipParams{
+		OrgID:  org.ID,
+		UserID: user.ID,
+		Role:   auth.RoleTeamAdmin,
+	})
+	if err != nil {
+		t.Fatalf("CreateOrgMembership: %v", err)
+	}
+
+	testKey := addTestKeyWithUser(t, keyCache, auth.RoleTeamAdmin, org.ID, user.ID)
+
+	req := httptest.NewRequest("GET", teamModelAccessURL(org.ID, team.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusNotFound {
+		b, _ := io.ReadAll(resp.Body)
+		t.Errorf("non-member GET status = %d, want 404; body: %s", resp.StatusCode, b)
+	}
+}
+
+func TestSetTeamModelAccess_MostRestrictiveWins(t *testing.T) {
+	t.Parallel()
+
+	// Org allows only testModelName; trying to set testConflictModelName at
+	// team level must fail even though it's a known model.
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestSetTeamModelAccess_MostRestrictive?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Restrictive Org", "restrictive-org-access")
+	team := mustCreateTeam(t, database, org.ID, "Restricted Team", "restricted-team-access")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	// Set org allowlist to only testModelName.
+	orgReq := httptest.NewRequest("PUT", orgModelAccessURL(org.ID),
+		bodyJSON(t, map[string]any{"models": []string{testModelName}}))
+	orgReq.Header.Set("Content-Type", "application/json")
+	orgReq.Header.Set("Authorization", "Bearer "+testKey)
+	orgResp, err := app.Test(orgReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("set org access: %v", err)
+	}
+	orgResp.Body.Close()
+	if orgResp.StatusCode != fiber.StatusOK {
+		t.Fatalf("set org access: status = %d, want 200", orgResp.StatusCode)
+	}
+
+	// Try to set team access to testConflictModelName — should fail.
+	teamReq := httptest.NewRequest("PUT", teamModelAccessURL(org.ID, team.ID),
+		bodyJSON(t, map[string]any{"models": []string{testConflictModelName}}))
+	teamReq.Header.Set("Content-Type", "application/json")
+	teamReq.Header.Set("Authorization", "Bearer "+testKey)
+	teamResp, err := app.Test(teamReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("set team access: %v", err)
+	}
+	defer teamResp.Body.Close()
+
+	if teamResp.StatusCode != fiber.StatusBadRequest {
+		b, _ := io.ReadAll(teamResp.Body)
+		t.Errorf("status = %d, want 400 (model not allowed by org); body: %s", teamResp.StatusCode, b)
+	}
+}

--- a/internal/api/admin/model_aliases_test.go
+++ b/internal/api/admin/model_aliases_test.go
@@ -1,0 +1,823 @@
+package admin_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/voidmind-io/voidllm/internal/api/admin"
+	"github.com/voidmind-io/voidllm/internal/auth"
+	"github.com/voidmind-io/voidllm/internal/cache"
+	"github.com/voidmind-io/voidllm/internal/config"
+	"github.com/voidmind-io/voidllm/internal/db"
+	"github.com/voidmind-io/voidllm/internal/license"
+	"github.com/voidmind-io/voidllm/internal/proxy"
+	"github.com/voidmind-io/voidllm/pkg/keygen"
+)
+
+// testModelName is the canonical model name registered in the test registry.
+const testModelName = "gpt-4o"
+
+// testConflictModelName is a second model used to test alias-vs-name conflicts.
+const testConflictModelName = "claude-3-5-sonnet"
+
+// setupTestAppWithRegistry creates a Fiber app with a populated model registry
+// suitable for testing model alias and model access endpoints.
+func setupTestAppWithRegistry(t *testing.T, dsn string) (*fiber.App, *db.DB, *cache.Cache[string, auth.KeyInfo]) {
+	t.Helper()
+
+	ctx := context.Background()
+	database, err := db.Open(ctx, config.DatabaseConfig{
+		Driver:          "sqlite",
+		DSN:             dsn,
+		MaxOpenConns:    1,
+		MaxIdleConns:    1,
+		ConnMaxLifetime: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("open test DB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	if err := db.RunMigrations(ctx, database.SQL(), db.SQLiteDialect{}); err != nil {
+		t.Fatalf("run migrations: %v", err)
+	}
+
+	registry, err := proxy.NewRegistry([]config.ModelConfig{
+		{
+			Name:     testModelName,
+			Provider: "openai",
+			BaseURL:  "https://api.openai.com/v1",
+		},
+		{
+			Name:     testConflictModelName,
+			Provider: "anthropic",
+			BaseURL:  "https://api.anthropic.com",
+		},
+	})
+	if err != nil {
+		t.Fatalf("proxy.NewRegistry: %v", err)
+	}
+
+	keyCache := cache.New[string, auth.KeyInfo]()
+
+	handler := &admin.Handler{
+		DB:         database,
+		HMACSecret: testHMACSecret,
+		KeyCache:   keyCache,
+		Registry:   registry,
+		License:    license.NewHolder(license.Verify("", true)),
+		Log:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	app := fiber.New()
+	admin.RegisterRoutes(app, handler, keyCache, testHMACSecret, nil)
+
+	return app, database, keyCache
+}
+
+// addRegistryTestKey generates a key whose ID field is set to the given userID,
+// which satisfies the NOT NULL REFERENCES users(id) constraint on model_aliases.created_by.
+// It should be used whenever the handler writes keyInfo.ID to a DB column referencing users.
+func addRegistryTestKey(t *testing.T, keyCache *cache.Cache[string, auth.KeyInfo], role, orgID, userID string) string {
+	t.Helper()
+
+	plaintext, err := keygen.Generate(keygen.KeyTypeUser)
+	if err != nil {
+		t.Fatalf("addRegistryTestKey: generate: %v", err)
+	}
+
+	hash := keygen.Hash(plaintext, testHMACSecret)
+	keyCache.Set(hash, auth.KeyInfo{
+		ID:      userID, // handler passes keyInfo.ID as created_by
+		KeyType: keygen.KeyTypeUser,
+		Role:    role,
+		OrgID:   orgID,
+		UserID:  userID,
+		Name:    "test key " + role,
+	})
+
+	return plaintext
+}
+
+// orgAliasURL returns the org model-aliases base URL.
+func orgAliasURL(orgID string) string {
+	return "/api/v1/orgs/" + orgID + "/model-aliases"
+}
+
+// orgAliasItemURL returns the URL for a specific org model alias.
+func orgAliasItemURL(orgID, aliasID string) string {
+	return "/api/v1/orgs/" + orgID + "/model-aliases/" + aliasID
+}
+
+// teamAliasURL returns the team model-aliases base URL.
+func teamAliasURL(orgID, teamID string) string {
+	return "/api/v1/orgs/" + orgID + "/teams/" + teamID + "/model-aliases"
+}
+
+// teamAliasItemURL returns the URL for a specific team model alias.
+func teamAliasItemURL(orgID, teamID, aliasID string) string {
+	return "/api/v1/orgs/" + orgID + "/teams/" + teamID + "/model-aliases/" + aliasID
+}
+
+// ---- POST /api/v1/orgs/:org_id/model-aliases --------------------------------
+
+func TestCreateOrgAlias(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		role       string
+		sameOrg    bool
+		body       any
+		wantStatus int
+		checkField string
+	}{
+		{
+			name:       "org_admin creates org alias",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			body:       map[string]any{"alias": "my-model", "model_name": testModelName},
+			wantStatus: fiber.StatusCreated,
+			checkField: "id",
+		},
+		{
+			name:       "system_admin creates org alias",
+			role:       auth.RoleSystemAdmin,
+			sameOrg:    false,
+			body:       map[string]any{"alias": "sys-alias", "model_name": testModelName},
+			wantStatus: fiber.StatusCreated,
+			checkField: "id",
+		},
+		{
+			name:       "unknown model returns 400",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			body:       map[string]any{"alias": "bad-alias", "model_name": "does-not-exist"},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "empty alias returns 400",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			body:       map[string]any{"alias": "", "model_name": testModelName},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "alias with spaces returns 400",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			body:       map[string]any{"alias": "has spaces", "model_name": testModelName},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "missing model_name returns 400",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			body:       map[string]any{"alias": "valid-alias"},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "alias conflicts with existing model name returns 400",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			body:       map[string]any{"alias": testConflictModelName, "model_name": testModelName},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "org_admin of different org returns 403",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    false,
+			body:       map[string]any{"alias": "cross-org-alias", "model_name": testModelName},
+			wantStatus: fiber.StatusForbidden,
+		},
+		{
+			name:       "member of same org returns 403 from route middleware",
+			role:       auth.RoleMember,
+			sameOrg:    true,
+			body:       map[string]any{"alias": "member-alias", "model_name": testModelName},
+			wantStatus: fiber.StatusForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dsn := fmt.Sprintf("file:TestCreateOrgAlias_%s?mode=memory&cache=private", strings.ReplaceAll(tc.name, " ", "_"))
+			app, database, keyCache := setupTestAppWithRegistry(t, dsn)
+
+			org := mustCreateOrg(t, database, "Alias Org", "alias-org-coa-"+strings.ReplaceAll(tc.name, " ", "-"))
+			creator := mustCreateUser(t, database, "creator-coa-"+strings.ReplaceAll(tc.name, " ", "-")+"@example.com", "Creator")
+
+			keyOrgID := "00000000-0000-0000-0000-000000000000"
+			if tc.sameOrg {
+				keyOrgID = org.ID
+			}
+			testKey := addRegistryTestKey(t, keyCache, tc.role, keyOrgID, creator.ID)
+
+			req := httptest.NewRequest("POST", orgAliasURL(org.ID), bodyJSON(t, tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testKey)
+
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+			if err != nil {
+				t.Fatalf("app.Test: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				b, _ := io.ReadAll(resp.Body)
+				t.Errorf("status = %d, want %d; body: %s", resp.StatusCode, tc.wantStatus, b)
+				return
+			}
+
+			if tc.checkField != "" {
+				var got map[string]any
+				decodeBody(t, resp.Body, &got)
+				if _, ok := got[tc.checkField]; !ok {
+					t.Errorf("response missing field %q; got: %v", tc.checkField, got)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateOrgAlias_ResponseFields(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestCreateOrgAlias_Fields?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Fields Org", "fields-org-coa")
+	creator := mustCreateUser(t, database, "creator-fields-coa@example.com", "Creator")
+	testKey := addRegistryTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID, creator.ID)
+
+	req := httptest.NewRequest("POST", orgAliasURL(org.ID),
+		bodyJSON(t, map[string]any{"alias": "fields-alias", "model_name": testModelName}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusCreated {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 201; body: %s", resp.StatusCode, b)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+
+	for _, field := range []string{"id", "alias", "model_name", "scope_type", "org_id", "created_by", "created_at"} {
+		if _, ok := got[field]; !ok {
+			t.Errorf("response missing field %q; got: %v", field, got)
+		}
+	}
+	if got["alias"] != "fields-alias" {
+		t.Errorf("alias = %q, want %q", got["alias"], "fields-alias")
+	}
+	if got["model_name"] != testModelName {
+		t.Errorf("model_name = %q, want %q", got["model_name"], testModelName)
+	}
+	if got["scope_type"] != "org" {
+		t.Errorf("scope_type = %q, want %q", got["scope_type"], "org")
+	}
+	if got["org_id"] != org.ID {
+		t.Errorf("org_id = %q, want %q", got["org_id"], org.ID)
+	}
+}
+
+// ---- GET /api/v1/orgs/:org_id/model-aliases ---------------------------------
+
+func TestListOrgAliases(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestListOrgAliases?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "List Alias Org", "list-alias-org")
+	creator := mustCreateUser(t, database, "creator-loa@example.com", "Creator")
+	testKey := addRegistryTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID, creator.ID)
+
+	// Create two aliases via API.
+	for _, alias := range []string{"alias-a", "alias-b"} {
+		req := httptest.NewRequest("POST", orgAliasURL(org.ID),
+			bodyJSON(t, map[string]any{"alias": alias, "model_name": testModelName}))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+testKey)
+		resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+		if err != nil {
+			t.Fatalf("create alias %q: %v", alias, err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != fiber.StatusCreated {
+			t.Fatalf("create alias %q: status = %d, want 201", alias, resp.StatusCode)
+		}
+	}
+
+	req := httptest.NewRequest("GET", orgAliasURL(org.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, b)
+	}
+
+	var got []any
+	decodeBody(t, resp.Body, &got)
+
+	if len(got) != 2 {
+		t.Errorf("len(aliases) = %d, want 2", len(got))
+	}
+}
+
+func TestListOrgAliases_Empty(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestListOrgAliases_Empty?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Empty Alias Org", "empty-alias-org")
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("GET", orgAliasURL(org.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, b)
+	}
+
+	var got []any
+	decodeBody(t, resp.Body, &got)
+
+	if len(got) != 0 {
+		t.Errorf("len(aliases) = %d, want 0", len(got))
+	}
+}
+
+// ---- DELETE /api/v1/orgs/:org_id/model-aliases/:alias_id --------------------
+
+func TestDeleteOrgAlias(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestDeleteOrgAlias?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Delete Alias Org", "delete-alias-org")
+	creator := mustCreateUser(t, database, "creator-doa@example.com", "Creator")
+	testKey := addRegistryTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID, creator.ID)
+
+	// Create alias.
+	createReq := httptest.NewRequest("POST", orgAliasURL(org.ID),
+		bodyJSON(t, map[string]any{"alias": "to-delete-alias", "model_name": testModelName}))
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.Header.Set("Authorization", "Bearer "+testKey)
+	createResp, err := app.Test(createReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("create alias: %v", err)
+	}
+	if createResp.StatusCode != fiber.StatusCreated {
+		b, _ := io.ReadAll(createResp.Body)
+		createResp.Body.Close()
+		t.Fatalf("create alias: status = %d; body: %s", createResp.StatusCode, b)
+	}
+	var created map[string]any
+	decodeBody(t, createResp.Body, &created)
+	aliasID := created["id"].(string)
+
+	// Delete it.
+	delReq := httptest.NewRequest("DELETE", orgAliasItemURL(org.ID, aliasID), nil)
+	delReq.Header.Set("Authorization", "Bearer "+testKey)
+	delResp, err := app.Test(delReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("delete alias: %v", err)
+	}
+	defer delResp.Body.Close()
+
+	if delResp.StatusCode != fiber.StatusNoContent {
+		b, _ := io.ReadAll(delResp.Body)
+		t.Errorf("status = %d, want 204; body: %s", delResp.StatusCode, b)
+	}
+}
+
+func TestDeleteOrgAlias_NotFound(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestDeleteOrgAlias_NotFound?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "NF Alias Org", "nf-alias-org")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	req := httptest.NewRequest("DELETE", orgAliasItemURL(org.ID, "00000000-0000-0000-0000-000000000099"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusNotFound {
+		b, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 404; body: %s", resp.StatusCode, b)
+	}
+}
+
+func TestDeleteOrgAlias_ThenListShowsRemoved(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestDeleteOrgAlias_ThenList?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Gone Alias Org", "gone-alias-org")
+	creator := mustCreateUser(t, database, "creator-doatl@example.com", "Creator")
+	testKey := addRegistryTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID, creator.ID)
+
+	// Create and immediately delete.
+	createReq := httptest.NewRequest("POST", orgAliasURL(org.ID),
+		bodyJSON(t, map[string]any{"alias": "gone-alias", "model_name": testModelName}))
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.Header.Set("Authorization", "Bearer "+testKey)
+	createResp, err := app.Test(createReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	var created map[string]any
+	decodeBody(t, createResp.Body, &created)
+	aliasID := created["id"].(string)
+
+	delReq := httptest.NewRequest("DELETE", orgAliasItemURL(org.ID, aliasID), nil)
+	delReq.Header.Set("Authorization", "Bearer "+testKey)
+	delResp, err := app.Test(delReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	delResp.Body.Close()
+
+	// List should now be empty.
+	listReq := httptest.NewRequest("GET", orgAliasURL(org.ID), nil)
+	listReq.Header.Set("Authorization", "Bearer "+testKey)
+	listResp, err := app.Test(listReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	defer listResp.Body.Close()
+
+	var got []any
+	decodeBody(t, listResp.Body, &got)
+	if len(got) != 0 {
+		t.Errorf("len(aliases) = %d after delete, want 0", len(got))
+	}
+}
+
+func TestCreateOrgAlias_DuplicateReturnsConflict(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestCreateOrgAlias_Dup?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Dup Alias Org", "dup-alias-org")
+	creator := mustCreateUser(t, database, "creator-dup-coa@example.com", "Creator")
+	testKey := addRegistryTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID, creator.ID)
+
+	body := bodyJSON(t, map[string]any{"alias": "dup-alias", "model_name": testModelName})
+	req1 := httptest.NewRequest("POST", orgAliasURL(org.ID), body)
+	req1.Header.Set("Content-Type", "application/json")
+	req1.Header.Set("Authorization", "Bearer "+testKey)
+	resp1, err := app.Test(req1, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	resp1.Body.Close()
+	if resp1.StatusCode != fiber.StatusCreated {
+		t.Fatalf("first create: status = %d, want 201", resp1.StatusCode)
+	}
+
+	req2 := httptest.NewRequest("POST", orgAliasURL(org.ID),
+		bodyJSON(t, map[string]any{"alias": "dup-alias", "model_name": testModelName}))
+	req2.Header.Set("Content-Type", "application/json")
+	req2.Header.Set("Authorization", "Bearer "+testKey)
+	resp2, err := app.Test(req2, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("second create: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != fiber.StatusConflict {
+		b, _ := io.ReadAll(resp2.Body)
+		t.Errorf("status = %d, want 409; body: %s", resp2.StatusCode, b)
+	}
+}
+
+// ---- POST /api/v1/orgs/:org_id/teams/:team_id/model-aliases -----------------
+
+func TestCreateTeamAlias(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		role       string
+		sameOrg    bool
+		body       any
+		wantStatus int
+		checkField string
+	}{
+		{
+			name:       "org_admin creates team alias",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			body:       map[string]any{"alias": "team-model", "model_name": testModelName},
+			wantStatus: fiber.StatusCreated,
+			checkField: "id",
+		},
+		{
+			name:       "system_admin creates team alias",
+			role:       auth.RoleSystemAdmin,
+			sameOrg:    false,
+			body:       map[string]any{"alias": "sys-team-alias", "model_name": testModelName},
+			wantStatus: fiber.StatusCreated,
+			checkField: "id",
+		},
+		{
+			name:       "unknown model returns 400",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    true,
+			body:       map[string]any{"alias": "bad-team-alias", "model_name": "ghost-model"},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "org_admin of different org returns 403",
+			role:       auth.RoleOrgAdmin,
+			sameOrg:    false,
+			body:       map[string]any{"alias": "cross-team-alias", "model_name": testModelName},
+			wantStatus: fiber.StatusForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dsn := fmt.Sprintf("file:TestCreateTeamAlias_%s?mode=memory&cache=private", strings.ReplaceAll(tc.name, " ", "_"))
+			app, database, keyCache := setupTestAppWithRegistry(t, dsn)
+
+			org := mustCreateOrg(t, database, "Team Alias Org", "team-alias-org-"+strings.ReplaceAll(tc.name, " ", "-"))
+			team := mustCreateTeam(t, database, org.ID, "Alias Team", "alias-team-cta-"+strings.ReplaceAll(tc.name, " ", "-"))
+			creator := mustCreateUser(t, database, "creator-cta-"+strings.ReplaceAll(tc.name, " ", "-")+"@example.com", "Creator")
+
+			keyOrgID := "00000000-0000-0000-0000-000000000000"
+			if tc.sameOrg {
+				keyOrgID = org.ID
+			}
+			testKey := addRegistryTestKey(t, keyCache, tc.role, keyOrgID, creator.ID)
+
+			req := httptest.NewRequest("POST", teamAliasURL(org.ID, team.ID), bodyJSON(t, tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testKey)
+
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+			if err != nil {
+				t.Fatalf("app.Test: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				b, _ := io.ReadAll(resp.Body)
+				t.Errorf("status = %d, want %d; body: %s", resp.StatusCode, tc.wantStatus, b)
+				return
+			}
+
+			if tc.checkField != "" {
+				var got map[string]any
+				decodeBody(t, resp.Body, &got)
+				if _, ok := got[tc.checkField]; !ok {
+					t.Errorf("response missing field %q; got: %v", tc.checkField, got)
+				}
+			}
+		})
+	}
+}
+
+func TestCreateTeamAlias_ResponseFields(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestCreateTeamAlias_Fields?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Team Fields Org", "team-fields-org")
+	team := mustCreateTeam(t, database, org.ID, "Fields Team", "fields-team-cta")
+	creator := mustCreateUser(t, database, "creator-fields-cta@example.com", "Creator")
+	testKey := addRegistryTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID, creator.ID)
+
+	req := httptest.NewRequest("POST", teamAliasURL(org.ID, team.ID),
+		bodyJSON(t, map[string]any{"alias": "team-fields-alias", "model_name": testModelName}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusCreated {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 201; body: %s", resp.StatusCode, b)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+
+	for _, field := range []string{"id", "alias", "model_name", "scope_type", "org_id", "team_id", "created_at"} {
+		if _, ok := got[field]; !ok {
+			t.Errorf("response missing field %q; got: %v", field, got)
+		}
+	}
+	if got["scope_type"] != "team" {
+		t.Errorf("scope_type = %q, want %q", got["scope_type"], "team")
+	}
+	if got["team_id"] != team.ID {
+		t.Errorf("team_id = %q, want %q", got["team_id"], team.ID)
+	}
+}
+
+// ---- GET /api/v1/orgs/:org_id/teams/:team_id/model-aliases ------------------
+
+func TestListTeamAliases(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestListTeamAliases?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "List Team Alias Org", "list-team-alias-org")
+	team := mustCreateTeam(t, database, org.ID, "List Alias Team", "list-alias-team")
+	creator := mustCreateUser(t, database, "creator-lta@example.com", "Creator")
+	testKey := addRegistryTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID, creator.ID)
+
+	// Create one team alias.
+	createReq := httptest.NewRequest("POST", teamAliasURL(org.ID, team.ID),
+		bodyJSON(t, map[string]any{"alias": "list-team-alias", "model_name": testModelName}))
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.Header.Set("Authorization", "Bearer "+testKey)
+	createResp, err := app.Test(createReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	createResp.Body.Close()
+	if createResp.StatusCode != fiber.StatusCreated {
+		t.Fatalf("create: status = %d, want 201", createResp.StatusCode)
+	}
+
+	req := httptest.NewRequest("GET", teamAliasURL(org.ID, team.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, b)
+	}
+
+	var got []any
+	decodeBody(t, resp.Body, &got)
+
+	if len(got) != 1 {
+		t.Errorf("len(aliases) = %d, want 1", len(got))
+	}
+}
+
+func TestListTeamAliases_WrongOrg(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestListTeamAliases_WrongOrg?mode=memory&cache=private")
+	orgA := mustCreateOrg(t, database, "Org A", "org-a-lta")
+	orgB := mustCreateOrg(t, database, "Org B", "org-b-lta")
+	teamB := mustCreateTeam(t, database, orgB.ID, "Team B", "team-b-lta")
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	// Request teamB's aliases via orgA URL — must be 404.
+	req := httptest.NewRequest("GET", teamAliasURL(orgA.ID, teamB.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusNotFound {
+		b, _ := io.ReadAll(resp.Body)
+		t.Errorf("cross-org GET status = %d, want 404; body: %s", resp.StatusCode, b)
+	}
+}
+
+// ---- DELETE /api/v1/orgs/:org_id/teams/:team_id/model-aliases/:alias_id -----
+
+func TestDeleteTeamAlias(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestDeleteTeamAlias?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Del Team Alias Org", "del-team-alias-org")
+	team := mustCreateTeam(t, database, org.ID, "Del Alias Team", "del-alias-team")
+	creator := mustCreateUser(t, database, "creator-dta@example.com", "Creator")
+	testKey := addRegistryTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID, creator.ID)
+
+	// Create alias.
+	createReq := httptest.NewRequest("POST", teamAliasURL(org.ID, team.ID),
+		bodyJSON(t, map[string]any{"alias": "team-alias-del", "model_name": testModelName}))
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.Header.Set("Authorization", "Bearer "+testKey)
+	createResp, err := app.Test(createReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	var created map[string]any
+	decodeBody(t, createResp.Body, &created)
+	aliasID := created["id"].(string)
+
+	// Delete it.
+	delReq := httptest.NewRequest("DELETE", teamAliasItemURL(org.ID, team.ID, aliasID), nil)
+	delReq.Header.Set("Authorization", "Bearer "+testKey)
+	delResp, err := app.Test(delReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	defer delResp.Body.Close()
+
+	if delResp.StatusCode != fiber.StatusNoContent {
+		b, _ := io.ReadAll(delResp.Body)
+		t.Errorf("status = %d, want 204; body: %s", delResp.StatusCode, b)
+	}
+}
+
+func TestDeleteTeamAlias_NotFound(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestDeleteTeamAlias_NotFound?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "NF Del Team Alias Org", "nf-del-team-alias-org")
+	team := mustCreateTeam(t, database, org.ID, "NF Team", "nf-team-dta")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	req := httptest.NewRequest("DELETE", teamAliasItemURL(org.ID, team.ID, "00000000-0000-0000-0000-000000000099"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusNotFound {
+		b, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 404; body: %s", resp.StatusCode, b)
+	}
+}
+
+func TestCreateTeamAlias_DuplicateReturnsConflict(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithRegistry(t, "file:TestCreateTeamAlias_Dup?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Dup Team Alias Org", "dup-team-alias-org")
+	team := mustCreateTeam(t, database, org.ID, "Dup Team", "dup-alias-team")
+	creator := mustCreateUser(t, database, "creator-dup-cta@example.com", "Creator")
+	testKey := addRegistryTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID, creator.ID)
+
+	createBody := map[string]any{"alias": "dup-team-alias", "model_name": testModelName}
+
+	req1 := httptest.NewRequest("POST", teamAliasURL(org.ID, team.ID), bodyJSON(t, createBody))
+	req1.Header.Set("Content-Type", "application/json")
+	req1.Header.Set("Authorization", "Bearer "+testKey)
+	resp1, err := app.Test(req1, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("first create: %v", err)
+	}
+	resp1.Body.Close()
+	if resp1.StatusCode != fiber.StatusCreated {
+		t.Fatalf("first create: status = %d, want 201", resp1.StatusCode)
+	}
+
+	req2 := httptest.NewRequest("POST", teamAliasURL(org.ID, team.ID),
+		bodyJSON(t, createBody))
+	req2.Header.Set("Content-Type", "application/json")
+	req2.Header.Set("Authorization", "Bearer "+testKey)
+	resp2, err := app.Test(req2, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("second create: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != fiber.StatusConflict {
+		b, _ := io.ReadAll(resp2.Body)
+		t.Errorf("status = %d, want 409; body: %s", resp2.StatusCode, b)
+	}
+}

--- a/internal/api/admin/models_test.go
+++ b/internal/api/admin/models_test.go
@@ -1,0 +1,1577 @@
+package admin_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/voidmind-io/voidllm/internal/api/admin"
+	"github.com/voidmind-io/voidllm/internal/auth"
+	"github.com/voidmind-io/voidllm/internal/cache"
+	"github.com/voidmind-io/voidllm/internal/config"
+	"github.com/voidmind-io/voidllm/internal/db"
+	"github.com/voidmind-io/voidllm/internal/license"
+	"github.com/voidmind-io/voidllm/internal/proxy"
+)
+
+// setupModelTestApp creates a Fiber app wired with a fresh in-memory SQLite
+// database, an empty proxy.Registry, an AES-256 encryption key, and all admin
+// routes registered. It is used by model tests that exercise handlers which
+// call Registry methods (CreateModel, UpdateModel, DeleteModel, ActivateModel,
+// DeactivateModel) and optionally encrypt upstream API keys.
+func setupModelTestApp(t *testing.T, dsn string) (*fiber.App, *db.DB, *cache.Cache[string, auth.KeyInfo]) {
+	t.Helper()
+
+	ctx := context.Background()
+	database, err := db.Open(ctx, config.DatabaseConfig{
+		Driver:          "sqlite",
+		DSN:             dsn,
+		MaxOpenConns:    1,
+		MaxIdleConns:    1,
+		ConnMaxLifetime: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("open test DB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	if err := db.RunMigrations(ctx, database.SQL(), db.SQLiteDialect{}); err != nil {
+		t.Fatalf("run migrations: %v", err)
+	}
+
+	registry, err := proxy.NewRegistry(nil)
+	if err != nil {
+		t.Fatalf("proxy.NewRegistry: %v", err)
+	}
+
+	keyCache := cache.New[string, auth.KeyInfo]()
+
+	handler := &admin.Handler{
+		DB:            database,
+		HMACSecret:    testHMACSecret,
+		EncryptionKey: testEncryptionKey,
+		Registry:      registry,
+		KeyCache:      keyCache,
+		License:       license.NewHolder(license.Verify("", true)),
+		Log:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	app := fiber.New()
+	admin.RegisterRoutes(app, handler, keyCache, testHMACSecret, nil)
+
+	return app, database, keyCache
+}
+
+// modelURL returns the collection URL for models.
+func modelURL() string {
+	return "/api/v1/models"
+}
+
+// modelItemURL returns the URL for a specific model.
+func modelItemURL(modelID string) string {
+	return "/api/v1/models/" + modelID
+}
+
+// modelActivateURL returns the activate URL for a model.
+func modelActivateURL(modelID string) string {
+	return "/api/v1/models/" + modelID + "/activate"
+}
+
+// modelDeactivateURL returns the deactivate URL for a model.
+func modelDeactivateURL(modelID string) string {
+	return "/api/v1/models/" + modelID + "/deactivate"
+}
+
+// modelTestConnectionURL returns the test-connection URL.
+func modelTestConnectionURL() string {
+	return "/api/v1/models/test-connection"
+}
+
+// ---- POST /api/v1/models ----------------------------------------------------
+
+func TestCreateModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		body       any
+		wantStatus int
+		checkBody  func(t *testing.T, got map[string]any)
+	}{
+		{
+			name: "valid minimal request returns 201",
+			body: map[string]any{
+				"name":     "gpt-4o",
+				"provider": "openai",
+				"base_url": "https://api.openai.com/v1",
+			},
+			wantStatus: fiber.StatusCreated,
+			checkBody: func(t *testing.T, got map[string]any) {
+				t.Helper()
+				for _, field := range []string{"id", "name", "provider", "base_url", "is_active", "source", "aliases", "created_at", "updated_at"} {
+					if _, ok := got[field]; !ok {
+						t.Errorf("response missing field %q", field)
+					}
+				}
+				if got["name"] != "gpt-4o" {
+					t.Errorf("name = %v, want %q", got["name"], "gpt-4o")
+				}
+				if got["provider"] != "openai" {
+					t.Errorf("provider = %v, want %q", got["provider"], "openai")
+				}
+				if got["source"] != "api" {
+					t.Errorf("source = %v, want %q", got["source"], "api")
+				}
+			},
+		},
+		{
+			name: "valid request with all optional fields returns 201",
+			body: map[string]any{
+				"name":                "claude-opus",
+				"provider":            "anthropic",
+				"base_url":            "https://api.anthropic.com",
+				"max_context_tokens":  200000,
+				"input_price_per_1m":  15.0,
+				"output_price_per_1m": 75.0,
+				"type":                "chat",
+				"timeout":             "60s",
+				"aliases":             []string{"claude-3-opus"},
+			},
+			wantStatus: fiber.StatusCreated,
+			checkBody: func(t *testing.T, got map[string]any) {
+				t.Helper()
+				if got["name"] != "claude-opus" {
+					t.Errorf("name = %v, want %q", got["name"], "claude-opus")
+				}
+				aliases, ok := got["aliases"].([]any)
+				if !ok || len(aliases) != 1 {
+					t.Errorf("aliases = %v, want slice of 1", got["aliases"])
+				}
+			},
+		},
+		{
+			name: "valid request with api_key does not return api_key in response",
+			body: map[string]any{
+				"name":     "gpt-4-with-key",
+				"provider": "openai",
+				"base_url": "https://api.openai.com/v1",
+				"api_key":  "sk-supersecret",
+			},
+			wantStatus: fiber.StatusCreated,
+			checkBody: func(t *testing.T, got map[string]any) {
+				t.Helper()
+				if _, ok := got["api_key"]; ok {
+					t.Error("response must not include api_key field")
+				}
+				if _, ok := got["api_key_encrypted"]; ok {
+					t.Error("response must not include api_key_encrypted field")
+				}
+			},
+		},
+		{
+			name: "valid request with strategy does not require provider or base_url",
+			body: map[string]any{
+				"name":     "load-balanced-model",
+				"strategy": "round-robin",
+			},
+			wantStatus: fiber.StatusCreated,
+			checkBody: func(t *testing.T, got map[string]any) {
+				t.Helper()
+				if got["name"] != "load-balanced-model" {
+					t.Errorf("name = %v, want %q", got["name"], "load-balanced-model")
+				}
+			},
+		},
+		{
+			name: "missing name returns 400",
+			body: map[string]any{
+				"provider": "openai",
+				"base_url": "https://api.openai.com/v1",
+			},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name: "missing provider in single-endpoint mode returns 400",
+			body: map[string]any{
+				"name":     "no-provider-model",
+				"base_url": "https://api.openai.com/v1",
+			},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name: "missing base_url in single-endpoint mode returns 400",
+			body: map[string]any{
+				"name":     "no-url-model",
+				"provider": "openai",
+			},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name: "invalid provider returns 400",
+			body: map[string]any{
+				"name":     "bad-provider-model",
+				"provider": "not-a-real-provider",
+				"base_url": "https://api.openai.com/v1",
+			},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name: "invalid model type returns 400",
+			body: map[string]any{
+				"name":     "bad-type-model",
+				"provider": "openai",
+				"base_url": "https://api.openai.com/v1",
+				"type":     "not-a-real-type",
+			},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name: "invalid timeout returns 400",
+			body: map[string]any{
+				"name":     "bad-timeout-model",
+				"provider": "openai",
+				"base_url": "https://api.openai.com/v1",
+				"timeout":  "not-a-duration",
+			},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name: "invalid strategy returns 400",
+			body: map[string]any{
+				"name":     "bad-strategy-model",
+				"strategy": "not-a-strategy",
+			},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name: "valid strategy round-robin returns 201",
+			body: map[string]any{
+				"name":     "rr-model",
+				"strategy": "round-robin",
+			},
+			wantStatus: fiber.StatusCreated,
+		},
+		{
+			name: "valid strategy weighted returns 201",
+			body: map[string]any{
+				"name":     "weighted-model",
+				"strategy": "weighted",
+			},
+			wantStatus: fiber.StatusCreated,
+		},
+		{
+			name: "valid strategy priority returns 201",
+			body: map[string]any{
+				"name":     "priority-model",
+				"strategy": "priority",
+			},
+			wantStatus: fiber.StatusCreated,
+		},
+		{
+			name: "valid strategy least-latency returns 201",
+			body: map[string]any{
+				"name":     "ll-model",
+				"strategy": "least-latency",
+			},
+			wantStatus: fiber.StatusCreated,
+		},
+		{
+			name: "valid model type embedding returns 201",
+			body: map[string]any{
+				"name":     "embed-model",
+				"provider": "openai",
+				"base_url": "https://api.openai.com/v1",
+				"type":     "embedding",
+			},
+			wantStatus: fiber.StatusCreated,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dsn := fmt.Sprintf("file:TestCreateModel_%s?mode=memory&cache=private",
+				strings.ReplaceAll(tc.name, " ", "_"))
+			app, _, keyCache := setupModelTestApp(t, dsn)
+			testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+			req := httptest.NewRequest("POST", modelURL(), bodyJSON(t, tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testKey)
+
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+			if err != nil {
+				t.Fatalf("app.Test: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want %d; body: %s", resp.StatusCode, tc.wantStatus, body)
+			}
+
+			if tc.checkBody != nil && resp.StatusCode < 300 {
+				var got map[string]any
+				decodeBody(t, resp.Body, &got)
+				tc.checkBody(t, got)
+			}
+		})
+	}
+}
+
+func TestCreateModel_DuplicateName(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestCreateModel_DuplicateName?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	body := map[string]any{
+		"name":     "unique-model",
+		"provider": "openai",
+		"base_url": "https://api.openai.com/v1",
+	}
+
+	// First creation must succeed.
+	req1 := httptest.NewRequest("POST", modelURL(), bodyJSON(t, body))
+	req1.Header.Set("Content-Type", "application/json")
+	req1.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp1, err := app.Test(req1, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test (first): %v", err)
+	}
+	defer resp1.Body.Close()
+
+	if resp1.StatusCode != fiber.StatusCreated {
+		b, _ := io.ReadAll(resp1.Body)
+		t.Fatalf("first create status = %d, want 201; body: %s", resp1.StatusCode, b)
+	}
+
+	// Second creation with the same name must conflict.
+	req2 := httptest.NewRequest("POST", modelURL(), bodyJSON(t, body))
+	req2.Header.Set("Content-Type", "application/json")
+	req2.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp2, err := app.Test(req2, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test (second): %v", err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != fiber.StatusConflict {
+		b, _ := io.ReadAll(resp2.Body)
+		t.Errorf("second create status = %d, want 409; body: %s", resp2.StatusCode, b)
+	}
+}
+
+func TestCreateModel_ForbiddenForNonSystemAdmin(t *testing.T) {
+	t.Parallel()
+
+	roles := []string{auth.RoleOrgAdmin, auth.RoleMember}
+	for _, role := range roles {
+		t.Run(role, func(t *testing.T) {
+			t.Parallel()
+
+			dsn := fmt.Sprintf("file:TestCreateModel_Forbidden_%s?mode=memory&cache=private", role)
+			app, _, keyCache := setupModelTestApp(t, dsn)
+			testKey := addTestKey(t, keyCache, role, "")
+
+			req := httptest.NewRequest("POST", modelURL(), bodyJSON(t, map[string]any{
+				"name":     "model-forbidden",
+				"provider": "openai",
+				"base_url": "https://api.openai.com/v1",
+			}))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testKey)
+
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+			if err != nil {
+				t.Fatalf("app.Test: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != fiber.StatusForbidden {
+				b, _ := io.ReadAll(resp.Body)
+				t.Errorf("status = %d, want 403; body: %s", resp.StatusCode, b)
+			}
+		})
+	}
+}
+
+func TestCreateModel_Unauthenticated(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestCreateModel_Unauthenticated?mode=memory&cache=private"
+	app, _, _ := setupModelTestApp(t, dsn)
+
+	req := httptest.NewRequest("POST", modelURL(), bodyJSON(t, map[string]any{
+		"name":     "model-unauth",
+		"provider": "openai",
+		"base_url": "https://api.openai.com/v1",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusUnauthorized {
+		b, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 401; body: %s", resp.StatusCode, b)
+	}
+}
+
+// ---- GET /api/v1/models -----------------------------------------------------
+
+func TestListModels(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestListModels?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	// Seed three models so we can assert on count.
+	for i := range 3 {
+		mustCreateModelForDeployment(t, database, fmt.Sprintf("list-model-%d", i))
+	}
+
+	req := httptest.NewRequest("GET", modelURL(), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+
+	data, ok := got["data"].([]any)
+	if !ok {
+		t.Fatalf("response data field is not an array: %v", got["data"])
+	}
+	if len(data) != 3 {
+		t.Errorf("len(data) = %d, want 3", len(data))
+	}
+	if _, ok := got["has_more"]; !ok {
+		t.Error("response missing has_more field")
+	}
+}
+
+func TestListModels_Empty(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestListModels_Empty?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("GET", modelURL(), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+
+	data, ok := got["data"].([]any)
+	if !ok {
+		t.Fatalf("data is not an array: %v", got["data"])
+	}
+	if len(data) != 0 {
+		t.Errorf("len(data) = %d, want 0", len(data))
+	}
+	if got["has_more"] != false {
+		t.Errorf("has_more = %v, want false", got["has_more"])
+	}
+}
+
+func TestListModels_Pagination(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestListModels_Pagination?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	// Seed 5 models.
+	for i := range 5 {
+		mustCreateModelForDeployment(t, database, fmt.Sprintf("paged-model-%02d", i))
+	}
+
+	// Request only the first 3.
+	req := httptest.NewRequest("GET", modelURL()+"?limit=3", nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+
+	data, ok := got["data"].([]any)
+	if !ok {
+		t.Fatalf("data is not an array: %v", got["data"])
+	}
+	if len(data) != 3 {
+		t.Errorf("len(data) = %d, want 3", len(data))
+	}
+	if got["has_more"] != true {
+		t.Errorf("has_more = %v, want true", got["has_more"])
+	}
+	if got["next_cursor"] == "" || got["next_cursor"] == nil {
+		t.Error("next_cursor should be set when has_more is true")
+	}
+}
+
+func TestListModels_IncludesDeployments(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestListModels_IncludesDeployments?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	m := mustCreateModelForDeployment(t, database, "model-with-deps-list")
+	mustCreateDeploymentDB(t, database, m.ID, "dep-list-a")
+	mustCreateDeploymentDB(t, database, m.ID, "dep-list-b")
+
+	req := httptest.NewRequest("GET", modelURL(), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+
+	data, ok := got["data"].([]any)
+	if !ok || len(data) == 0 {
+		t.Fatalf("data = %v, want non-empty array", got["data"])
+	}
+
+	item, ok := data[0].(map[string]any)
+	if !ok {
+		t.Fatalf("data[0] is not a map: %T", data[0])
+	}
+
+	deployments, ok := item["deployments"].([]any)
+	if !ok || len(deployments) != 2 {
+		t.Errorf("deployments = %v, want array of 2", item["deployments"])
+	}
+}
+
+func TestListModels_ForbiddenForNonSystemAdmin(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestListModels_Forbidden?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, "")
+
+	req := httptest.NewRequest("GET", modelURL(), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 403; body: %s", resp.StatusCode, body)
+	}
+}
+
+// ---- GET /api/v1/models/:model_id -------------------------------------------
+
+func TestGetModel(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestGetModel?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	m := mustCreateModelForDeployment(t, database, "get-model-target")
+	mustCreateDeploymentDB(t, database, m.ID, "get-dep-a")
+
+	req := httptest.NewRequest("GET", modelItemURL(m.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+
+	if got["id"] != m.ID {
+		t.Errorf("id = %v, want %q", got["id"], m.ID)
+	}
+	if got["name"] != "get-model-target" {
+		t.Errorf("name = %v, want %q", got["name"], "get-model-target")
+	}
+
+	// Deployments must be embedded.
+	deps, ok := got["deployments"].([]any)
+	if !ok || len(deps) != 1 {
+		t.Errorf("deployments = %v, want array of 1", got["deployments"])
+	}
+
+	// API key must never appear.
+	for _, forbidden := range []string{"api_key", "api_key_encrypted"} {
+		if _, ok := got[forbidden]; ok {
+			t.Errorf("response must not include %q field", forbidden)
+		}
+	}
+}
+
+func TestGetModel_NotFound(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestGetModel_NotFound?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("GET", modelItemURL("00000000-0000-0000-0000-000000000000"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 404; body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestGetModel_ForbiddenForNonSystemAdmin(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestGetModel_Forbidden?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, "")
+
+	m := mustCreateModelForDeployment(t, database, "get-model-forbidden")
+
+	req := httptest.NewRequest("GET", modelItemURL(m.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 403; body: %s", resp.StatusCode, body)
+	}
+}
+
+// ---- PATCH /api/v1/models/:model_id -----------------------------------------
+
+func TestUpdateModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		body       any
+		wantStatus int
+		checkBody  func(t *testing.T, got map[string]any)
+	}{
+		{
+			name:       "partial update name returns 200",
+			body:       map[string]any{"name": "updated-model-name"},
+			wantStatus: fiber.StatusOK,
+			checkBody: func(t *testing.T, got map[string]any) {
+				t.Helper()
+				if got["name"] != "updated-model-name" {
+					t.Errorf("name = %v, want %q", got["name"], "updated-model-name")
+				}
+			},
+		},
+		{
+			name:       "partial update base_url returns 200",
+			body:       map[string]any{"base_url": "https://api.openai.com/v2"},
+			wantStatus: fiber.StatusOK,
+			checkBody: func(t *testing.T, got map[string]any) {
+				t.Helper()
+				if got["base_url"] != "https://api.openai.com/v2" {
+					t.Errorf("base_url = %v, want %q", got["base_url"], "https://api.openai.com/v2")
+				}
+			},
+		},
+		{
+			name:       "update with valid provider returns 200",
+			body:       map[string]any{"provider": "anthropic"},
+			wantStatus: fiber.StatusOK,
+			checkBody: func(t *testing.T, got map[string]any) {
+				t.Helper()
+				if got["provider"] != "anthropic" {
+					t.Errorf("provider = %v, want %q", got["provider"], "anthropic")
+				}
+			},
+		},
+		{
+			name:       "update with valid timeout returns 200",
+			body:       map[string]any{"timeout": "120s"},
+			wantStatus: fiber.StatusOK,
+			checkBody: func(t *testing.T, got map[string]any) {
+				t.Helper()
+				if got["timeout"] != "120s" {
+					t.Errorf("timeout = %v, want %q", got["timeout"], "120s")
+				}
+			},
+		},
+		{
+			name:       "update with valid strategy returns 200",
+			body:       map[string]any{"strategy": "weighted"},
+			wantStatus: fiber.StatusOK,
+			checkBody: func(t *testing.T, got map[string]any) {
+				t.Helper()
+				if got["strategy"] != "weighted" {
+					t.Errorf("strategy = %v, want %q", got["strategy"], "weighted")
+				}
+			},
+		},
+		{
+			name:       "update api_key does not return api_key in response",
+			body:       map[string]any{"api_key": "sk-new-secret"},
+			wantStatus: fiber.StatusOK,
+			checkBody: func(t *testing.T, got map[string]any) {
+				t.Helper()
+				if _, ok := got["api_key"]; ok {
+					t.Error("response must not include api_key field")
+				}
+				if _, ok := got["api_key_encrypted"]; ok {
+					t.Error("response must not include api_key_encrypted field")
+				}
+			},
+		},
+		{
+			name:       "update with invalid provider returns 400",
+			body:       map[string]any{"provider": "not-a-real-provider"},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "update with invalid strategy returns 400",
+			body:       map[string]any{"strategy": "not-a-strategy"},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "update with invalid timeout returns 400",
+			body:       map[string]any{"timeout": "not-a-duration"},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "update with invalid model type returns 400",
+			body:       map[string]any{"type": "not-a-type"},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "clearing provider in single-endpoint mode returns 400",
+			body:       map[string]any{"provider": ""},
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "clearing base_url in single-endpoint mode returns 400",
+			body:       map[string]any{"base_url": ""},
+			wantStatus: fiber.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dsn := fmt.Sprintf("file:TestUpdateModel_%s?mode=memory&cache=private",
+				strings.ReplaceAll(tc.name, " ", "_"))
+			app, database, keyCache := setupModelTestApp(t, dsn)
+			testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+			m := mustCreateModelForDeployment(t, database, "update-target-"+strings.ReplaceAll(tc.name, " ", "-"))
+
+			req := httptest.NewRequest("PATCH", modelItemURL(m.ID), bodyJSON(t, tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testKey)
+
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+			if err != nil {
+				t.Fatalf("app.Test: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want %d; body: %s", resp.StatusCode, tc.wantStatus, body)
+			}
+
+			if tc.checkBody != nil && resp.StatusCode == fiber.StatusOK {
+				var got map[string]any
+				decodeBody(t, resp.Body, &got)
+				tc.checkBody(t, got)
+			}
+		})
+	}
+}
+
+func TestUpdateModel_NotFound(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestUpdateModel_NotFound?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("PATCH", modelItemURL("00000000-0000-0000-0000-000000000000"),
+		bodyJSON(t, map[string]any{"name": "new-name"}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 404; body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestUpdateModel_DuplicateName(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestUpdateModel_DuplicateName?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	_ = mustCreateModelForDeployment(t, database, "existing-model-name")
+	m2 := mustCreateModelForDeployment(t, database, "model-to-rename")
+
+	req := httptest.NewRequest("PATCH", modelItemURL(m2.ID),
+		bodyJSON(t, map[string]any{"name": "existing-model-name"}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusConflict {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 409; body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestUpdateModel_ForbiddenForNonSystemAdmin(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestUpdateModel_Forbidden?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, "")
+
+	m := mustCreateModelForDeployment(t, database, "update-forbidden-model")
+
+	req := httptest.NewRequest("PATCH", modelItemURL(m.ID),
+		bodyJSON(t, map[string]any{"name": "hijacked"}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 403; body: %s", resp.StatusCode, body)
+	}
+}
+
+// ---- DELETE /api/v1/models/:model_id ----------------------------------------
+
+func TestDeleteModel(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestDeleteModel?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	m := mustCreateModelForDeployment(t, database, "model-to-delete")
+
+	req := httptest.NewRequest("DELETE", modelItemURL(m.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 204; body: %s", resp.StatusCode, body)
+	}
+
+	// Confirm the model is no longer accessible via GET.
+	getReq := httptest.NewRequest("GET", modelItemURL(m.ID), nil)
+	getReq.Header.Set("Authorization", "Bearer "+testKey)
+
+	getResp, err := app.Test(getReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test after delete: %v", err)
+	}
+	defer getResp.Body.Close()
+
+	if getResp.StatusCode != fiber.StatusNotFound {
+		t.Errorf("get after delete status = %d, want 404", getResp.StatusCode)
+	}
+}
+
+func TestDeleteModel_NotFound(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestDeleteModel_NotFound?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("DELETE", modelItemURL("00000000-0000-0000-0000-000000000000"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 404; body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestDeleteModel_ForbiddenForNonSystemAdmin(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestDeleteModel_Forbidden?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, "")
+
+	m := mustCreateModelForDeployment(t, database, "delete-forbidden-model")
+
+	req := httptest.NewRequest("DELETE", modelItemURL(m.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 403; body: %s", resp.StatusCode, body)
+	}
+}
+
+// ---- PATCH /api/v1/models/:model_id/activate --------------------------------
+
+func TestActivateModel(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestActivateModel?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	m := mustCreateModelForDeployment(t, database, "model-to-activate")
+
+	req := httptest.NewRequest("PATCH", modelActivateURL(m.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+
+	if got["is_active"] != true {
+		t.Errorf("is_active = %v, want true", got["is_active"])
+	}
+	if got["id"] != m.ID {
+		t.Errorf("id = %v, want %q", got["id"], m.ID)
+	}
+}
+
+func TestActivateModel_NotFound(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestActivateModel_NotFound?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("PATCH", modelActivateURL("00000000-0000-0000-0000-000000000000"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 404; body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestActivateModel_ForbiddenForNonSystemAdmin(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestActivateModel_Forbidden?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, "")
+
+	m := mustCreateModelForDeployment(t, database, "activate-forbidden-model")
+
+	req := httptest.NewRequest("PATCH", modelActivateURL(m.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 403; body: %s", resp.StatusCode, body)
+	}
+}
+
+// ---- PATCH /api/v1/models/:model_id/deactivate ------------------------------
+
+func TestDeactivateModel(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestDeactivateModel?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	m := mustCreateModelForDeployment(t, database, "model-to-deactivate")
+
+	req := httptest.NewRequest("PATCH", modelDeactivateURL(m.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+
+	if got["is_active"] != false {
+		t.Errorf("is_active = %v, want false", got["is_active"])
+	}
+	if got["id"] != m.ID {
+		t.Errorf("id = %v, want %q", got["id"], m.ID)
+	}
+}
+
+func TestDeactivateModel_NotFound(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestDeactivateModel_NotFound?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("PATCH", modelDeactivateURL("00000000-0000-0000-0000-000000000000"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 404; body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestDeactivateModel_ForbiddenForNonSystemAdmin(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestDeactivateModel_Forbidden?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, "")
+
+	m := mustCreateModelForDeployment(t, database, "deactivate-forbidden-model")
+
+	req := httptest.NewRequest("PATCH", modelDeactivateURL(m.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 403; body: %s", resp.StatusCode, body)
+	}
+}
+
+// TestActivateDeactivateToggle verifies the full activate/deactivate round-trip
+// on a single model using a shared DB instance.
+func TestActivateDeactivateToggle(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestActivateDeactivateToggle?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	m := mustCreateModelForDeployment(t, database, "toggle-model")
+
+	// Deactivate it.
+	deactivateReq := httptest.NewRequest("PATCH", modelDeactivateURL(m.ID), nil)
+	deactivateReq.Header.Set("Authorization", "Bearer "+testKey)
+	deactivateResp, err := app.Test(deactivateReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test deactivate: %v", err)
+	}
+	defer deactivateResp.Body.Close()
+	if deactivateResp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(deactivateResp.Body)
+		t.Fatalf("deactivate status = %d; body: %s", deactivateResp.StatusCode, body)
+	}
+	var deactivated map[string]any
+	decodeBody(t, deactivateResp.Body, &deactivated)
+	if deactivated["is_active"] != false {
+		t.Errorf("after deactivate: is_active = %v, want false", deactivated["is_active"])
+	}
+
+	// Re-activate it.
+	activateReq := httptest.NewRequest("PATCH", modelActivateURL(m.ID), nil)
+	activateReq.Header.Set("Authorization", "Bearer "+testKey)
+	activateResp, err := app.Test(activateReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test activate: %v", err)
+	}
+	defer activateResp.Body.Close()
+	if activateResp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(activateResp.Body)
+		t.Fatalf("activate status = %d; body: %s", activateResp.StatusCode, body)
+	}
+	var activated map[string]any
+	decodeBody(t, activateResp.Body, &activated)
+	if activated["is_active"] != true {
+		t.Errorf("after activate: is_active = %v, want true", activated["is_active"])
+	}
+}
+
+// ---- POST /api/v1/models/test-connection ------------------------------------
+
+func TestTestConnection_MissingBaseURL(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestTestConnection_MissingBaseURL?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("POST", modelTestConnectionURL(), bodyJSON(t, map[string]any{
+		"provider": "openai",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 400; body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestTestConnection_InvalidScheme(t *testing.T) {
+	t.Parallel()
+
+	schemes := []struct {
+		name    string
+		baseURL string
+	}{
+		{name: "ftp scheme", baseURL: "ftp://example.com/v1"},
+		{name: "file scheme", baseURL: "file:///etc/passwd"},
+		{name: "no scheme", baseURL: "example.com/v1"},
+	}
+
+	for _, tc := range schemes {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dsn := fmt.Sprintf("file:TestTestConnection_InvalidScheme_%s?mode=memory&cache=private",
+				strings.ReplaceAll(tc.name, " ", "_"))
+			app, _, keyCache := setupModelTestApp(t, dsn)
+			testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+			req := httptest.NewRequest("POST", modelTestConnectionURL(), bodyJSON(t, map[string]any{
+				"provider": "openai",
+				"base_url": tc.baseURL,
+			}))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testKey)
+
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+			if err != nil {
+				t.Fatalf("app.Test: %v", err)
+			}
+			defer resp.Body.Close()
+
+			// The handler returns 200 with success=false for bad schemes.
+			if resp.StatusCode != fiber.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+			}
+
+			var got map[string]any
+			decodeBody(t, resp.Body, &got)
+			if got["success"] != false {
+				t.Errorf("success = %v, want false", got["success"])
+			}
+		})
+	}
+}
+
+func TestTestConnection_ReachableServer(t *testing.T) {
+	t.Parallel()
+
+	// Spin up a mock upstream that returns a valid OpenAI-style /models response.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"gpt-4"},{"id":"gpt-3.5-turbo"}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	dsn := "file:TestTestConnection_ReachableServer?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("POST", modelTestConnectionURL(), bodyJSON(t, map[string]any{
+		"provider": "openai",
+		"base_url": upstream.URL,
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+
+	if got["success"] != true {
+		t.Errorf("success = %v, want true", got["success"])
+	}
+	msg, _ := got["message"].(string)
+	if !strings.Contains(msg, "2 models") {
+		t.Errorf("message = %q, want to contain '2 models'", msg)
+	}
+}
+
+func TestTestConnection_UnreachableServer(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestTestConnection_UnreachableServer?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	// Port 1 is almost universally refused / unreachable.
+	req := httptest.NewRequest("POST", modelTestConnectionURL(), bodyJSON(t, map[string]any{
+		"provider": "openai",
+		"base_url": "http://127.0.0.1:1",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 15 * testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+
+	if got["success"] != false {
+		t.Errorf("success = %v, want false", got["success"])
+	}
+}
+
+func TestTestConnection_AuthFailure(t *testing.T) {
+	t.Parallel()
+
+	// Mock upstream that returns 401.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(upstream.Close)
+
+	dsn := "file:TestTestConnection_AuthFailure?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("POST", modelTestConnectionURL(), bodyJSON(t, map[string]any{
+		"provider": "openai",
+		"base_url": upstream.URL,
+		"api_key":  "invalid-key",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+
+	if got["success"] != false {
+		t.Errorf("success = %v, want false", got["success"])
+	}
+	msg, _ := got["message"].(string)
+	if !strings.Contains(msg, "authentication failed") {
+		t.Errorf("message = %q, want to contain 'authentication failed'", msg)
+	}
+}
+
+func TestTestConnection_ServerError(t *testing.T) {
+	t.Parallel()
+
+	// Mock upstream that returns 500.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(upstream.Close)
+
+	dsn := "file:TestTestConnection_ServerError?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("POST", modelTestConnectionURL(), bodyJSON(t, map[string]any{
+		"provider": "openai",
+		"base_url": upstream.URL,
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+
+	if got["success"] != false {
+		t.Errorf("success = %v, want false", got["success"])
+	}
+}
+
+func TestTestConnection_ForbiddenForNonSystemAdmin(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestTestConnection_Forbidden?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, "")
+
+	req := httptest.NewRequest("POST", modelTestConnectionURL(), bodyJSON(t, map[string]any{
+		"provider": "openai",
+		"base_url": "https://api.openai.com/v1",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 403; body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestTestConnection_AnthropicUsesXAPIKeyHeader(t *testing.T) {
+	t.Parallel()
+
+	var capturedHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	dsn := "file:TestTestConnection_AnthropicHeader?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("POST", modelTestConnectionURL(), bodyJSON(t, map[string]any{
+		"provider": "anthropic",
+		"base_url": upstream.URL,
+		"api_key":  "sk-ant-test-key",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if capturedHeaders.Get("x-api-key") != "sk-ant-test-key" {
+		t.Errorf("x-api-key header = %q, want %q", capturedHeaders.Get("x-api-key"), "sk-ant-test-key")
+	}
+	if capturedHeaders.Get("anthropic-version") == "" {
+		t.Error("anthropic-version header must be set for anthropic provider")
+	}
+	if capturedHeaders.Get("Authorization") != "" {
+		t.Error("Authorization header must not be set for anthropic provider")
+	}
+}
+
+func TestTestConnection_NonAnthropicUsesBearerAuth(t *testing.T) {
+	t.Parallel()
+
+	var capturedHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	dsn := "file:TestTestConnection_BearerAuth?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("POST", modelTestConnectionURL(), bodyJSON(t, map[string]any{
+		"provider": "openai",
+		"base_url": upstream.URL,
+		"api_key":  "sk-openai-key",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if capturedHeaders.Get("Authorization") != "Bearer sk-openai-key" {
+		t.Errorf("Authorization header = %q, want %q", capturedHeaders.Get("Authorization"), "Bearer sk-openai-key")
+	}
+}


### PR DESCRIPTION
## Summary

Adds ~3700 lines of integration tests for previously untested admin API handlers.

- **models_test.go** — 17 test functions: CRUD, strategy validation, deployment inclusion, test-connection with mock servers, RBAC, API key redaction
- **invites_test.go** — create/list/revoke invites, email validation, cross-org RBAC
- **model_aliases_test.go** — org + team alias CRUD, duplicate detection, RBAC
- **model_access_test.go** — org + team allowlists, most-restrictive-wins enforcement, RBAC

All tests use real SQLite in-memory databases, no mocks.

## Test plan

- [ ] `go test ./internal/api/admin/... -race -count=1`
- [ ] Coverage increase visible on Codecov