### PR TITLE
feat: built-in VoidLLM management MCP as default server entry

### DIFF
--- a/internal/api/admin/call_mcp_tool_test.go
+++ b/internal/api/admin/call_mcp_tool_test.go
@@ -354,6 +354,41 @@ func TestCallMCPTool_NilLogger(t *testing.T) {
 	}
 }
 
+// ---- TestCallMCPTool_BuiltinServer ------------------------------------------
+
+// TestCallMCPTool_BuiltinServer verifies that CallMCPTool with alias "voidllm"
+// dispatches the tool call in-process via the built-in MCP server rather than
+// making an HTTP request. The response must be a valid JSON-RPC result.
+func TestCallMCPTool_BuiltinServer(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestCallMCPTool_BuiltinServer?mode=memory&cache=private"
+	handler, _ := newCallMCPToolHandler(t, dsn, nil)
+	ki := newTestKeyInfo("org-builtin", "key-builtin")
+
+	// list_models is a real registered tool that requires no arguments and
+	// returns a JSON array. Using it proves the full in-process dispatch path.
+	result, err := handler.CallMCPTool(context.Background(), ki, "voidllm", "list_models", json.RawMessage(`{}`), false, "")
+	if err != nil {
+		t.Fatalf("CallMCPTool(voidllm/list_models) error = %v, want nil", err)
+	}
+	if result == nil {
+		t.Fatal("CallMCPTool(voidllm/list_models) result = nil, want non-nil")
+	}
+	// The response must be valid JSON.
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("result is not valid JSON: %v — raw: %s", err, result)
+	}
+	// A successful JSON-RPC response must carry a "result" key, not "error".
+	if _, hasErr := parsed["error"]; hasErr {
+		t.Errorf("response contains \"error\" key, want successful result: %s", result)
+	}
+	if _, hasResult := parsed["result"]; !hasResult {
+		t.Errorf("response missing \"result\" key: %s", result)
+	}
+}
+
 // ---- TestCallMCPTool_LoggerFields -------------------------------------------
 
 // TestCallMCPTool_LoggerFields verifies that the event emitted to MCPLogger

--- a/internal/api/admin/mcp_proxy.go
+++ b/internal/api/admin/mcp_proxy.go
@@ -374,6 +374,11 @@ func buildToolCallRequest(toolName string, args json.RawMessage) []byte {
 // all tool calls from a single execute_code invocation; pass an empty string
 // for non-Code-Mode calls.
 func (h *Handler) CallMCPTool(ctx context.Context, ki *auth.KeyInfo, serverAlias, toolName string, args json.RawMessage, codeMode bool, executionID string) (json.RawMessage, error) {
+	// Built-in VoidLLM management server — dispatch in-process instead of HTTP.
+	if serverAlias == "voidllm" && h.MCPServer != nil {
+		return h.callBuiltinTool(ctx, ki, toolName, args)
+	}
+
 	server, err := h.DB.GetMCPServerByAliasScoped(ctx, serverAlias, ki.OrgID, ki.TeamID)
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
@@ -485,6 +490,25 @@ func (h *Handler) CallMCPTool(ctx context.Context, ki *auth.KeyInfo, serverAlias
 		return nil, fmt.Errorf("CallMCPTool %s/%s: transport: %w", serverAlias, toolName, callErr)
 	}
 
+	return result, nil
+}
+
+// callBuiltinTool dispatches a tool call to the built-in VoidLLM management
+// MCP server in-process, without HTTP. The caller's identity is injected into
+// the MCP context so tool handlers can enforce RBAC.
+func (h *Handler) callBuiltinTool(ctx context.Context, ki *auth.KeyInfo, toolName string, args json.RawMessage) (json.RawMessage, error) {
+	mcpCtx := mcp.WithKeyIdentity(ctx, mcp.KeyIdentity{
+		OrgID:  ki.OrgID,
+		TeamID: ki.TeamID,
+		KeyID:  ki.ID,
+		UserID: ki.UserID,
+		Role:   ki.Role,
+	})
+	body := buildToolCallRequest(toolName, args)
+	result := h.MCPServer.Handle(mcpCtx, body)
+	if result == nil {
+		return nil, fmt.Errorf("builtin tool %s: no response", toolName)
+	}
 	return result, nil
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -210,11 +210,17 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 	if err := database.SyncYAMLMCPServers(ctx, cfg.MCPServers, encKey); err != nil {
 		return nil, fmt.Errorf("sync YAML MCP servers: %w", err)
 	}
+	if _, err := database.EnsureBuiltinMCPServer(ctx); err != nil {
+		return nil, fmt.Errorf("ensure builtin MCP server: %w", err)
+	}
 
 	// Probe all active MCP servers to detect deprecated SSE transport.
 	// Servers that only support SSE are auto-deactivated with a warning.
 	if allServers, listErr := database.ListMCPServers(ctx); listErr == nil {
 		for _, s := range allServers {
+			if s.Source == "builtin" {
+				continue // built-in server has no external URL to probe
+			}
 			var token string
 			if s.AuthTokenEnc != nil && *s.AuthTokenEnc != "" {
 				token, _ = crypto.DecryptString(*s.AuthTokenEnc, encKey, []byte("mcp_server:"+s.ID))
@@ -580,6 +586,13 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 		adminHandler.HealthChecker = healthChecker
 	}
 
+	// builtinMCPServer is set after RegisterVoidLLMTools below; the ToolFetcher
+	// closure captures this variable so the assignment is visible at call time.
+	// toolStore is also hoisted so the built-in tools can be persisted after
+	// RegisterVoidLLMTools populates the server.
+	var builtinMCPServer *mcp.Server
+	var toolStore mcp.ToolStore
+
 	// Code Mode: create the runtime pool, executor, and tool cache when enabled.
 	// These are assigned to the handler before RegisterVoidLLMTools is called so
 	// that the deps closures below can close over the handler and its fields.
@@ -595,8 +608,14 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 		}
 		adminHandler.CodePool = codePool
 		adminHandler.CodeExecutor = mcp.NewExecutor(codePool)
-		toolStore := &dbToolStore{db: database}
-		adminHandler.ToolCache = mcp.NewPersistentToolCache(adminHandler.MakeToolFetcher(), time.Hour, toolStore)
+		toolStore = &dbToolStore{db: database}
+		httpFetcher := adminHandler.MakeToolFetcher()
+		adminHandler.ToolCache = mcp.NewPersistentToolCache(func(fetchCtx context.Context, alias string) ([]mcp.Tool, error) {
+			if alias == "voidllm" && builtinMCPServer != nil {
+				return builtinMCPServer.Tools(), nil
+			}
+			return httpFetcher(fetchCtx, alias)
+		}, time.Hour, toolStore)
 		if loadErr := adminHandler.ToolCache.LoadFromStore(ctx); loadErr != nil {
 			log.WarnContext(ctx, "failed to load cached tools from DB", slog.String("error", loadErr.Error()))
 		}
@@ -808,6 +827,17 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 	}
 	mcp.RegisterVoidLLMTools(mcpServer, voidllmDeps)
 	adminHandler.MCPServer = mcpServer
+
+	// Expose the built-in server's tools through the ToolCache so Code Mode
+	// callers can discover and invoke them without an HTTP round-trip.
+	builtinMCPServer = mcpServer
+	if adminHandler.ToolCache != nil {
+		builtinTools := mcpServer.Tools()
+		adminHandler.ToolCache.SetTools("voidllm", builtinTools)
+		if toolStore != nil {
+			toolStore.Save(ctx, "voidllm", builtinTools) //nolint:errcheck
+		}
+	}
 
 	// Wire the Code Mode MCP server when Code Mode is enabled. It exposes only
 	// the list_servers, search_tools, and execute_code tools and is served at

--- a/internal/app/code_mode.go
+++ b/internal/app/code_mode.go
@@ -74,6 +74,13 @@ func (s *codeModeService) accessibleServers(ctx context.Context, codeModeOnly bo
 			}
 			continue
 		}
+		// Built-in server is always accessible — no explicit MCP access entry needed.
+		if sv.Source == "builtin" {
+			if !codeModeOnly || sv.CodeModeEnabled {
+				accessible = append(accessible, sv)
+			}
+			continue
+		}
 		allowed, accessErr := s.db.CheckMCPAccess(ctx, ki.OrgID, ki.TeamID, ki.KeyID, sv.ID)
 		if accessErr != nil {
 			continue

--- a/internal/app/code_mode_test.go
+++ b/internal/app/code_mode_test.go
@@ -276,6 +276,90 @@ func TestAccessibleServers_MCPAccessFilter(t *testing.T) {
 	}
 }
 
+// TestAccessibleServers_BuiltinAlwaysIncluded verifies that a global server
+// with source="builtin" is included without requiring a MCP access entry.
+func TestAccessibleServers_BuiltinAlwaysIncluded(t *testing.T) {
+	t.Parallel()
+
+	builtinSv := db.MCPServer{
+		ID:              "sv-builtin",
+		Alias:           "voidllm",
+		Name:            "VoidLLM",
+		Source:          "builtin",
+		CodeModeEnabled: true,
+	}
+	// A regular global server that requires explicit access — denied here.
+	regularSv := db.MCPServer{
+		ID:              "sv-regular",
+		Alias:           "other",
+		Name:            "Other Server",
+		Source:          "api",
+		CodeModeEnabled: true,
+	}
+
+	mock := &mockCodeModeDB{
+		servers:       []db.MCPServer{builtinSv, regularSv},
+		accessAllowed: map[string]bool{
+			// Neither server has explicit access; builtin must bypass this.
+		},
+	}
+	svc := &codeModeService{db: mock, log: newDiscardLogger()}
+
+	ctx := ctxWithIdentity(mcp.KeyIdentity{KeyID: "key-builtin-test", Role: "member"})
+	got, err := svc.accessibleServers(ctx, false)
+	if err != nil {
+		t.Fatalf("accessibleServers() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d servers, want 1 (only builtin)", len(got))
+	}
+	if got[0].Source != "builtin" {
+		t.Errorf("got server Source = %q, want %q", got[0].Source, "builtin")
+	}
+	if got[0].Alias != "voidllm" {
+		t.Errorf("got server Alias = %q, want %q", got[0].Alias, "voidllm")
+	}
+}
+
+// TestAccessibleServers_BuiltinRespectsCodeModeFilter verifies that a builtin
+// server with CodeModeEnabled=false is excluded when codeModeOnly=true.
+func TestAccessibleServers_BuiltinRespectsCodeModeFilter(t *testing.T) {
+	t.Parallel()
+
+	builtinDisabled := db.MCPServer{
+		ID:              "sv-builtin-disabled",
+		Alias:           "voidllm",
+		Name:            "VoidLLM",
+		Source:          "builtin",
+		CodeModeEnabled: false,
+	}
+
+	mock := &mockCodeModeDB{
+		servers: []db.MCPServer{builtinDisabled},
+	}
+	svc := &codeModeService{db: mock, log: newDiscardLogger()}
+
+	ctx := ctxWithIdentity(mcp.KeyIdentity{KeyID: "key-builtin-cm", Role: "member"})
+
+	// codeModeOnly=true — the disabled builtin server must be excluded.
+	got, err := svc.accessibleServers(ctx, true)
+	if err != nil {
+		t.Fatalf("accessibleServers(codeModeOnly=true) error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("got %d servers with codeModeOnly=true, want 0 (builtin CodeModeEnabled=false)", len(got))
+	}
+
+	// codeModeOnly=false — the disabled builtin server should appear.
+	got2, err := svc.accessibleServers(ctx, false)
+	if err != nil {
+		t.Fatalf("accessibleServers(codeModeOnly=false) error = %v", err)
+	}
+	if len(got2) != 1 {
+		t.Errorf("got %d servers with codeModeOnly=false, want 1", len(got2))
+	}
+}
+
 func TestAccessibleServers_CodeModeDisabled(t *testing.T) {
 	t.Parallel()
 

--- a/internal/db/mcp_servers.go
+++ b/internal/db/mcp_servers.go
@@ -31,7 +31,8 @@ type MCPServer struct {
 	IsActive     bool
 	CreatedBy    *string
 	// Source indicates how this server was registered: "api" for Admin API-created
-	// servers, "yaml" for config-file-sourced servers. Defaults to "api".
+	// servers, "yaml" for config-file-sourced servers, or "builtin" for the
+	// built-in VoidLLM management server. Defaults to "api".
 	Source string
 	// CodeModeEnabled controls whether this server's tools are available in
 	// Code Mode sandboxed execution. Default true.
@@ -491,6 +492,47 @@ func scanMCPServer(scanner interface{ Scan(...any) error }) (*MCPServer, error) 
 // against a different row.
 func mcpServerAAD(serverID string) []byte {
 	return []byte("mcp_server:" + serverID)
+}
+
+// EnsureBuiltinMCPServer creates or returns the built-in VoidLLM management
+// MCP server record. It is idempotent — safe to call on every startup.
+// If a server with alias "voidllm" already exists (any source), it is left
+// untouched and returned as-is.
+func (d *DB) EnsureBuiltinMCPServer(ctx context.Context) (*MCPServer, error) {
+	existing, err := d.GetMCPServerByAlias(ctx, "voidllm")
+	if err == nil {
+		return existing, nil // already exists and is active
+	}
+	if !errors.Is(err, ErrNotFound) {
+		return nil, fmt.Errorf("ensure builtin mcp server: %w", err)
+	}
+
+	// Not found (inactive or never created). Try to create.
+	created, createErr := d.CreateMCPServer(ctx, CreateMCPServerParams{
+		Name:     "VoidLLM",
+		Alias:    "voidllm",
+		URL:      "",
+		AuthType: "none",
+		Source:   "builtin",
+	})
+	if createErr == nil {
+		return created, nil
+	}
+
+	// ErrConflict means the row exists but is inactive or soft-deleted.
+	// Re-activate it.
+	if errors.Is(createErr, ErrConflict) {
+		p := d.dialect.Placeholder
+		reactivateQuery := "UPDATE mcp_servers SET is_active = 1, deleted_at = NULL, updated_at = CURRENT_TIMESTAMP" +
+			" WHERE alias = " + p(1) + " AND org_id IS NULL AND team_id IS NULL"
+		if _, execErr := d.sql.ExecContext(ctx, reactivateQuery, "voidllm"); execErr != nil {
+			return nil, fmt.Errorf("ensure builtin mcp server: reactivate: %w", execErr)
+		}
+		// Re-fetch the now-active row.
+		return d.GetMCPServerByAlias(ctx, "voidllm")
+	}
+
+	return nil, fmt.Errorf("ensure builtin mcp server: %w", createErr)
 }
 
 // SyncYAMLMCPServers upserts YAML-configured global MCP servers into the database.

--- a/internal/db/mcp_servers_test.go
+++ b/internal/db/mcp_servers_test.go
@@ -1062,3 +1062,135 @@ func TestSyncYAMLMCPServers_Empty(t *testing.T) {
 		t.Errorf("SyncYAMLMCPServers([]) error = %v, want nil", err)
 	}
 }
+
+// ---- EnsureBuiltinMCPServer -------------------------------------------------
+
+// TestEnsureBuiltinMCPServer_CreatesNew verifies that the first call creates a
+// global server with source="builtin" and alias="voidllm".
+func TestEnsureBuiltinMCPServer_CreatesNew(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+
+	got, err := d.EnsureBuiltinMCPServer(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureBuiltinMCPServer() error = %v, want nil", err)
+	}
+	if got == nil {
+		t.Fatal("EnsureBuiltinMCPServer() = nil, want non-nil server")
+	}
+	if got.Alias != "voidllm" {
+		t.Errorf("Alias = %q, want %q", got.Alias, "voidllm")
+	}
+	if got.Source != "builtin" {
+		t.Errorf("Source = %q, want %q", got.Source, "builtin")
+	}
+	if got.Name != "VoidLLM" {
+		t.Errorf("Name = %q, want %q", got.Name, "VoidLLM")
+	}
+	if !got.IsActive {
+		t.Error("IsActive = false, want true")
+	}
+	if got.OrgID != nil {
+		t.Errorf("OrgID = %v, want nil (global server)", got.OrgID)
+	}
+	if got.TeamID != nil {
+		t.Errorf("TeamID = %v, want nil (global server)", got.TeamID)
+	}
+	if got.ID == "" {
+		t.Error("ID is empty, want non-empty UUID")
+	}
+}
+
+// TestEnsureBuiltinMCPServer_Idempotent verifies that calling
+// EnsureBuiltinMCPServer twice returns the same record.
+func TestEnsureBuiltinMCPServer_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+
+	first, err := d.EnsureBuiltinMCPServer(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureBuiltinMCPServer() first call error = %v", err)
+	}
+
+	second, err := d.EnsureBuiltinMCPServer(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureBuiltinMCPServer() second call error = %v", err)
+	}
+
+	if first.ID != second.ID {
+		t.Errorf("second call returned different ID: first=%q second=%q", first.ID, second.ID)
+	}
+	if second.Source != "builtin" {
+		t.Errorf("second call Source = %q, want %q", second.Source, "builtin")
+	}
+}
+
+// TestEnsureBuiltinMCPServer_ReactivatesInactive verifies that when the builtin
+// server has been deactivated, EnsureBuiltinMCPServer reactivates it.
+func TestEnsureBuiltinMCPServer_ReactivatesInactive(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+
+	// Create the builtin server.
+	created, err := d.EnsureBuiltinMCPServer(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureBuiltinMCPServer() create error = %v", err)
+	}
+
+	// Deactivate it.
+	falseVal := false
+	if _, err := d.UpdateMCPServer(context.Background(), created.ID, UpdateMCPServerParams{IsActive: &falseVal}); err != nil {
+		t.Fatalf("UpdateMCPServer(deactivate) error = %v", err)
+	}
+
+	// Calling again should reactivate it.
+	reactivated, err := d.EnsureBuiltinMCPServer(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureBuiltinMCPServer() reactivate error = %v", err)
+	}
+	if !reactivated.IsActive {
+		t.Error("IsActive = false after EnsureBuiltinMCPServer reactivation, want true")
+	}
+	if reactivated.ID != created.ID {
+		t.Errorf("reactivated ID = %q, want original ID %q", reactivated.ID, created.ID)
+	}
+}
+
+// TestEnsureBuiltinMCPServer_DoesNotOverrideAPI verifies that when a server
+// with alias "voidllm" already exists with source="api", EnsureBuiltinMCPServer
+// returns it unchanged and does not overwrite its source.
+func TestEnsureBuiltinMCPServer_DoesNotOverrideAPI(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+
+	// Create an API-sourced server with the same alias first.
+	apiServer, err := d.CreateMCPServer(context.Background(), CreateMCPServerParams{
+		Name:     "Custom VoidLLM",
+		Alias:    "voidllm",
+		URL:      "https://custom.example.com/mcp",
+		AuthType: "none",
+		Source:   "api",
+	})
+	if err != nil {
+		t.Fatalf("CreateMCPServer(api) error = %v", err)
+	}
+
+	// EnsureBuiltinMCPServer must find the existing row and return it as-is.
+	got, err := d.EnsureBuiltinMCPServer(context.Background())
+	if err != nil {
+		t.Fatalf("EnsureBuiltinMCPServer() error = %v", err)
+	}
+	if got.ID != apiServer.ID {
+		t.Errorf("returned ID = %q, want original API server ID %q", got.ID, apiServer.ID)
+	}
+	if got.Source != "api" {
+		t.Errorf("Source = %q, want %q (must not overwrite API server)", got.Source, "api")
+	}
+	if got.URL != "https://custom.example.com/mcp" {
+		t.Errorf("URL = %q, want original URL to be preserved", got.URL)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -53,6 +53,17 @@ func (s *Server) RegisterTool(tool Tool, handler ToolHandler) {
 	s.handlers[tool.Name] = handler
 }
 
+// Tools returns a copy of the registered tool schemas. The returned slice is
+// safe to use after the call; mutations do not affect the server's internal
+// state. It is safe to call concurrently with Handle and RegisterTool.
+func (s *Server) Tools() []Tool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Tool, len(s.tools))
+	copy(out, s.tools)
+	return out
+}
+
 // SetOnToolsList registers a hook that is called inside tools/list before the
 // tool list is returned. The hook receives a shallow copy of the registered
 // tools and may return a modified slice. Setting a nil hook clears any

--- a/internal/mcp/tool_cache.go
+++ b/internal/mcp/tool_cache.go
@@ -205,6 +205,19 @@ func (tc *ToolCache) RefreshAll(ctx context.Context) error {
 	return firstErr
 }
 
+// SetTools manually populates the cache for an alias with the given tools.
+// Used for the built-in server whose tools come from memory, not HTTP.
+// The entry is marked fresh at the current time; it will not be re-fetched
+// from upstream until maxAge has elapsed.
+func (tc *ToolCache) SetTools(alias string, tools []Tool) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+	tc.entries[alias] = &cacheEntry{
+		tools:     tools,
+		fetchedAt: time.Now(),
+	}
+}
+
 // Invalidate removes the cached entry for alias. Subsequent calls to GetTools
 // for that alias will trigger a fresh upstream fetch.
 func (tc *ToolCache) Invalidate(alias string) {

--- a/internal/mcp/tool_cache_test.go
+++ b/internal/mcp/tool_cache_test.go
@@ -509,6 +509,80 @@ func TestToolCache_GetTools_ReturnsCopy(t *testing.T) {
 	}
 }
 
+// ---- SetTools ----------------------------------------------------------------
+
+// TestSetTools_PopulatesCache verifies that SetTools writes tools into the
+// cache so that GetAllTools returns them immediately without an upstream fetch.
+func TestSetTools_PopulatesCache(t *testing.T) {
+	t.Parallel()
+
+	tools := []mcp.Tool{
+		{Name: "builtin_tool_a", Description: "First builtin tool"},
+		{Name: "builtin_tool_b", Description: "Second builtin tool"},
+	}
+
+	// Use a fetcher that always fails so any GetTools call would error — only
+	// SetTools should populate the cache.
+	fetcher := func(_ context.Context, _ string) ([]mcp.Tool, error) {
+		return nil, errors.New("should not be called")
+	}
+	cache := mcp.NewToolCache(fetcher, time.Hour)
+
+	cache.SetTools("voidllm", tools)
+
+	all := cache.GetAllTools()
+	got, ok := all["voidllm"]
+	if !ok {
+		t.Fatal("GetAllTools() missing key \"voidllm\" after SetTools")
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(tools) = %d, want 2", len(got))
+	}
+	if got[0].Name != "builtin_tool_a" {
+		t.Errorf("tools[0].Name = %q, want %q", got[0].Name, "builtin_tool_a")
+	}
+	if got[1].Name != "builtin_tool_b" {
+		t.Errorf("tools[1].Name = %q, want %q", got[1].Name, "builtin_tool_b")
+	}
+}
+
+// TestSetTools_OverwritesExisting verifies that calling SetTools a second time
+// for the same alias replaces the previous tools entirely.
+func TestSetTools_OverwritesExisting(t *testing.T) {
+	t.Parallel()
+
+	firstTools := []mcp.Tool{
+		{Name: "v1_tool"},
+	}
+	secondTools := []mcp.Tool{
+		{Name: "v2_tool_a"},
+		{Name: "v2_tool_b"},
+	}
+
+	fetcher := func(_ context.Context, _ string) ([]mcp.Tool, error) {
+		return nil, errors.New("should not be called")
+	}
+	cache := mcp.NewToolCache(fetcher, time.Hour)
+
+	cache.SetTools("voidllm", firstTools)
+	cache.SetTools("voidllm", secondTools)
+
+	all := cache.GetAllTools()
+	got, ok := all["voidllm"]
+	if !ok {
+		t.Fatal("GetAllTools() missing key \"voidllm\" after second SetTools")
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(tools) = %d, want 2 (second set must overwrite first)", len(got))
+	}
+	if got[0].Name != "v2_tool_a" {
+		t.Errorf("tools[0].Name = %q, want %q", got[0].Name, "v2_tool_a")
+	}
+	if got[1].Name != "v2_tool_b" {
+		t.Errorf("tools[1].Name = %q, want %q", got[1].Name, "v2_tool_b")
+	}
+}
+
 // ---- helpers -----------------------------------------------------------------
 
 // containsErrMsg checks whether err's message contains substr.

--- a/ui/src/pages/MCPServersPage.tsx
+++ b/ui/src/pages/MCPServersPage.tsx
@@ -144,12 +144,16 @@ function scopeLabel(scope: string): string {
   return scope
 }
 
-function sourceBadgeVariant(source: string): 'muted' | 'warning' {
-  return source === 'yaml' ? 'warning' : 'muted'
+function sourceBadgeVariant(source: string): 'default' | 'muted' | 'warning' {
+  if (source === 'yaml') return 'warning'
+  if (source === 'builtin') return 'default'
+  return 'muted'
 }
 
 function sourceLabel(source: string): string {
-  return source === 'yaml' ? 'YAML' : 'API'
+  if (source === 'yaml') return 'YAML'
+  if (source === 'builtin') return 'Built-in'
+  return 'API'
 }
 
 // ---------------------------------------------------------------------------
@@ -806,7 +810,7 @@ export default function MCPServersPage() {
         // Only allow toggling if the user has permission for that server's scope.
         // yaml-sourced servers cannot be toggled through the Admin API.
         const canToggle =
-          row.source !== 'yaml' &&
+          row.source !== 'yaml' && row.source !== 'builtin' &&
           ((row.scope === 'global' && isSystemAdmin) ||
           (row.scope === 'org' && isOrgAdmin) ||
           (row.scope === 'team' && isTeamAdmin))
@@ -840,7 +844,6 @@ export default function MCPServersPage() {
       header: 'Code Mode',
       render: (row) => {
         const canToggle =
-          row.source !== 'yaml' &&
           ((row.scope === 'global' && isSystemAdmin) ||
           (row.scope === 'org' && isOrgAdmin) ||
           (row.scope === 'team' && isTeamAdmin))
@@ -877,7 +880,7 @@ export default function MCPServersPage() {
         // yaml-sourced servers are managed via config file and cannot be
         // edited or deleted through the Admin API.
         const canModify =
-          row.source !== 'yaml' &&
+          row.source !== 'yaml' && row.source !== 'builtin' &&
           ((row.scope === 'global' && isSystemAdmin) ||
           (row.scope === 'org' && isOrgAdmin) ||
           (row.scope === 'team' && isTeamAdmin))


### PR DESCRIPTION
## Summary

The VoidLLM management MCP server (list_models, get_usage, list_keys, etc.) now appears as a built-in server alongside external MCP servers — visible in the UI, discoverable via Code Mode tools, and callable from WASM-sandboxed JS.

- **Built-in server record** with `source="builtin"` created idempotently at startup
- **In-process dispatch** via `callBuiltinTool` — 0ms, no HTTP needed
- **Always accessible** — skips MCP access check (no explicit grant needed)
- **UI badge** "Built-in" (read-only, like YAML servers)
- **Pre-cached tools** in memory + DB for warm restarts
- SSE probe skips built-in server (no URL to probe)

## Test plan

- [x] `go test ./... -race` — all packages green
- [x] `list_servers` returns "voidllm" with tool_count=6
- [x] `search_tools` finds management tools (list_models, get_usage)
- [x] `execute_code` calls `tools.voidllm.list_models({})` — 0ms in-process
- [x] UI shows "Built-in" badge, server is read-only
- [x] Code review + security audit (0 open findings)