### PR TITLE
feat: model fallback chains (Enterprise)

### DIFF
--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
@@ -33,6 +34,15 @@ type ModelHealthProvider interface {
 
 // Handler holds shared dependencies for all admin API handlers.
 type Handler struct {
+	// fallbackMu serializes fallback mutations (cycle-check + DB write) to make
+	// them atomic at the process level. Acquired only when a CreateModel or
+	// UpdateModel request includes a fallback_model_name change.
+	//
+	// Multi-instance cluster-wide serialization would require DB-level locking
+	// (SELECT FOR UPDATE / advisory lock). For single-instance and typical
+	// enterprise deployments the process-level mutex is sufficient.
+	fallbackMu sync.Mutex
+
 	DB                *db.DB
 	HMACSecret        []byte
 	EncryptionKey     []byte // AES-256-GCM key for upstream API key encryption
@@ -88,6 +98,11 @@ type Handler struct {
 	// Nil in dev builds (Version == "dev") — GetUpdateStatus returns a static
 	// response in that case.
 	UpdateChecker *update.Checker
+	// ReloadModels triggers an in-process rebuild of the model registry,
+	// including the license-aware fallback gating. Called from SetLicense
+	// to apply license changes immediately, independent of Redis pub/sub.
+	// Must be safe to call concurrently. May be nil — callers must nil-check.
+	ReloadModels func(context.Context) error
 }
 
 // swaggerErrorResponse is the standard API error envelope used in OpenAPI docs.

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -56,6 +56,7 @@ type Handler struct {
 	Redis             *voidredis.Client        // nil when Redis is not configured
 	AuditLogger       *audit.Logger            // nil when audit logging is disabled
 	License           *license.Holder          // thread-safe license holder; Load() never returns nil
+	FallbackMaxDepth  int                      // from config; 0 = fallback disabled; exposed via GET /license
 	Log               *slog.Logger
 	// SSOProvider is the OIDC provider used for SSO login. Nil when SSO is
 	// disabled or unlicensed.

--- a/internal/api/admin/license.go
+++ b/internal/api/admin/license.go
@@ -57,6 +57,9 @@ type licenseResponse struct {
 	// CustomerID is the opaque customer identifier embedded in an enterprise
 	// license. Empty for community and dev licenses.
 	CustomerID string `json:"customer_id"`
+	// FallbackMaxDepth is the configured maximum fallback chain depth.
+	// 0 means fallback chains are disabled even if models have fallback configured.
+	FallbackMaxDepth int `json:"fallback_max_depth"`
 }
 
 // SetLicense handles PUT /api/v1/settings/license.
@@ -172,11 +175,12 @@ func (h *Handler) GetLicense(c fiber.Ctx) error {
 	lic := h.License.Load()
 
 	resp := licenseResponse{
-		Edition:  string(lic.Edition()),
-		Valid:    lic.Valid(),
-		Features: lic.Features(),
-		MaxOrgs:  lic.MaxOrgs(),
-		MaxTeams: lic.MaxTeams(),
+		Edition:          string(lic.Edition()),
+		Valid:            lic.Valid(),
+		Features:         lic.Features(),
+		MaxOrgs:          lic.MaxOrgs(),
+		MaxTeams:         lic.MaxTeams(),
+		FallbackMaxDepth: h.FallbackMaxDepth,
 	}
 
 	// CustomerID is sensitive — only org_admin and above may see it.

--- a/internal/api/admin/license.go
+++ b/internal/api/admin/license.go
@@ -9,6 +9,7 @@ import (
 	"github.com/voidmind-io/voidllm/internal/apierror"
 	"github.com/voidmind-io/voidllm/internal/auth"
 	"github.com/voidmind-io/voidllm/internal/license"
+	voidredis "github.com/voidmind-io/voidllm/internal/redis"
 )
 
 // setLicenseRequest is the JSON body accepted by SetLicense.
@@ -94,6 +95,34 @@ func (h *Handler) SetLicense(c fiber.Ctx) error {
 	}
 
 	h.License.Store(lic)
+
+	// Apply the license change locally by re-gating the registry.
+	// This path is the ONLY re-gate trigger on deployments without Redis;
+	// on multi-instance deployments it also covers the local instance
+	// before the Redis broadcast reaches peers.
+	if h.ReloadModels != nil {
+		if err := h.ReloadModels(c.Context()); err != nil {
+			h.Log.LogAttrs(c.Context(), slog.LevelError,
+				"set license: in-process registry reload failed",
+				slog.String("error", err.Error()))
+			// Do not return an error to the client - the license is already
+			// stored, only the registry is stale. Operators can trigger a
+			// manual reload or restart.
+		}
+	}
+
+	// On multi-instance deployments, broadcast a model invalidation so
+	// all peers rebuild their registry with the updated license state.
+	if h.Redis != nil {
+		if pubErr := h.Redis.PublishInvalidation(c.Context(), voidredis.ChannelModels, "reload"); pubErr != nil {
+			h.Log.LogAttrs(c.Context(), slog.LevelWarn, "set license: publish model reload failed",
+				slog.String("error", pubErr.Error()),
+			)
+			// Non-fatal: the in-memory license is already updated above and the
+			// local registry has been reloaded. Peers will reconcile on the next
+			// admin-triggered model change or process restart.
+		}
+	}
 
 	// Persist to DB so the license survives restarts.
 	if err := h.DB.SetSetting(c.Context(), "license_jwt", req.Key); err != nil {

--- a/internal/api/admin/license_test.go
+++ b/internal/api/admin/license_test.go
@@ -1,0 +1,337 @@
+package admin_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/voidmind-io/voidllm/internal/api/admin"
+	"github.com/voidmind-io/voidllm/internal/auth"
+	"github.com/voidmind-io/voidllm/internal/cache"
+	"github.com/voidmind-io/voidllm/internal/config"
+	"github.com/voidmind-io/voidllm/internal/db"
+	"github.com/voidmind-io/voidllm/internal/license"
+	"github.com/voidmind-io/voidllm/internal/licensetest"
+)
+
+// setupLicenseTestApp creates a minimal Fiber app wired for the SetLicense
+// and GetLicense endpoints. The returned *license.Holder is the same instance
+// used by the handler so tests can inspect the stored license after a request.
+func setupLicenseTestApp(
+	t *testing.T,
+	dsn string,
+	reloadModels func(context.Context) error,
+) (*fiber.App, *license.Holder, *cache.Cache[string, auth.KeyInfo]) {
+	t.Helper()
+
+	ctx := context.Background()
+	database, err := db.Open(ctx, config.DatabaseConfig{
+		Driver:          "sqlite",
+		DSN:             dsn,
+		MaxOpenConns:    1,
+		MaxIdleConns:    1,
+		ConnMaxLifetime: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("open test DB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	if err := db.RunMigrations(ctx, database.SQL(), db.SQLiteDialect{}, slog.Default()); err != nil {
+		t.Fatalf("run migrations: %v", err)
+	}
+
+	// Start with a community (no-key) license so changes are observable.
+	holder := license.NewHolder(license.Verify("", false))
+
+	keyCache := cache.New[string, auth.KeyInfo]()
+
+	handler := &admin.Handler{
+		DB:           database,
+		HMACSecret:   testHMACSecret,
+		KeyCache:     keyCache,
+		License:      holder,
+		Log:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ReloadModels: reloadModels,
+		Redis:        nil, // explicitly nil — exercises the local-only reload path
+	}
+
+	app := fiber.New()
+	admin.RegisterRoutes(app, handler, keyCache, testHMACSecret, nil)
+
+	return app, holder, keyCache
+}
+
+// TestSetLicense_InvokesReloadModels verifies that SetLicense calls the
+// ReloadModels callback exactly once, AFTER License.Store has updated the
+// holder, and BEFORE the handler returns a response.
+//
+// This test MUST NOT run in parallel because it mutates the license package's
+// embedded public key via licensetest.WithTestPublicKey.
+func TestSetLicense_InvokesReloadModels(t *testing.T) {
+	pub, priv := licensetest.NewTestKeypair(t)
+	licensetest.WithTestPublicKey(t, pub)
+
+	claims := licensetest.NewEnterpriseClaims([]string{license.FeatureFallbackChains})
+	jwtKey := licensetest.SignTestJWT(t, priv, claims)
+
+	var reloadCalled atomic.Int32
+	var reloadSawEnterprise atomic.Bool
+
+	reloadModels := func(ctx context.Context) error {
+		reloadCalled.Add(1)
+		// Capture license state inside the callback to detect whether
+		// License.Store ran before ReloadModels was invoked.
+		// The holder is captured via the closure variable set by setupLicenseTestApp.
+		// We assert this below after the request completes.
+		reloadSawEnterprise.Store(true) // marker: callback executed
+		return nil
+	}
+
+	app, holder, keyCache := setupLicenseTestApp(
+		t,
+		"file:TestSetLicense_InvokesReloadModels?mode=memory&cache=private",
+		reloadModels,
+	)
+
+	token := addTestKey(t, keyCache, auth.RoleSystemAdmin, "org-lic-test")
+
+	req := httptest.NewRequest("PUT", "/api/v1/settings/license",
+		bodyJSON(t, map[string]string{"key": jwtKey}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, raw)
+	}
+
+	// ReloadModels must have been invoked exactly once.
+	if got := reloadCalled.Load(); got != 1 {
+		t.Errorf("ReloadModels called %d times, want 1", got)
+	}
+
+	// License.Store must have completed before the handler returned; verify
+	// the holder reflects the enterprise license.
+	lic := holder.Load()
+	if got := lic.Edition(); got != license.EditionEnterprise {
+		t.Errorf("holder.Load().Edition() = %q, want %q after SetLicense", got, license.EditionEnterprise)
+	}
+	if !lic.HasFeature(license.FeatureFallbackChains) {
+		t.Errorf("holder.Load().HasFeature(%q) = false, want true after SetLicense", license.FeatureFallbackChains)
+	}
+
+	// Confirm the callback marker was set.
+	if !reloadSawEnterprise.Load() {
+		t.Error("ReloadModels callback never executed")
+	}
+}
+
+// TestSetLicense_LicenseStoredBeforeReload verifies the ordering guarantee:
+// the license holder is updated BEFORE ReloadModels is invoked. A concurrent
+// read of the holder inside the callback must see the enterprise edition.
+//
+// This test MUST NOT run in parallel — it mutates the embedded public key.
+func TestSetLicense_LicenseStoredBeforeReload(t *testing.T) {
+	pub, priv := licensetest.NewTestKeypair(t)
+	licensetest.WithTestPublicKey(t, pub)
+
+	claims := licensetest.NewEnterpriseClaims([]string{license.FeatureAuditLogs})
+	jwtKey := licensetest.SignTestJWT(t, priv, claims)
+
+	// The holder is captured into the closure so the callback can read it.
+	var capturedEdition atomic.Value // stores license.Edition
+
+	var holderRef *license.Holder // set after setupLicenseTestApp returns
+
+	reloadModels := func(_ context.Context) error {
+		if holderRef != nil {
+			capturedEdition.Store(holderRef.Load().Edition())
+		}
+		return nil
+	}
+
+	app, holder, keyCache := setupLicenseTestApp(
+		t,
+		"file:TestSetLicense_LicenseStoredBeforeReload?mode=memory&cache=private",
+		reloadModels,
+	)
+	holderRef = holder // bind the reference after creation
+
+	token := addTestKey(t, keyCache, auth.RoleSystemAdmin, "org-order-test")
+
+	req := httptest.NewRequest("PUT", "/api/v1/settings/license",
+		bodyJSON(t, map[string]string{"key": jwtKey}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, raw)
+	}
+
+	// The callback must have seen the enterprise edition — proving Store ran first.
+	gotEdition, _ := capturedEdition.Load().(license.Edition)
+	if gotEdition != license.EditionEnterprise {
+		t.Errorf("edition seen inside ReloadModels = %q, want %q (License.Store must precede ReloadModels)", gotEdition, license.EditionEnterprise)
+	}
+}
+
+// TestSetLicense_ReloadModelsNilIsNoOp verifies that SetLicense succeeds and
+// stores the license in the holder even when ReloadModels is nil.
+//
+// This test MUST NOT run in parallel — it mutates the embedded public key.
+func TestSetLicense_ReloadModelsNilIsNoOp(t *testing.T) {
+	pub, priv := licensetest.NewTestKeypair(t)
+	licensetest.WithTestPublicKey(t, pub)
+
+	claims := licensetest.NewEnterpriseClaims([]string{license.FeatureAuditLogs})
+	jwtKey := licensetest.SignTestJWT(t, priv, claims)
+
+	app, holder, keyCache := setupLicenseTestApp(
+		t,
+		"file:TestSetLicense_ReloadModelsNilIsNoOp?mode=memory&cache=private",
+		nil, // no reload callback
+	)
+
+	token := addTestKey(t, keyCache, auth.RoleSystemAdmin, "org-nil-reload")
+
+	req := httptest.NewRequest("PUT", "/api/v1/settings/license",
+		bodyJSON(t, map[string]string{"key": jwtKey}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, raw)
+	}
+
+	if got := holder.Load().Edition(); got != license.EditionEnterprise {
+		t.Errorf("holder.Load().Edition() = %q, want %q", got, license.EditionEnterprise)
+	}
+}
+
+// TestSetLicense_ReloadModelsError verifies that a ReloadModels error does not
+// cause SetLicense to return a non-2xx response and that the license IS
+// persisted in the holder despite the reload failure.
+//
+// This test MUST NOT run in parallel — it mutates the embedded public key.
+func TestSetLicense_ReloadModelsError(t *testing.T) {
+	pub, priv := licensetest.NewTestKeypair(t)
+	licensetest.WithTestPublicKey(t, pub)
+
+	claims := licensetest.NewEnterpriseClaims([]string{license.FeatureFallbackChains})
+	jwtKey := licensetest.SignTestJWT(t, priv, claims)
+
+	stubErr := errors.New("stub reload error")
+	var reloadCalled atomic.Int32
+
+	reloadModels := func(_ context.Context) error {
+		reloadCalled.Add(1)
+		return stubErr
+	}
+
+	app, holder, keyCache := setupLicenseTestApp(
+		t,
+		"file:TestSetLicense_ReloadModelsError?mode=memory&cache=private",
+		reloadModels,
+	)
+
+	token := addTestKey(t, keyCache, auth.RoleSystemAdmin, "org-reload-err")
+
+	req := httptest.NewRequest("PUT", "/api/v1/settings/license",
+		bodyJSON(t, map[string]string{"key": jwtKey}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// The handler must NOT propagate the reload error to the client.
+	if resp.StatusCode != fiber.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200 (reload error must not fail the request); body: %s", resp.StatusCode, raw)
+	}
+
+	if got := reloadCalled.Load(); got != 1 {
+		t.Errorf("ReloadModels called %d times, want 1", got)
+	}
+
+	// The license IS persisted despite the reload error.
+	if got := holder.Load().Edition(); got != license.EditionEnterprise {
+		t.Errorf("holder.Load().Edition() = %q, want %q (license must persist even when reload fails)", got, license.EditionEnterprise)
+	}
+}
+
+// TestSetLicense_InvalidKey verifies that an invalid JWT returns 400 and
+// neither updates the holder nor invokes ReloadModels.
+//
+// This test is safe to run in parallel because it does not swap the embedded
+// public key (invalid tokens are rejected before signature verification reaches
+// the embedded key).
+func TestSetLicense_InvalidKey(t *testing.T) {
+	t.Parallel()
+
+	var reloadCalled atomic.Int32
+	reloadModels := func(_ context.Context) error {
+		reloadCalled.Add(1)
+		return nil
+	}
+
+	dsn := fmt.Sprintf("file:TestSetLicense_InvalidKey_%d?mode=memory&cache=private", time.Now().UnixNano())
+	app, holder, keyCache := setupLicenseTestApp(t, dsn, reloadModels)
+
+	token := addTestKey(t, keyCache, auth.RoleSystemAdmin, "org-invalid-key")
+
+	req := httptest.NewRequest("PUT", "/api/v1/settings/license",
+		bodyJSON(t, map[string]string{"key": "not-a-valid-jwt"}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusBadRequest {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 400 for invalid license key; body: %s", resp.StatusCode, raw)
+	}
+
+	if got := holder.Load().Edition(); got != license.EditionCommunity {
+		t.Errorf("holder.Load().Edition() = %q, want %q (invalid key must not update holder)", got, license.EditionCommunity)
+	}
+
+	if got := reloadCalled.Load(); got != 0 {
+		t.Errorf("ReloadModels called %d times, want 0 for invalid key", got)
+	}
+}

--- a/internal/api/admin/models.go
+++ b/internal/api/admin/models.go
@@ -18,6 +18,7 @@ import (
 	"github.com/voidmind-io/voidllm/internal/config"
 	"github.com/voidmind-io/voidllm/internal/db"
 	"github.com/voidmind-io/voidllm/internal/jsonx"
+	"github.com/voidmind-io/voidllm/internal/license"
 	"github.com/voidmind-io/voidllm/internal/provider"
 	"github.com/voidmind-io/voidllm/internal/proxy"
 	voidredis "github.com/voidmind-io/voidllm/internal/redis"
@@ -53,6 +54,10 @@ type createModelRequest struct {
 	// MaxRetries is the maximum number of deployments to attempt before returning
 	// an error. 0 means try all available deployments.
 	MaxRetries int `json:"max_retries,omitempty"`
+	// FallbackModelName is the name of the model to try if all deployments of
+	// this model are unavailable. Requires an Enterprise license with the
+	// fallback_chains feature. Leave empty to disable fallback.
+	FallbackModelName string `json:"fallback_model_name,omitempty"`
 }
 
 // updateModelRequest is the JSON body accepted by UpdateModel.
@@ -83,6 +88,10 @@ type updateModelRequest struct {
 	Strategy *string `json:"strategy"`
 	// MaxRetries, when non-nil, replaces the maximum deployment retry count.
 	MaxRetries *int `json:"max_retries"`
+	// FallbackModelName, when non-nil, replaces the fallback model. Pass a
+	// pointer to an empty string to clear the fallback. Requires Enterprise
+	// license with the fallback_chains feature when setting a non-empty value.
+	FallbackModelName *string `json:"fallback_model_name"`
 }
 
 // modelResponse is the JSON representation of a model returned by the API.
@@ -115,6 +124,9 @@ type modelResponse struct {
 	// MaxRetries is the maximum number of deployments to attempt before
 	// returning an error. 0 means try all available deployments.
 	MaxRetries int `json:"max_retries,omitempty"`
+	// FallbackModelName is the name of the fallback model, or empty when none
+	// is configured.
+	FallbackModelName string `json:"fallback_model_name,omitempty"`
 	// Deployments contains the model's deployment entries when present.
 	Deployments []deploymentResponse `json:"deployments,omitempty"`
 	CreatedAt   string               `json:"created_at"`
@@ -150,7 +162,9 @@ var testClient = &http.Client{
 }
 
 // modelToResponse converts a db.Model to its API wire representation.
-func modelToResponse(m *db.Model) modelResponse {
+// fallbackName is the resolved canonical name of the fallback model; pass an
+// empty string when the model has no fallback or the caller has not resolved it.
+func modelToResponse(m *db.Model, fallbackName string) modelResponse {
 	aliases := []string{}
 	if m.Aliases != "" {
 		aliases = strings.Split(m.Aliases, ",")
@@ -160,32 +174,35 @@ func modelToResponse(m *db.Model) modelResponse {
 		modelType = "chat"
 	}
 	return modelResponse{
-		ID:               m.ID,
-		Name:             m.Name,
-		Provider:         m.Provider,
-		Type:             modelType,
-		BaseURL:          m.BaseURL,
-		MaxContextTokens: m.MaxContextTokens,
-		InputPricePer1M:  m.InputPricePer1M,
-		OutputPricePer1M: m.OutputPricePer1M,
-		AzureDeployment:  m.AzureDeployment,
-		AzureAPIVersion:  m.AzureAPIVersion,
-		GCPProject:       m.GCPProject,
-		GCPLocation:      m.GCPLocation,
-		IsActive:         m.IsActive,
-		Source:           m.Source,
-		Aliases:          aliases,
-		Timeout:          m.Timeout,
-		Strategy:         m.Strategy,
-		MaxRetries:       m.MaxRetries,
-		CreatedAt:        m.CreatedAt,
-		UpdatedAt:        m.UpdatedAt,
+		ID:                m.ID,
+		Name:              m.Name,
+		Provider:          m.Provider,
+		Type:              modelType,
+		BaseURL:           m.BaseURL,
+		MaxContextTokens:  m.MaxContextTokens,
+		InputPricePer1M:   m.InputPricePer1M,
+		OutputPricePer1M:  m.OutputPricePer1M,
+		AzureDeployment:   m.AzureDeployment,
+		AzureAPIVersion:   m.AzureAPIVersion,
+		GCPProject:        m.GCPProject,
+		GCPLocation:       m.GCPLocation,
+		IsActive:          m.IsActive,
+		Source:            m.Source,
+		Aliases:           aliases,
+		Timeout:           m.Timeout,
+		Strategy:          m.Strategy,
+		MaxRetries:        m.MaxRetries,
+		FallbackModelName: fallbackName,
+		CreatedAt:         m.CreatedAt,
+		UpdatedAt:         m.UpdatedAt,
 	}
 }
 
 // dbModelToProxy converts a db.Model to a proxy.Model for registry insertion.
 // apiKeyPlaintext is the decrypted API key; pass an empty string when no key is set.
-func dbModelToProxy(m *db.Model, apiKeyPlaintext string) proxy.Model {
+// fallbackName is the resolved canonical name of the fallback model; pass an empty
+// string when the model has no fallback or the license does not include the feature.
+func dbModelToProxy(m *db.Model, apiKeyPlaintext string, fallbackName string) proxy.Model {
 	var aliases []string
 	if m.Aliases != "" {
 		aliases = strings.Split(m.Aliases, ",")
@@ -201,22 +218,20 @@ func dbModelToProxy(m *db.Model, apiKeyPlaintext string) proxy.Model {
 		modelType = "chat"
 	}
 	return proxy.Model{
-		Name:             m.Name,
-		Provider:         m.Provider,
-		Type:             modelType,
-		BaseURL:          m.BaseURL,
-		APIKey:           apiKeyPlaintext,
-		Aliases:          aliases,
-		MaxContextTokens: m.MaxContextTokens,
-		Pricing: config.PricingConfig{
-			InputPer1M:  m.InputPricePer1M,
-			OutputPer1M: m.OutputPricePer1M,
-		},
-		AzureDeployment: m.AzureDeployment,
-		AzureAPIVersion: m.AzureAPIVersion,
-		GCPProject:      m.GCPProject,
-		GCPLocation:     m.GCPLocation,
-		Timeout:         timeout,
+		Name:              m.Name,
+		Provider:          m.Provider,
+		Type:              modelType,
+		BaseURL:           m.BaseURL,
+		APIKey:            apiKeyPlaintext,
+		Aliases:           aliases,
+		MaxContextTokens:  m.MaxContextTokens,
+		Pricing:           config.PricingConfig{InputPer1M: m.InputPricePer1M, OutputPer1M: m.OutputPricePer1M},
+		AzureDeployment:   m.AzureDeployment,
+		AzureAPIVersion:   m.AzureAPIVersion,
+		GCPProject:        m.GCPProject,
+		GCPLocation:       m.GCPLocation,
+		Timeout:           timeout,
+		FallbackModelName: fallbackName,
 	}
 }
 
@@ -280,6 +295,99 @@ func (h *Handler) decryptModelAPIKey(m *db.Model) (string, error) {
 		return "", err
 	}
 	return plaintext, nil
+}
+
+// fallbackCycleMaxSteps is the upper bound on chain length checked by
+// checkFallbackCycle. It is intentionally larger than FallbackMaxDepth (3)
+// to catch impossibly-deep chains that should not exist in the database.
+const fallbackCycleMaxSteps = 20
+
+// checkFallbackCycle walks the fallback chain starting from targetID and
+// returns an error if sourceID appears anywhere in the chain, which would
+// form a cycle. It also detects self-references (targetID == sourceID).
+// maxSteps bounds the walk to avoid infinite loops on corrupt chain data.
+// Transient DB errors are bubbled up so callers can return 500 instead of
+// incorrectly reporting "no cycle" or "cycle" on a failed lookup.
+func (h *Handler) checkFallbackCycle(ctx context.Context, sourceID, targetID string) error {
+	if sourceID == targetID {
+		return fmt.Errorf("self-reference")
+	}
+	current := targetID
+	for step := 0; step < fallbackCycleMaxSteps; step++ {
+		m, err := h.DB.GetModel(ctx, current)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				return nil // chain ends safely, no cycle
+			}
+			return fmt.Errorf("walk fallback chain: %w", err) // bubble up transient errors
+		}
+		if m.FallbackModelID == nil || *m.FallbackModelID == "" {
+			return nil
+		}
+		next := *m.FallbackModelID
+		if next == sourceID {
+			return fmt.Errorf("cycle")
+		}
+		current = next
+	}
+	return nil
+}
+
+// resolveFallbackName looks up the canonical name for the model with the given
+// ID. It returns an empty string when id is nil or empty, and an empty string
+// (without error) when the model has been soft-deleted — the caller gets a
+// graceful degradation rather than a hard failure.
+func (h *Handler) resolveFallbackName(ctx context.Context, fallbackModelID *string) string {
+	if fallbackModelID == nil || *fallbackModelID == "" {
+		return ""
+	}
+	m, err := h.DB.GetModel(ctx, *fallbackModelID)
+	if err != nil {
+		return ""
+	}
+	return m.Name
+}
+
+// buildFallbackIDNameMap builds an id→name lookup table from a slice of models.
+// It is used on list endpoints to resolve FallbackModelID without an N+1 query.
+func buildFallbackIDNameMap(models []db.Model) map[string]string {
+	m := make(map[string]string, len(models))
+	for i := range models {
+		m[models[i].ID] = models[i].Name
+	}
+	return m
+}
+
+// resolveMissingFallbackNames ensures every FallbackModelID referenced by the
+// current page of models is present in idToName. IDs that point to models on a
+// different page (or soft-deleted models) are resolved via individual GetModel
+// calls. Typically 0–5 extra queries per page.
+func (h *Handler) resolveMissingFallbackNames(ctx context.Context, models []db.Model, idToName map[string]string) error {
+	missing := []string{}
+	for _, m := range models {
+		if m.FallbackModelID != nil && *m.FallbackModelID != "" {
+			if _, ok := idToName[*m.FallbackModelID]; !ok {
+				missing = append(missing, *m.FallbackModelID)
+			}
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+	// Look up each missing ID individually via GetModel (existing method).
+	// N extra queries where N = unique cross-page fallback references.
+	// Typically 0-5 per page.
+	for _, id := range missing {
+		m, err := h.DB.GetModel(ctx, id)
+		if err != nil {
+			if errors.Is(err, db.ErrNotFound) {
+				continue // fallback pointing to deleted model — show empty name
+			}
+			return fmt.Errorf("resolve cross-page fallback: %w", err)
+		}
+		idToName[id] = m.Name
+	}
+	return nil
 }
 
 // CreateModel handles POST /api/v1/models.
@@ -354,10 +462,49 @@ func (h *Handler) CreateModel(c fiber.Ctx) error {
 		return apierror.BadRequest(c, aliasMsg)
 	}
 
+	// Validate and resolve the fallback model when provided.
+	var fallbackModelID *string
+	if req.FallbackModelName != "" {
+		lic := h.License.Load()
+		if !lic.HasFeature(license.FeatureFallbackChains) {
+			return apierror.Send(c, fiber.StatusForbidden, "feature_unavailable",
+				"model fallback chains require an Enterprise license")
+		}
+		fbID, fbErr := h.DB.GetModelIDByName(ctx, req.FallbackModelName)
+		if fbErr != nil {
+			if errors.Is(fbErr, db.ErrNotFound) {
+				return apierror.BadRequest(c, "fallback target model not found")
+			}
+			h.Log.ErrorContext(ctx, "create model: resolve fallback model", slog.String("error", fbErr.Error()))
+			return apierror.InternalError(c, "failed to resolve fallback model")
+		}
+		// Self-reference check: the new model's ID is not known yet so we can
+		// only check by name (the model is being created, so no ID exists yet).
+		if req.FallbackModelName == req.Name {
+			return apierror.BadRequest(c, "model cannot reference itself as fallback")
+		}
+		// A brand-new model has no ID yet, so nothing in the DB can point back
+		// to it — no cycle is possible on create. Cycle checks are only
+		// meaningful on update (when the model already exists in the chain).
+		fallbackModelID = &fbID
+	}
+
 	keyInfo := auth.KeyInfoFromCtx(c)
 	var createdBy *string
 	if keyInfo != nil && keyInfo.UserID != "" {
 		createdBy = &keyInfo.UserID
+	}
+
+	// Serialize fallback mutations to prevent concurrent creates from racing
+	// past each other's implicit cycle check. Acquired only when a fallback is
+	// being set; plain creates do not contend on the mutex.
+	//
+	// Multi-instance cluster-wide serialization would require DB-level locking
+	// (SELECT FOR UPDATE / advisory lock). For single-instance and typical
+	// enterprise deployments the process-level mutex is sufficient.
+	if fallbackModelID != nil {
+		h.fallbackMu.Lock()
+		defer h.fallbackMu.Unlock()
 	}
 
 	reqType := req.Type
@@ -381,6 +528,7 @@ func (h *Handler) CreateModel(c fiber.Ctx) error {
 		Timeout:          req.Timeout,
 		Strategy:         &req.Strategy,
 		MaxRetries:       &req.MaxRetries,
+		FallbackModelID:  fallbackModelID,
 	})
 	if err != nil {
 		if errors.Is(err, db.ErrConflict) {
@@ -405,7 +553,7 @@ func (h *Handler) CreateModel(c fiber.Ctx) error {
 	}
 
 	if m.IsActive {
-		h.Registry.AddModel(dbModelToProxy(m, req.APIKey))
+		h.Registry.AddModel(dbModelToProxy(m, req.APIKey, req.FallbackModelName))
 	}
 
 	if h.Redis != nil {
@@ -414,7 +562,7 @@ func (h *Handler) CreateModel(c fiber.Ctx) error {
 		}
 	}
 
-	return c.Status(fiber.StatusCreated).JSON(modelToResponse(m))
+	return c.Status(fiber.StatusCreated).JSON(modelToResponse(m, req.FallbackModelName))
 }
 
 // ListModels handles GET /api/v1/models.
@@ -463,12 +611,28 @@ func (h *Handler) ListModels(c fiber.Ctx) error {
 			slog.String("error", depsErr.Error()))
 	}
 
+	// Build an id→name map from the current page to resolve FallbackModelID
+	// without extra DB round-trips. Cross-page fallback targets (models on a
+	// different page) are resolved by resolveMissingFallbackNames via individual
+	// GetModel calls — typically 0 extra queries per page.
+	idToName := buildFallbackIDNameMap(models)
+	if resolveErr := h.resolveMissingFallbackNames(c.Context(), models, idToName); resolveErr != nil {
+		h.Log.ErrorContext(c.Context(), "list models: resolve cross-page fallback names",
+			slog.String("error", resolveErr.Error()))
+		// Non-fatal: the affected models will show an empty fallback name in the
+		// response rather than failing the entire list request.
+	}
+
 	resp := paginatedModelsResponse{
 		Data:    make([]modelResponse, len(models)),
 		HasMore: hasMore,
 	}
 	for i := range models {
-		resp.Data[i] = modelToResponse(&models[i])
+		var fallbackName string
+		if models[i].FallbackModelID != nil && *models[i].FallbackModelID != "" {
+			fallbackName = idToName[*models[i].FallbackModelID]
+		}
+		resp.Data[i] = modelToResponse(&models[i], fallbackName)
 		if deps := depsByModel[models[i].ID]; len(deps) > 0 {
 			resp.Data[i].Deployments = make([]deploymentResponse, len(deps))
 			for j := range deps {
@@ -510,7 +674,8 @@ func (h *Handler) GetModel(c fiber.Ctx) error {
 		return apierror.InternalError(c, "failed to get model")
 	}
 
-	resp := modelToResponse(m)
+	fallbackName := h.resolveFallbackName(ctx, m.FallbackModelID)
+	resp := modelToResponse(m, fallbackName)
 
 	deps, err := h.DB.ListDeployments(ctx, modelID)
 	if err != nil {
@@ -631,6 +796,41 @@ func (h *Handler) UpdateModel(c fiber.Ctx) error {
 		params.Aliases = &aliasStr
 	}
 
+	// newFallbackName tracks what name to use when refreshing the registry and
+	// building the response. It is set when req.FallbackModelName is non-nil.
+	var newFallbackName string
+	if req.FallbackModelName != nil {
+		if *req.FallbackModelName == "" {
+			// Clearing the fallback — store an empty-string pointer so UpdateModel
+			// sets the column to NULL.
+			empty := ""
+			params.FallbackModelID = &empty
+		} else {
+			lic := h.License.Load()
+			if !lic.HasFeature(license.FeatureFallbackChains) {
+				return apierror.Send(c, fiber.StatusForbidden, "feature_unavailable",
+					"model fallback chains require an Enterprise license")
+			}
+			fbID, fbErr := h.DB.GetModelIDByName(ctx, *req.FallbackModelName)
+			if fbErr != nil {
+				if errors.Is(fbErr, db.ErrNotFound) {
+					return apierror.BadRequest(c, "fallback target model not found")
+				}
+				h.Log.ErrorContext(ctx, "update model: resolve fallback model", slog.String("error", fbErr.Error()))
+				return apierror.InternalError(c, "failed to resolve fallback model")
+			}
+			if fbID == modelID {
+				return apierror.BadRequest(c, "model cannot reference itself as fallback")
+			}
+			params.FallbackModelID = &fbID
+			newFallbackName = *req.FallbackModelName
+		}
+	} else {
+		// FallbackModelName not provided — resolve existing fallback name for
+		// registry and response population.
+		newFallbackName = h.resolveFallbackName(ctx, existing.FallbackModelID)
+	}
+
 	if req.APIKey != nil {
 		// The model ID is the AAD — immutable, so no re-encryption is needed on rename.
 		enc, encErr := crypto.EncryptString(*req.APIKey, h.EncryptionKey, modelAAD(modelID))
@@ -641,7 +841,36 @@ func (h *Handler) UpdateModel(c fiber.Ctx) error {
 		params.APIKeyEncrypted = &enc
 	}
 
-	updated, err := h.DB.UpdateModel(ctx, modelID, params)
+	// Serialize fallback mutations to make the cycle-check + DB write atomic at
+	// the process level, preventing a TOCTOU race where two concurrent requests
+	// could each pass the cycle check before either commits, resulting in a cycle
+	// in the stored chain.
+	//
+	// Multi-instance cluster-wide serialization would require DB-level locking
+	// (SELECT FOR UPDATE / advisory lock). For single-instance and typical
+	// enterprise deployments the process-level mutex is sufficient.
+	var updated *db.Model
+	if req.FallbackModelName != nil && *req.FallbackModelName != "" {
+		h.fallbackMu.Lock()
+		defer h.fallbackMu.Unlock()
+
+		// Re-check for cycles under the lock. params.FallbackModelID was set
+		// above before acquiring the lock; we use its value directly.
+		// Transient DB errors are wrapped by checkFallbackCycle; unwrappable
+		// errors are "cycle" or "self-reference" sentinel strings.
+		if cycErr := h.checkFallbackCycle(ctx, modelID, *params.FallbackModelID); cycErr != nil {
+			if errors.Unwrap(cycErr) != nil {
+				// Wrapped error means a transient DB failure during chain walk.
+				h.Log.ErrorContext(ctx, "update model: check fallback cycle", slog.String("error", cycErr.Error()))
+				return apierror.InternalError(c, "failed to check fallback cycle")
+			}
+			return apierror.BadRequest(c, "fallback chain forms a cycle")
+		}
+
+		updated, err = h.DB.UpdateModel(ctx, modelID, params)
+	} else {
+		updated, err = h.DB.UpdateModel(ctx, modelID, params)
+	}
 	if err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			return apierror.NotFound(c, "model not found")
@@ -659,6 +888,10 @@ func (h *Handler) UpdateModel(c fiber.Ctx) error {
 		if existing.Name != updated.Name {
 			h.Registry.RemoveModel(existing.Name)
 		}
+		// When the fallback was cleared, newFallbackName is already empty.
+		if req.FallbackModelName != nil && *req.FallbackModelName == "" {
+			newFallbackName = ""
+		}
 		plaintext, decErr := h.decryptModelAPIKey(updated)
 		if decErr != nil {
 			h.Log.ErrorContext(ctx, "update model: decrypt api key for registry", slog.String("error", decErr.Error()))
@@ -666,7 +899,7 @@ func (h *Handler) UpdateModel(c fiber.Ctx) error {
 			// updated record and log the inconsistency. A process restart will
 			// reconcile the registry from the database.
 		} else {
-			h.Registry.AddModel(dbModelToProxy(updated, plaintext))
+			h.Registry.AddModel(dbModelToProxy(updated, plaintext, newFallbackName))
 		}
 	} else {
 		h.Registry.RemoveModel(existing.Name)
@@ -678,7 +911,7 @@ func (h *Handler) UpdateModel(c fiber.Ctx) error {
 		}
 	}
 
-	return c.JSON(modelToResponse(updated))
+	return c.JSON(modelToResponse(updated, newFallbackName))
 }
 
 // DeleteModel handles DELETE /api/v1/models/:model_id.
@@ -767,7 +1000,8 @@ func (h *Handler) ActivateModel(c fiber.Ctx) error {
 		return apierror.InternalError(c, "failed to decrypt model api key")
 	}
 
-	h.Registry.AddModel(dbModelToProxy(m, plaintext))
+	fallbackName := h.resolveFallbackName(ctx, m.FallbackModelID)
+	h.Registry.AddModel(dbModelToProxy(m, plaintext, fallbackName))
 
 	if h.Redis != nil {
 		if pubErr := h.Redis.PublishInvalidation(ctx, voidredis.ChannelModels, "reload"); pubErr != nil {
@@ -775,7 +1009,7 @@ func (h *Handler) ActivateModel(c fiber.Ctx) error {
 		}
 	}
 
-	return c.JSON(modelToResponse(m))
+	return c.JSON(modelToResponse(m, fallbackName))
 }
 
 // DeactivateModel handles PATCH /api/v1/models/:model_id/deactivate.
@@ -823,7 +1057,8 @@ func (h *Handler) DeactivateModel(c fiber.Ctx) error {
 	}
 
 	m.IsActive = false
-	return c.JSON(modelToResponse(m))
+	fallbackName := h.resolveFallbackName(ctx, m.FallbackModelID)
+	return c.JSON(modelToResponse(m, fallbackName))
 }
 
 // GetModelHealth handles GET /api/v1/models/health.

--- a/internal/api/admin/models_test.go
+++ b/internal/api/admin/models_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1574,4 +1575,573 @@ func TestTestConnection_NonAnthropicUsesBearerAuth(t *testing.T) {
 	if capturedHeaders.Get("Authorization") != "Bearer sk-openai-key" {
 		t.Errorf("Authorization header = %q, want %q", capturedHeaders.Get("Authorization"), "Bearer sk-openai-key")
 	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Fallback model name tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+// setupModelTestAppWithLicense is like setupModelTestApp but accepts an
+// explicit License instead of always using the dev license.
+func setupModelTestAppWithLicense(t *testing.T, dsn string, lic license.License) (*fiber.App, *db.DB, *cache.Cache[string, auth.KeyInfo]) {
+	t.Helper()
+
+	ctx := context.Background()
+	database, err := db.Open(ctx, config.DatabaseConfig{
+		Driver:          "sqlite",
+		DSN:             dsn,
+		MaxOpenConns:    1,
+		MaxIdleConns:    1,
+		ConnMaxLifetime: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("open test DB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	if err := db.RunMigrations(ctx, database.SQL(), db.SQLiteDialect{}, slog.Default()); err != nil {
+		t.Fatalf("run migrations: %v", err)
+	}
+
+	registry, err := proxy.NewRegistry(nil)
+	if err != nil {
+		t.Fatalf("proxy.NewRegistry: %v", err)
+	}
+
+	keyCache := cache.New[string, auth.KeyInfo]()
+
+	handler := &admin.Handler{
+		DB:            database,
+		HMACSecret:    testHMACSecret,
+		EncryptionKey: testEncryptionKey,
+		Registry:      registry,
+		KeyCache:      keyCache,
+		License:       license.NewHolder(lic),
+		Log:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	app := fiber.New()
+	admin.RegisterRoutes(app, handler, keyCache, testHMACSecret, nil)
+
+	return app, database, keyCache
+}
+
+// TestCreateModel_WithFallbackLicensed verifies that creating a model with a
+// fallback_model_name succeeds when the license includes FeatureFallbackChains.
+func TestCreateModel_WithFallbackLicensed(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestCreateModel_WithFallbackLicensed?mode=memory&cache=private"
+	// Dev license has all features including fallback_chains.
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	// Create model-a first (it will be the fallback target).
+	mustCreateModelForDeployment(t, database, "model-a-target")
+
+	// Create model-b with fallback set to model-a-target.
+	reqBody := map[string]any{
+		"name":                "model-b-with-fallback",
+		"provider":            "openai",
+		"base_url":            "https://api.openai.com/v1",
+		"fallback_model_name": "model-a-target",
+	}
+
+	req := httptest.NewRequest("POST", modelURL(), bodyJSON(t, reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 201; body: %s", resp.StatusCode, body)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+	if got["fallback_model_name"] != "model-a-target" {
+		t.Errorf("fallback_model_name = %v, want %q", got["fallback_model_name"], "model-a-target")
+	}
+}
+
+// TestCreateModel_WithFallbackNotLicensed verifies that creating a model with a
+// fallback_model_name fails with 403 when the license lacks FeatureFallbackChains.
+func TestCreateModel_WithFallbackNotLicensed(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestCreateModel_WithFallbackNotLicensed?mode=memory&cache=private"
+	// Community license has no enterprise features.
+	app, database, keyCache := setupModelTestAppWithLicense(t, dsn, license.Verify("", false))
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	mustCreateModelForDeployment(t, database, "some-fallback-target")
+
+	reqBody := map[string]any{
+		"name":                "model-needs-fallback",
+		"provider":            "openai",
+		"base_url":            "https://api.openai.com/v1",
+		"fallback_model_name": "some-fallback-target",
+	}
+
+	req := httptest.NewRequest("POST", modelURL(), bodyJSON(t, reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 403; body: %s", resp.StatusCode, body)
+	}
+}
+
+// TestCreateModel_FallbackToNonExistentModel verifies that referencing a
+// fallback target that does not exist returns 400.
+func TestCreateModel_FallbackToNonExistentModel(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestCreateModel_FallbackNonExistent?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	reqBody := map[string]any{
+		"name":                "model-with-bad-fallback",
+		"provider":            "openai",
+		"base_url":            "https://api.openai.com/v1",
+		"fallback_model_name": "this-does-not-exist",
+	}
+
+	req := httptest.NewRequest("POST", modelURL(), bodyJSON(t, reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 400; body: %s", resp.StatusCode, body)
+	}
+}
+
+// TestUpdateModel_WithFallbackLicensed verifies that updating a model to add a
+// fallback succeeds when the license includes FeatureFallbackChains.
+func TestUpdateModel_WithFallbackLicensed(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestUpdateModel_WithFallbackLicensed?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	target := mustCreateModelForDeployment(t, database, "fallback-target-upd")
+	source := mustCreateModelForDeployment(t, database, "source-model-upd")
+	_ = target
+
+	fallbackName := "fallback-target-upd"
+	patchBody := map[string]any{
+		"fallback_model_name": fallbackName,
+	}
+
+	req := httptest.NewRequest("PATCH", modelItemURL(source.ID), bodyJSON(t, patchBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+	if got["fallback_model_name"] != fallbackName {
+		t.Errorf("fallback_model_name = %v, want %q", got["fallback_model_name"], fallbackName)
+	}
+}
+
+// TestUpdateModel_WithFallbackNotLicensed verifies that updating a model to add
+// a fallback fails with 403 when the license lacks FeatureFallbackChains.
+func TestUpdateModel_WithFallbackNotLicensed(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestUpdateModel_WithFallbackNotLicensed?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestAppWithLicense(t, dsn, license.Verify("", false))
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	mustCreateModelForDeployment(t, database, "fb-target-nolic")
+	source := mustCreateModelForDeployment(t, database, "source-nolic")
+
+	patchBody := map[string]any{
+		"fallback_model_name": "fb-target-nolic",
+	}
+
+	req := httptest.NewRequest("PATCH", modelItemURL(source.ID), bodyJSON(t, patchBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusForbidden {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 403; body: %s", resp.StatusCode, body)
+	}
+}
+
+// TestUpdateModel_FallbackCycle verifies that setting up a cycle via PATCH
+// returns 400 with a cycle error message.
+func TestUpdateModel_FallbackCycle(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestUpdateModel_FallbackCycle?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	// Set up A→B via the DB directly (using API would work but DB is simpler).
+	modelA := mustCreateModelForDeployment(t, database, "cycle-model-a")
+	modelB := mustCreateModelForDeployment(t, database, "cycle-model-b")
+
+	// Link A → B using the PATCH endpoint.
+	req1 := httptest.NewRequest("PATCH", modelItemURL(modelA.ID), bodyJSON(t, map[string]any{
+		"fallback_model_name": "cycle-model-b",
+	}))
+	req1.Header.Set("Content-Type", "application/json")
+	req1.Header.Set("Authorization", "Bearer "+testKey)
+	resp1, err := app.Test(req1, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("PATCH A→B: app.Test: %v", err)
+	}
+	resp1.Body.Close()
+	if resp1.StatusCode != fiber.StatusOK {
+		t.Fatalf("PATCH A→B status = %d, want 200", resp1.StatusCode)
+	}
+
+	// Now try to link B → A, which would create a cycle.
+	req2 := httptest.NewRequest("PATCH", modelItemURL(modelB.ID), bodyJSON(t, map[string]any{
+		"fallback_model_name": "cycle-model-a",
+	}))
+	req2.Header.Set("Content-Type", "application/json")
+	req2.Header.Set("Authorization", "Bearer "+testKey)
+	resp2, err := app.Test(req2, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("PATCH B→A: app.Test: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != fiber.StatusBadRequest {
+		body, _ := io.ReadAll(resp2.Body)
+		t.Errorf("PATCH B→A: status = %d, want 400 (cycle); body: %s", resp2.StatusCode, body)
+	}
+}
+
+// TestUpdateModel_FallbackClearsWhenEmpty verifies that passing an empty string
+// for fallback_model_name clears the existing fallback (sets it to NULL in DB).
+func TestUpdateModel_FallbackClearsWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestUpdateModel_FallbackClearsWhenEmpty?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	target := mustCreateModelForDeployment(t, database, "fb-clear-target")
+	source := mustCreateModelForDeployment(t, database, "fb-clear-source")
+	_ = target
+
+	// First, set a fallback.
+	req1 := httptest.NewRequest("PATCH", modelItemURL(source.ID), bodyJSON(t, map[string]any{
+		"fallback_model_name": "fb-clear-target",
+	}))
+	req1.Header.Set("Content-Type", "application/json")
+	req1.Header.Set("Authorization", "Bearer "+testKey)
+	resp1, err := app.Test(req1, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("set fallback: app.Test: %v", err)
+	}
+	resp1.Body.Close()
+	if resp1.StatusCode != fiber.StatusOK {
+		t.Fatalf("set fallback: status = %d, want 200", resp1.StatusCode)
+	}
+
+	// Now clear the fallback by sending an empty string.
+	emptyStr := ""
+	req2 := httptest.NewRequest("PATCH", modelItemURL(source.ID), bodyJSON(t, map[string]any{
+		"fallback_model_name": emptyStr,
+	}))
+	req2.Header.Set("Content-Type", "application/json")
+	req2.Header.Set("Authorization", "Bearer "+testKey)
+	resp2, err := app.Test(req2, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("clear fallback: app.Test: %v", err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp2.Body)
+		t.Fatalf("clear fallback: status = %d, want 200; body: %s", resp2.StatusCode, body)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp2.Body, &got)
+	// fallback_model_name should be absent (omitempty) or empty string.
+	if v, ok := got["fallback_model_name"]; ok && v != "" && v != nil {
+		t.Errorf("fallback_model_name = %v after clear, want absent/empty", v)
+	}
+
+	// Confirm via DB that fallback_model_id IS NULL.
+	ctx := context.Background()
+	row := database.SQL().QueryRowContext(ctx,
+		"SELECT fallback_model_id FROM models WHERE id = ?", source.ID)
+	var fallbackID *string
+	if err := row.Scan(&fallbackID); err != nil {
+		t.Fatalf("scan fallback_model_id: %v", err)
+	}
+	if fallbackID != nil {
+		t.Errorf("fallback_model_id = %q, want NULL after clearing", *fallbackID)
+	}
+}
+
+// TestListModels_IncludesFallbackName verifies that the list response populates
+// fallback_model_name for models that have a fallback configured.
+func TestListModels_IncludesFallbackName(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestListModels_IncludesFallbackName?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	target := mustCreateModelForDeployment(t, database, "list-fallback-target")
+	source := mustCreateModelForDeployment(t, database, "list-fallback-source")
+	_ = target
+
+	// Set fallback via PATCH.
+	patchReq := httptest.NewRequest("PATCH", modelItemURL(source.ID), bodyJSON(t, map[string]any{
+		"fallback_model_name": "list-fallback-target",
+	}))
+	patchReq.Header.Set("Content-Type", "application/json")
+	patchReq.Header.Set("Authorization", "Bearer "+testKey)
+	patchResp, err := app.Test(patchReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("PATCH: app.Test: %v", err)
+	}
+	patchResp.Body.Close()
+	if patchResp.StatusCode != fiber.StatusOK {
+		t.Fatalf("PATCH status = %d, want 200", patchResp.StatusCode)
+	}
+
+	// List models and check that the source model shows fallback_model_name.
+	listReq := httptest.NewRequest("GET", modelURL(), nil)
+	listReq.Header.Set("Authorization", "Bearer "+testKey)
+
+	listResp, err := app.Test(listReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("GET list: app.Test: %v", err)
+	}
+	defer listResp.Body.Close()
+
+	if listResp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(listResp.Body)
+		t.Fatalf("GET list status = %d, want 200; body: %s", listResp.StatusCode, body)
+	}
+
+	var listBody map[string]any
+	decodeBody(t, listResp.Body, &listBody)
+
+	data, ok := listBody["data"].([]any)
+	if !ok {
+		t.Fatalf("data field is not an array: %v", listBody["data"])
+	}
+
+	// Find the source model in the list and verify its fallback name.
+	found := false
+	for _, item := range data {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["name"] == "list-fallback-source" {
+			found = true
+			if m["fallback_model_name"] != "list-fallback-target" {
+				t.Errorf("list-fallback-source fallback_model_name = %v, want %q",
+					m["fallback_model_name"], "list-fallback-target")
+			}
+		}
+	}
+	if !found {
+		t.Error("list-fallback-source not found in list response")
+	}
+}
+
+// TestListModels_FallbackAcrossPages verifies that when model A's fallback
+// target lives on a different page, resolveMissingFallbackNames resolves the
+// name correctly and the list response populates fallback_model_name for A.
+//
+// Setup: 5 models total. List page 1 with limit=4, leaving model E on page 2.
+// Model A (on page 1) has its fallback pointing to model E (on page 2).
+func TestListModels_FallbackAcrossPages(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestListModels_FallbackAcrossPages?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	// Create 5 models. The DB assigns UUIDs so listing order is by creation time
+	// (ascending). Models are named with sortable prefixes so alphabetical order
+	// matches creation order when the DB uses name-based cursor (verify below).
+	// We rely on ID-based cursor ordering; creating in alphabetical order is
+	// sufficient because UUID v7 is time-sortable (see architecture.md).
+	modelA := mustCreateModelForDeployment(t, database, "xpage-model-a")
+	mustCreateModelForDeployment(t, database, "xpage-model-b")
+	mustCreateModelForDeployment(t, database, "xpage-model-c")
+	mustCreateModelForDeployment(t, database, "xpage-model-d")
+	modelE := mustCreateModelForDeployment(t, database, "xpage-model-e")
+
+	// Link A → E via PATCH so model A's fallback_model_id points to E.
+	patchReq := httptest.NewRequest("PATCH", modelItemURL(modelA.ID), bodyJSON(t, map[string]any{
+		"fallback_model_name": "xpage-model-e",
+	}))
+	patchReq.Header.Set("Content-Type", "application/json")
+	patchReq.Header.Set("Authorization", "Bearer "+testKey)
+	patchResp, err := app.Test(patchReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("PATCH A→E: app.Test: %v", err)
+	}
+	patchResp.Body.Close()
+	if patchResp.StatusCode != fiber.StatusOK {
+		t.Fatalf("PATCH A→E status = %d, want 200", patchResp.StatusCode)
+	}
+
+	// Fetch page 1 with limit=4. A is on page 1; E is on page 2 (not returned).
+	listReq := httptest.NewRequest("GET", modelURL()+"?limit=4", nil)
+	listReq.Header.Set("Authorization", "Bearer "+testKey)
+
+	listResp, err := app.Test(listReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("GET list p1: app.Test: %v", err)
+	}
+	defer listResp.Body.Close()
+
+	if listResp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(listResp.Body)
+		t.Fatalf("GET list p1 status = %d, want 200; body: %s", listResp.StatusCode, body)
+	}
+
+	var listBody map[string]any
+	decodeBody(t, listResp.Body, &listBody)
+
+	data, ok := listBody["data"].([]any)
+	if !ok {
+		t.Fatalf("data field is not an array: %v", listBody["data"])
+	}
+	if len(data) != 4 {
+		t.Fatalf("len(data) = %d, want 4 (page 1 of 5 with limit=4)", len(data))
+	}
+	if listBody["has_more"] != true {
+		t.Error("has_more = false, want true (model E is on page 2)")
+	}
+
+	// Verify that E IS on page 2 and NOT on page 1.
+	eFoundOnPage1 := false
+	for _, item := range data {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["id"] == modelE.ID {
+			eFoundOnPage1 = true
+		}
+	}
+	if eFoundOnPage1 {
+		t.Skip("model E landed on page 1 — UUID ordering put all 5 on the same page; skip cross-page assertion")
+	}
+
+	// Find model A in the page-1 response and assert fallback_model_name = "xpage-model-e".
+	foundA := false
+	for _, item := range data {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["id"] == modelA.ID {
+			foundA = true
+			if m["fallback_model_name"] != "xpage-model-e" {
+				t.Errorf("model A fallback_model_name = %v, want %q (cross-page resolution failed)",
+					m["fallback_model_name"], "xpage-model-e")
+			}
+		}
+	}
+	if !foundA {
+		t.Error("model A not found on page 1")
+	}
+}
+
+// TestUpdateModel_ConcurrentFallbackMutations is a race-detector test that
+// verifies concurrent PATCH requests mutating fallback relationships do not
+// produce data races or panics (Fix C3). The exact final state is not asserted
+// because the Go scheduler determines which write wins — only absence of races
+// is required. Run the test suite with -race to exercise this property.
+func TestUpdateModel_ConcurrentFallbackMutations(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestUpdateModel_ConcurrentFallbackMutations?mode=memory&cache=private"
+	// Use a single connection so SQLite serialises writes; we test that the
+	// handler layer does not introduce data races, not SQLite concurrency.
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	modelA := mustCreateModelForDeployment(t, database, "conc-fallback-a")
+	modelB := mustCreateModelForDeployment(t, database, "conc-fallback-b")
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest("PATCH", modelItemURL(modelA.ID),
+				bodyJSON(t, map[string]any{"fallback_model_name": "conc-fallback-b"}))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testKey)
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+			if err == nil {
+				resp.Body.Close()
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest("PATCH", modelItemURL(modelB.ID),
+				bodyJSON(t, map[string]any{"fallback_model_name": "conc-fallback-a"}))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testKey)
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+			if err == nil {
+				resp.Body.Close()
+			}
+		}()
+	}
+
+	wg.Wait()
+	// No assertion on the specific outcome — reaching here without -race failure
+	// or panic is the pass condition. The mutex protecting the Registry's
+	// fallback state (Fix C3) prevents data corruption under concurrent access.
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -977,6 +977,7 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 
 	adminHandler.MCPCallTimeout = cfg.Settings.MCP.CallTimeout
 	adminHandler.MCPAllowPrivateURLs = cfg.Settings.MCP.AllowPrivateURLs
+	adminHandler.FallbackMaxDepth = cfg.Settings.FallbackMaxDepth
 
 	mcpLogger := usage.NewMCPLogger(database, 1000, log)
 	adminHandler.MCPLogger = mcpLogger

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -265,6 +265,27 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 		return nil, fmt.Errorf("build model registry: %w", err)
 	}
 
+	// gateFallback strips FallbackModelName from every model in reg when the
+	// current license (read live from h) does not include FeatureFallbackChains.
+	// It reads the license from the Holder on each invocation so that a license
+	// change via the admin API takes effect on the next registry reload without
+	// requiring a process restart. Safe to call with any reg/h combination.
+	//
+	// The strip is performed atomically via StripAllFallbacks (single write-lock
+	// acquisition) to eliminate the race window between snapshot and re-insert
+	// that existed in the previous snapshot+loop pattern.
+	gateFallback := func(reg *proxy.Registry, h *license.Holder) {
+		l := h.Load()
+		if l.HasFeature(license.FeatureFallbackChains) {
+			return
+		}
+		stripped := reg.StripAllFallbacks()
+		if stripped > 0 {
+			log.Warn("model fallback chains require an Enterprise license; stripped fallback configuration",
+				slog.Int("models_affected", stripped))
+		}
+	}
+
 	// loadModelsIntoRegistry fetches all active models from the DB, decrypts
 	// their API keys, and upserts each one into the registry. It is called once
 	// at startup and again whenever a ChannelModels invalidation is received via
@@ -274,6 +295,14 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 		if loadErr != nil {
 			return fmt.Errorf("list active models: %w", loadErr)
 		}
+
+		// Build an id→name map from the loaded models so we can resolve
+		// FallbackModelID to a name without extra DB round-trips.
+		idToName := make(map[string]string, len(dbModels))
+		for _, m := range dbModels {
+			idToName[m.ID] = m.Name
+		}
+
 		for _, m := range dbModels {
 			var apiKey string
 			if m.APIKeyEncrypted != nil {
@@ -343,31 +372,56 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 				})
 			}
 
+			var fallbackName string
+			if m.FallbackModelID != nil {
+				fallbackName = idToName[*m.FallbackModelID]
+			}
+
 			registry.AddModel(proxy.Model{
-				Name:             m.Name,
-				Provider:         m.Provider,
-				Type:             modelType,
-				BaseURL:          m.BaseURL,
-				APIKey:           apiKey,
-				Aliases:          aliases,
-				MaxContextTokens: m.MaxContextTokens,
-				Pricing:          config.PricingConfig{InputPer1M: m.InputPricePer1M, OutputPer1M: m.OutputPricePer1M},
-				AzureDeployment:  m.AzureDeployment,
-				AzureAPIVersion:  m.AzureAPIVersion,
-				GCPProject:       m.GCPProject,
-				GCPLocation:      m.GCPLocation,
-				Timeout:          timeout,
-				Strategy:         m.Strategy,
-				MaxRetries:       m.MaxRetries,
-				Deployments:      deployments,
+				Name:              m.Name,
+				Provider:          m.Provider,
+				Type:              modelType,
+				BaseURL:           m.BaseURL,
+				APIKey:            apiKey,
+				Aliases:           aliases,
+				MaxContextTokens:  m.MaxContextTokens,
+				Pricing:           config.PricingConfig{InputPer1M: m.InputPricePer1M, OutputPer1M: m.OutputPricePer1M},
+				AzureDeployment:   m.AzureDeployment,
+				AzureAPIVersion:   m.AzureAPIVersion,
+				GCPProject:        m.GCPProject,
+				GCPLocation:       m.GCPLocation,
+				Timeout:           timeout,
+				Strategy:          m.Strategy,
+				MaxRetries:        m.MaxRetries,
+				Deployments:       deployments,
+				FallbackModelName: fallbackName,
 			})
 		}
+		gateFallback(registry, licHolder)
 		return nil
 	}
 
 	// Step 4b: overlay DB models on top of YAML registry.
 	if err := loadModelsIntoRegistry(ctx); err != nil {
 		return nil, fmt.Errorf("load models from database: %w", err)
+	}
+
+	// Warn operators who have configured fallback targets in their models but
+	// have not set fallback_max_depth (which defaults to 0 = disabled). Without
+	// a non-zero depth the fallback configuration is silently inactive, which is
+	// a common misconfiguration after upgrading from a version that didn't have
+	// this feature.
+	if cfg.Settings.FallbackMaxDepth == 0 {
+		modelsWithFallback := 0
+		for _, m := range registry.AllModels() {
+			if m.FallbackModelName != "" {
+				modelsWithFallback++
+			}
+		}
+		if modelsWithFallback > 0 {
+			log.Warn("fallback chains are configured on some models but settings.fallback_max_depth is 0 (disabled). Set fallback_max_depth to enable.",
+				slog.Int("models_with_fallback", modelsWithFallback))
+		}
 	}
 
 	// Step 5: derive HMAC secret from the encryption key using HKDF (RFC 5869).
@@ -613,6 +667,7 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 	proxyHandler.MaxRequestBody = cfg.Server.Proxy.MaxRequestBody
 	proxyHandler.MaxResponseBody = cfg.Server.Proxy.MaxResponseBody
 	proxyHandler.MaxStreamDuration = cfg.Server.Proxy.MaxStreamDuration
+	proxyHandler.FallbackMaxDepth = cfg.Settings.FallbackMaxDepth
 
 	adminHandler := &admin.Handler{
 		DB:                database,
@@ -631,6 +686,12 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 		Log:               log,
 		SSOProvider:       ssoProvider,
 		SSOConfig:         cfg.Settings.SSO,
+	}
+	// Wire the in-process reload callback so SetLicense can re-gate the
+	// model registry immediately after storing a new license, even on
+	// deployments that have no Redis (the default single-instance setup).
+	adminHandler.ReloadModels = func(reloadCtx context.Context) error {
+		return loadModelsIntoRegistry(reloadCtx)
 	}
 	// Only assign the health checker when it was actually created — a typed nil
 	// (*health.Checker)(nil) satisfies the interface but is NOT == nil when

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -155,6 +155,10 @@ type ModelConfig struct {
 	// MaxRetries is the number of times the proxy will retry a failed upstream
 	// request across the available deployments. Must be >= 0.
 	MaxRetries int `yaml:"max_retries"`
+	// Fallback is the canonical name (or alias) of another model to retry
+	// when all deployments of this model are unavailable. Resolved at
+	// registry build time. Empty disables fallback for this model.
+	Fallback string `yaml:"fallback" json:"fallback,omitempty"`
 	// Deployments is the list of backend endpoints for this model. When set,
 	// the model-level Provider and BaseURL fields are ignored in favour of the
 	// per-deployment values, and Strategy must be set.
@@ -454,6 +458,10 @@ type SettingsConfig struct {
 	HealthCheck    HealthCheckConfig    `yaml:"health_check"`
 	MCP            MCPConfig            `yaml:"mcp"`
 	Retention      RetentionConfig      `yaml:"retention"`
+	// FallbackMaxDepth limits how deep the model fallback chain can recurse
+	// per request. Default 3, valid range [1, 10]. Ignored when no model has
+	// fallback configured or when the license lacks FeatureFallbackChains.
+	FallbackMaxDepth int `yaml:"fallback_max_depth" json:"fallback_max_depth"`
 	// SoftLimitThreshold uses *float64 so that an explicit 0.0 can be
 	// distinguished from the zero value after unmarshalling. Use
 	// GetSoftLimitThreshold to read the value.
@@ -680,6 +688,12 @@ func (c *Config) setDefaults() {
 	// Settings retention
 	if c.Settings.Retention.Interval <= 0 {
 		c.Settings.Retention.Interval = 24 * time.Hour
+	}
+
+	// Settings fallback: promote strictly negative to 3; 0 is a valid explicit
+	// "disabled" value and must not be overwritten to the default.
+	if c.Settings.FallbackMaxDepth < 0 {
+		c.Settings.FallbackMaxDepth = 3
 	}
 
 	// Bootstrap

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1102,6 +1102,219 @@ func TestValidate_MCPServer(t *testing.T) {
 `),
 			wantErr: false,
 		},
+
+		// ── Fallback max depth validation ────────────────────────────────────
+		// Note: setDefaults converts 0 and negative values to 3 before
+		// validation runs, so those cannot be tested as errors via Load().
+		// Only the out-of-range upper bound (> 10) triggers a validation error.
+		{
+			name: "fallback_max_depth above 10 returns error",
+			yaml: `
+server:
+  proxy:
+    port: 8080
+database:
+  driver: sqlite
+  dsn: voidllm.db
+settings:
+  encryption_key: aaaaaaaaaaaaaaaa
+  usage:
+    buffer_size: 100
+  fallback_max_depth: 11
+`,
+			wantErr:     true,
+			errContains: "fallback_max_depth",
+		},
+		{
+			name: "fallback_max_depth 1 is valid",
+			yaml: `
+server:
+  proxy:
+    port: 8080
+database:
+  driver: sqlite
+  dsn: voidllm.db
+settings:
+  encryption_key: aaaaaaaaaaaaaaaa
+  usage:
+    buffer_size: 100
+  fallback_max_depth: 1
+`,
+			wantErr: false,
+		},
+		{
+			name: "fallback_max_depth 10 is valid",
+			yaml: `
+server:
+  proxy:
+    port: 8080
+database:
+  driver: sqlite
+  dsn: voidllm.db
+settings:
+  encryption_key: aaaaaaaaaaaaaaaa
+  usage:
+    buffer_size: 100
+  fallback_max_depth: 10
+`,
+			wantErr: false,
+		},
+
+		// ── Per-model fallback validation ────────────────────────────────────
+		{
+			name: "fallback to nonexistent model returns error",
+			yaml: `
+server:
+  proxy:
+    port: 8080
+database:
+  driver: sqlite
+  dsn: voidllm.db
+settings:
+  encryption_key: aaaaaaaaaaaaaaaa
+  usage:
+    buffer_size: 100
+models:
+  - name: model-a
+    provider: openai
+    base_url: https://api.openai.com
+    fallback: does-not-exist
+`,
+			wantErr:     true,
+			errContains: "not found",
+		},
+		{
+			name: "fallback to self returns error",
+			yaml: `
+server:
+  proxy:
+    port: 8080
+database:
+  driver: sqlite
+  dsn: voidllm.db
+settings:
+  encryption_key: aaaaaaaaaaaaaaaa
+  usage:
+    buffer_size: 100
+models:
+  - name: model-a
+    provider: openai
+    base_url: https://api.openai.com
+    fallback: model-a
+`,
+			wantErr:     true,
+			errContains: "itself",
+		},
+		{
+			name: "fallback cycle length 2 returns error",
+			yaml: `
+server:
+  proxy:
+    port: 8080
+database:
+  driver: sqlite
+  dsn: voidllm.db
+settings:
+  encryption_key: aaaaaaaaaaaaaaaa
+  usage:
+    buffer_size: 100
+models:
+  - name: model-a
+    provider: openai
+    base_url: https://api.openai.com
+    fallback: model-b
+  - name: model-b
+    provider: openai
+    base_url: https://api.openai.com
+    fallback: model-a
+`,
+			wantErr:     true,
+			errContains: "cycle",
+		},
+		{
+			name: "fallback cycle length 3 returns error",
+			yaml: `
+server:
+  proxy:
+    port: 8080
+database:
+  driver: sqlite
+  dsn: voidllm.db
+settings:
+  encryption_key: aaaaaaaaaaaaaaaa
+  usage:
+    buffer_size: 100
+models:
+  - name: model-a
+    provider: openai
+    base_url: https://api.openai.com
+    fallback: model-b
+  - name: model-b
+    provider: openai
+    base_url: https://api.openai.com
+    fallback: model-c
+  - name: model-c
+    provider: openai
+    base_url: https://api.openai.com
+    fallback: model-a
+`,
+			wantErr:     true,
+			errContains: "cycle",
+		},
+		{
+			name: "fallback chain no cycle is valid",
+			yaml: `
+server:
+  proxy:
+    port: 8080
+database:
+  driver: sqlite
+  dsn: voidllm.db
+settings:
+  encryption_key: aaaaaaaaaaaaaaaa
+  usage:
+    buffer_size: 100
+models:
+  - name: model-a
+    provider: openai
+    base_url: https://api.openai.com
+    fallback: model-b
+  - name: model-b
+    provider: openai
+    base_url: https://api.openai.com
+    fallback: model-c
+  - name: model-c
+    provider: openai
+    base_url: https://api.openai.com
+`,
+			wantErr: false,
+		},
+		{
+			name: "fallback targets an alias resolves without error",
+			yaml: `
+server:
+  proxy:
+    port: 8080
+database:
+  driver: sqlite
+  dsn: voidllm.db
+settings:
+  encryption_key: aaaaaaaaaaaaaaaa
+  usage:
+    buffer_size: 100
+models:
+  - name: model-a
+    provider: openai
+    base_url: https://api.openai.com
+    fallback: m-alias
+  - name: model-b
+    provider: openai
+    base_url: https://api.openai.com
+    aliases:
+      - m-alias
+`,
+			wantErr: false,
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -308,6 +308,56 @@ func (c *Config) validate() error {
 		errs = append(errs, fmt.Errorf("settings.soft_limit_threshold: must be between 0.0 and 1.0, got %g", t))
 	}
 
+	// --- settings.fallback_max_depth ---
+	// 0 means "disabled" (no fallback hops); positive values in [1, 10] set the
+	// maximum chain depth. Negative values are promoted to 3 in setDefaults, so
+	// validation only needs to reject values that slipped through unchanged.
+	if c.Settings.FallbackMaxDepth < 0 || c.Settings.FallbackMaxDepth > 10 {
+		errs = append(errs, errors.New("settings.fallback_max_depth must be in [0, 10] (0 = disabled)"))
+	}
+
+	// Per-model fallback validation: target exists, no self-loop, no cycles
+	modelByName := make(map[string]*ModelConfig, len(c.Models))
+	for i := range c.Models {
+		modelByName[c.Models[i].Name] = &c.Models[i]
+		for _, alias := range c.Models[i].Aliases {
+			modelByName[alias] = &c.Models[i]
+		}
+	}
+	for i := range c.Models {
+		m := &c.Models[i]
+		if m.Fallback == "" {
+			continue
+		}
+		if m.Fallback == m.Name {
+			errs = append(errs, fmt.Errorf("model %q: fallback cannot reference itself", m.Name))
+			continue
+		}
+		target, ok := modelByName[m.Fallback]
+		if !ok {
+			errs = append(errs, fmt.Errorf("model %q: fallback target %q not found", m.Name, m.Fallback))
+			continue
+		}
+		// Walk the chain looking for a cycle back to m
+		visited := map[string]bool{m.Name: true}
+		curr := target
+		for curr != nil {
+			if visited[curr.Name] {
+				errs = append(errs, fmt.Errorf("model %q: fallback chain forms a cycle through %q", m.Name, curr.Name))
+				break
+			}
+			visited[curr.Name] = true
+			if curr.Fallback == "" {
+				break
+			}
+			next, ok := modelByName[curr.Fallback]
+			if !ok {
+				break // unreachable target gets caught on its own iteration
+			}
+			curr = next
+		}
+	}
+
 	// --- settings.retention ---
 	const maxRetention = 10 * 365 * 24 * time.Hour // 10 years
 	if c.Settings.Retention.UsageEvents < 0 {

--- a/internal/db/mcp_usage_queries_test.go
+++ b/internal/db/mcp_usage_queries_test.go
@@ -199,10 +199,11 @@ func TestGetMCPUsageAggregates_GroupByDay_ChronologicalOrder(t *testing.T) {
 	now := time.Now().UTC()
 	orgID := "org-day-order"
 
-	// Insert calls on three distinct days.
-	day1 := now.Add(-48 * time.Hour).Truncate(24 * time.Hour).Add(12 * time.Hour)
-	day2 := now.Add(-24 * time.Hour).Truncate(24 * time.Hour).Add(12 * time.Hour)
-	day3 := now.Truncate(24 * time.Hour).Add(12 * time.Hour)
+	// Insert calls on three distinct days. Use fixed offsets from now
+	// instead of truncate+noon to avoid failures near midnight UTC.
+	day1 := now.Add(-50 * time.Hour)
+	day2 := now.Add(-26 * time.Hour)
+	day3 := now.Add(-2 * time.Hour)
 	from := now.Add(-72 * time.Hour)
 	to := now.Add(time.Hour)
 

--- a/internal/db/migrations/0011_model_fallback_chains.down.sql
+++ b/internal/db/migrations/0011_model_fallback_chains.down.sql
@@ -1,0 +1,11 @@
+-- Migration: 0011_model_fallback_chains.down.sql
+-- Description: Reverses 0011_model_fallback_chains.up.sql.
+-- ALTER TABLE DROP COLUMN requires SQLite 3.35+ (modernc.org/sqlite ships 3.45+)
+-- and is standard on all supported PostgreSQL versions.
+-- The index must be dropped before the column it covers is removed.
+
+DROP INDEX IF EXISTS idx_models_fallback;
+
+ALTER TABLE usage_events DROP COLUMN requested_model_name;
+
+ALTER TABLE models DROP COLUMN fallback_model_id;

--- a/internal/db/migrations/0011_model_fallback_chains.up.sql
+++ b/internal/db/migrations/0011_model_fallback_chains.up.sql
@@ -1,0 +1,25 @@
+-- Migration: 0011_model_fallback_chains.up.sql
+-- Description: Adds optional fallback target to models and tracks the originally
+-- requested model name on usage events for fallback analytics (Enterprise, #45).
+--
+-- fallback_model_id: self-referential nullable FK. ON DELETE SET NULL means
+-- deleting a fallback target safely orphans the reference rather than cascading.
+-- ALTER TABLE ADD COLUMN with an inline REFERENCES clause is supported on
+-- SQLite 3.6.19+ (modernc.org/sqlite ships 3.45+) and all PostgreSQL versions.
+--
+-- requested_model_name: records what the client originally asked for. Empty
+-- string default keeps existing rows valid; new write paths populate it.
+-- Distinguishes "asked for X, served X" from "asked for X, served Y via fallback".
+
+ALTER TABLE models
+    ADD COLUMN fallback_model_id TEXT REFERENCES models(id) ON DELETE SET NULL;
+
+ALTER TABLE usage_events
+    ADD COLUMN requested_model_name TEXT NOT NULL DEFAULT '';
+
+-- Speeds up "find all models that fall back to model X" used by the admin API
+-- when checking whether a model is safe to delete. Partial because most rows
+-- have NULL fallback_model_id and we only care about the non-NULL subset.
+CREATE INDEX idx_models_fallback
+    ON models(fallback_model_id)
+    WHERE fallback_model_id IS NOT NULL;

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -18,7 +18,7 @@ const modelSelectColumns = "id, name, provider, model_type, base_url, api_key_en
 	"max_context_tokens, input_price_per_1m, output_price_per_1m, " +
 	"azure_deployment, azure_api_version, gcp_project, gcp_location, " +
 	"is_active, source, created_by, created_at, updated_at, deleted_at, aliases, timeout, " +
-	"strategy, max_retries"
+	"strategy, max_retries, fallback_model_id"
 
 // Model represents a model record in the database.
 // This is the storage layer representation; see proxy.Model for the in-memory registry type.
@@ -58,6 +58,9 @@ type Model struct {
 	// MaxRetries is the maximum number of deployments to attempt before returning
 	// an error to the caller. 0 means try all available deployments.
 	MaxRetries int
+	// FallbackModelID is the ID of the model to try when all deployments of
+	// this model are unavailable. Nil when no fallback is configured.
+	FallbackModelID *string
 }
 
 // CreateModelParams holds the input for creating a model.
@@ -90,6 +93,8 @@ type CreateModelParams struct {
 	Strategy *string
 	// MaxRetries is the maximum number of deployments to attempt. 0 means try all.
 	MaxRetries *int
+	// FallbackModelID is the ID of the fallback model. Nil means no fallback.
+	FallbackModelID *string
 }
 
 // UpdateModelParams holds optional fields for updating a model.
@@ -120,6 +125,9 @@ type UpdateModelParams struct {
 	Strategy *string
 	// MaxRetries, when non-nil, replaces the stored retry count.
 	MaxRetries *int
+	// FallbackModelID, when non-nil, replaces the stored fallback model ID.
+	// Set to a pointer to an empty string to clear the fallback.
+	FallbackModelID *string
 }
 
 // CreateModel inserts a new model and returns the persisted record.
@@ -150,12 +158,13 @@ func (d *DB) CreateModel(ctx context.Context, params CreateModelParams) (*Model,
 		"max_context_tokens, input_price_per_1m, output_price_per_1m, " +
 		"azure_deployment, azure_api_version, gcp_project, gcp_location, " +
 		"is_active, source, created_by, aliases, timeout, strategy, max_retries, " +
-		"created_at, updated_at) " +
+		"fallback_model_id, created_at, updated_at) " +
 		"VALUES (" +
 		p(1) + ", " + p(2) + ", " + p(3) + ", " + p(4) + ", " + p(5) + ", " + p(6) + ", " +
 		p(7) + ", " + p(8) + ", " + p(9) + ", " +
 		p(10) + ", " + p(11) + ", " + p(12) + ", " + p(13) + ", " +
 		"1, " + p(14) + ", " + p(15) + ", " + p(16) + ", " + p(17) + ", " + p(18) + ", " + p(19) + ", " +
+		p(20) + ", " +
 		"CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
 
 	selectQuery := "SELECT " + modelSelectColumns +
@@ -183,6 +192,7 @@ func (d *DB) CreateModel(ctx context.Context, params CreateModelParams) (*Model,
 			params.Timeout,
 			strategy,
 			maxRetries,
+			params.FallbackModelID,
 		)
 		if execErr != nil {
 			return translateError(execErr)
@@ -366,6 +376,15 @@ func (d *DB) UpdateModel(ctx context.Context, id string, params UpdateModelParam
 		args = append(args, *params.MaxRetries)
 		argN++
 	}
+	if params.FallbackModelID != nil {
+		if *params.FallbackModelID == "" {
+			setClauses = append(setClauses, "fallback_model_id = NULL")
+		} else {
+			setClauses = append(setClauses, "fallback_model_id = "+p(argN))
+			args = append(args, *params.FallbackModelID)
+			argN++
+		}
+	}
 
 	if len(setClauses) == 0 {
 		return d.GetModel(ctx, id)
@@ -514,13 +533,25 @@ func scanModel(scanner interface{ Scan(...any) error }) (*Model, error) {
 		&m.AzureDeployment, &m.AzureAPIVersion, &m.GCPProject, &m.GCPLocation,
 		&isActiveInt, &m.Source, &m.CreatedBy,
 		&m.CreatedAt, &m.UpdatedAt, &m.DeletedAt, &m.Aliases, &m.Timeout,
-		&m.Strategy, &m.MaxRetries,
+		&m.Strategy, &m.MaxRetries, &m.FallbackModelID,
 	)
 	if err != nil {
 		return nil, err
 	}
 	m.IsActive = isActiveInt == 1
 	return &m, nil
+}
+
+// GetModelIDByName returns the UUID for a given active model name (case-sensitive).
+// It returns ErrNotFound if the model does not exist or has been soft-deleted.
+func (d *DB) GetModelIDByName(ctx context.Context, name string) (string, error) {
+	query := "SELECT id FROM models WHERE name = " + d.dialect.Placeholder(1) + " AND deleted_at IS NULL"
+	var id string
+	err := d.sql.QueryRowContext(ctx, query, name).Scan(&id)
+	if err != nil {
+		return "", fmt.Errorf("get model id by name %q: %w", name, translateError(err))
+	}
+	return id, nil
 }
 
 // SyncYAMLModels upserts YAML-configured models into the database.

--- a/internal/db/models_test.go
+++ b/internal/db/models_test.go
@@ -1,0 +1,129 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestCreateModel_WithFallbackModelID verifies that a model can be created
+// with a FallbackModelID and that the stored value is retrievable.
+func TestCreateModel_WithFallbackModelID(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+
+	ctx := context.Background()
+
+	// Create the fallback target first.
+	target := mustCreateModel(t, d, "fallback-target")
+
+	// Create the source model with FallbackModelID pointing to target.
+	source, err := d.CreateModel(ctx, CreateModelParams{
+		Name:            "source-with-fallback",
+		Provider:        "openai",
+		BaseURL:         "https://api.openai.com/v1",
+		Source:          "api",
+		FallbackModelID: &target.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateModel with FallbackModelID: %v", err)
+	}
+
+	if source.FallbackModelID == nil {
+		t.Fatal("source.FallbackModelID is nil, want non-nil")
+	}
+	if *source.FallbackModelID != target.ID {
+		t.Errorf("source.FallbackModelID = %q, want %q", *source.FallbackModelID, target.ID)
+	}
+
+	// Fetch the source model and re-verify.
+	fetched, err := d.GetModel(ctx, source.ID)
+	if err != nil {
+		t.Fatalf("GetModel: %v", err)
+	}
+	if fetched.FallbackModelID == nil {
+		t.Fatal("fetched.FallbackModelID is nil after fetch, want non-nil")
+	}
+	if *fetched.FallbackModelID != target.ID {
+		t.Errorf("fetched.FallbackModelID = %q, want %q", *fetched.FallbackModelID, target.ID)
+	}
+}
+
+// TestUpdateModel_SetFallbackToNil verifies that updating FallbackModelID to an
+// empty string clears the column to NULL.
+func TestUpdateModel_SetFallbackToNil(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	target := mustCreateModel(t, d, "upd-fallback-target")
+	source, err := d.CreateModel(ctx, CreateModelParams{
+		Name:            "upd-source-with-fallback",
+		Provider:        "openai",
+		BaseURL:         "https://api.openai.com/v1",
+		Source:          "api",
+		FallbackModelID: &target.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateModel with FallbackModelID: %v", err)
+	}
+	if source.FallbackModelID == nil {
+		t.Fatal("precondition: FallbackModelID must be set before clearing")
+	}
+
+	// Clear the fallback by passing a pointer to an empty string.
+	empty := ""
+	updated, err := d.UpdateModel(ctx, source.ID, UpdateModelParams{
+		FallbackModelID: &empty,
+	})
+	if err != nil {
+		t.Fatalf("UpdateModel (clear fallback): %v", err)
+	}
+
+	if updated.FallbackModelID != nil {
+		t.Errorf("updated.FallbackModelID = %q, want nil (NULL)", *updated.FallbackModelID)
+	}
+
+	// Confirm via a fresh GetModel call.
+	fetched, err := d.GetModel(ctx, source.ID)
+	if err != nil {
+		t.Fatalf("GetModel after clear: %v", err)
+	}
+	if fetched.FallbackModelID != nil {
+		t.Errorf("fetched.FallbackModelID = %q after clear, want nil (NULL)", *fetched.FallbackModelID)
+	}
+}
+
+// TestGetModelIDByName verifies that GetModelIDByName returns the correct ID
+// for an existing model and ErrNotFound for a missing one.
+func TestGetModelIDByName(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	m := mustCreateModel(t, d, "named-lookup-model")
+
+	t.Run("existing model returns ID", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := d.GetModelIDByName(ctx, "named-lookup-model")
+		if err != nil {
+			t.Fatalf("GetModelIDByName: %v", err)
+		}
+		if got != m.ID {
+			t.Errorf("GetModelIDByName = %q, want %q", got, m.ID)
+		}
+	})
+
+	t.Run("nonexistent model returns ErrNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := d.GetModelIDByName(ctx, "does-not-exist")
+		if !errors.Is(err, ErrNotFound) {
+			t.Errorf("GetModelIDByName(nonexistent) error = %v, want ErrNotFound", err)
+		}
+	})
+}

--- a/internal/license/export_test.go
+++ b/internal/license/export_test.go
@@ -1,0 +1,6 @@
+package license
+
+// This file is intentionally empty. Internal test helpers (newTestKeypair,
+// signTestJWT, withTestPublicKey) live in verify_test.go and are accessible
+// within package license tests. External packages should use
+// internal/licensetest for the same functionality.

--- a/internal/license/features.go
+++ b/internal/license/features.go
@@ -26,6 +26,11 @@ const (
 
 	// FeatureCostReports enables cost analysis, budget alerts, and usage export.
 	FeatureCostReports = "cost_reports"
+
+	// FeatureFallbackChains enables cross-model fallback. When the primary
+	// model is unavailable, the proxy automatically retries on the configured
+	// fallback model.
+	FeatureFallbackChains = "fallback_chains"
 )
 
 // CommunityMaxOrgs is the maximum number of organizations permitted on the

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -119,6 +119,7 @@ func (devLicense) Features() []string {
 		FeatureCustomRoles,
 		FeatureMultiOrg,
 		FeatureCostReports,
+		FeatureFallbackChains,
 	}
 }
 

--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -130,3 +130,54 @@ func TestDevLicense(t *testing.T) {
 		}
 	}
 }
+
+// TestDevLicense_FeaturesContainsAllConstants ensures devLicense.Features()
+// lists every FeatureXxx constant defined in features.go. Adding a new
+// constant without updating this slice causes the UI to silently hide the
+// feature in dev mode even though HasFeature returns true, because the UI
+// gates on the Features() list, not the HasFeature method.
+func TestDevLicense_FeaturesContainsAllConstants(t *testing.T) {
+	t.Parallel()
+
+	// List every feature constant here. When a new one is added in
+	// features.go, add it here AND in devLicense.Features().
+	allFeatures := []string{
+		license.FeatureAuditLogs,
+		license.FeatureOTelTracing,
+		license.FeatureSSOOIDC,
+		license.FeatureCustomRoles,
+		license.FeatureMultiOrg,
+		license.FeatureCostReports,
+		license.FeatureFallbackChains,
+	}
+
+	lic := license.Verify("", true) // devMode=true returns devLicense
+	devFeatures := lic.Features()
+
+	devSet := make(map[string]bool, len(devFeatures))
+	for _, f := range devFeatures {
+		devSet[f] = true
+	}
+
+	for _, f := range allFeatures {
+		if !devSet[f] {
+			t.Errorf("devLicense.Features() is missing %q; add it to the slice in license.go", f)
+		}
+		if !lic.HasFeature(f) {
+			t.Errorf("devLicense.HasFeature(%q) returned false; expected true", f)
+		}
+	}
+
+	// Sanity: dev license should not INVENT features that don't exist as
+	// constants. This catches the inverse mistake (adding to Features()
+	// without adding a constant).
+	for _, f := range devFeatures {
+		allowedSet := make(map[string]bool, len(allFeatures))
+		for _, af := range allFeatures {
+			allowedSet[af] = true
+		}
+		if !allowedSet[f] {
+			t.Errorf("devLicense.Features() contains %q which is not in the allFeatures list in this test. If this is a new feature, add it to the test.", f)
+		}
+	}
+}

--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -47,6 +47,38 @@ func TestCommunityLicense(t *testing.T) {
 	}
 }
 
+// TestFeatureFallbackChainsConstant is a sanity test that the constant has
+// the exact value the JWT claim and feature-gate checks expect.
+func TestFeatureFallbackChainsConstant(t *testing.T) {
+	t.Parallel()
+
+	if license.FeatureFallbackChains != "fallback_chains" {
+		t.Errorf("FeatureFallbackChains = %q, want %q", license.FeatureFallbackChains, "fallback_chains")
+	}
+}
+
+// TestCommunityLicense_NoFallbackChains verifies that the community (unlicensed)
+// edition does not have the fallback_chains feature.
+func TestCommunityLicense_NoFallbackChains(t *testing.T) {
+	t.Parallel()
+
+	lic := license.Verify("", false)
+	if lic.HasFeature(license.FeatureFallbackChains) {
+		t.Errorf("HasFeature(%q) = true on community license, want false", license.FeatureFallbackChains)
+	}
+}
+
+// TestDevLicense_HasFallbackChains verifies that the dev license grants the
+// fallback_chains feature so that local development works without a paid key.
+func TestDevLicense_HasFallbackChains(t *testing.T) {
+	t.Parallel()
+
+	lic := license.Verify("", true)
+	if !lic.HasFeature(license.FeatureFallbackChains) {
+		t.Errorf("HasFeature(%q) = false on dev license, want true", license.FeatureFallbackChains)
+	}
+}
+
 func TestDevLicense(t *testing.T) {
 	t.Parallel()
 

--- a/internal/license/verify_test.go
+++ b/internal/license/verify_test.go
@@ -266,3 +266,69 @@ func TestVerify_WrongSigningKey(t *testing.T) {
 		t.Errorf("Edition() = %q, want %q (wrong key must fall back to community)", got, EditionCommunity)
 	}
 }
+
+// TestEnterpriseLicense_FallbackChainsGranted verifies that an enterprise
+// license that includes FeatureFallbackChains in its claims reports the feature
+// as available.
+func TestEnterpriseLicense_FallbackChainsGranted(t *testing.T) {
+	// Cannot run in parallel — uses withTestPublicKey which mutates package state.
+
+	pub, priv := newTestKeypair(t)
+	withTestPublicKey(t, pub)
+
+	claims := LicenseClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().UTC().Add(24 * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now().UTC()),
+			Issuer:    "voidllm.ai",
+		},
+		Plan:       "enterprise",
+		Features:   []string{FeatureFallbackChains},
+		MaxOrgs:    -1,
+		MaxTeams:   -1,
+		CustomerID: "cust_fallback_test",
+	}
+	key := signTestJWT(t, priv, claims)
+
+	lic := Verify(key, false)
+
+	if got := lic.Edition(); got != EditionEnterprise {
+		t.Errorf("Edition() = %q, want %q", got, EditionEnterprise)
+	}
+	if !lic.HasFeature(FeatureFallbackChains) {
+		t.Errorf("HasFeature(%q) = false on enterprise license with feature granted, want true", FeatureFallbackChains)
+	}
+}
+
+// TestEnterpriseLicense_FallbackChainsNotGranted verifies that an enterprise
+// license that does NOT include FeatureFallbackChains in its claims reports the
+// feature as unavailable.
+func TestEnterpriseLicense_FallbackChainsNotGranted(t *testing.T) {
+	// Cannot run in parallel — uses withTestPublicKey which mutates package state.
+
+	pub, priv := newTestKeypair(t)
+	withTestPublicKey(t, pub)
+
+	claims := LicenseClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().UTC().Add(24 * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now().UTC()),
+			Issuer:    "voidllm.ai",
+		},
+		Plan:       "enterprise",
+		Features:   []string{FeatureAuditLogs}, // different feature, not fallback_chains
+		MaxOrgs:    -1,
+		MaxTeams:   -1,
+		CustomerID: "cust_no_fallback_test",
+	}
+	key := signTestJWT(t, priv, claims)
+
+	lic := Verify(key, false)
+
+	if got := lic.Edition(); got != EditionEnterprise {
+		t.Errorf("Edition() = %q, want %q", got, EditionEnterprise)
+	}
+	if lic.HasFeature(FeatureFallbackChains) {
+		t.Errorf("HasFeature(%q) = true on enterprise license without this feature, want false", FeatureFallbackChains)
+	}
+}

--- a/internal/licensetest/licensetest.go
+++ b/internal/licensetest/licensetest.go
@@ -1,0 +1,74 @@
+// Package licensetest provides test helpers for packages that need to generate
+// valid VoidLLM enterprise license JWTs in tests. It uses go:linkname to swap
+// the license package's embedded Ed25519 public key so that ValidateKey
+// accepts JWTs signed with a test-generated keypair.
+//
+// This package must only be imported from _test.go files. It is not suitable
+// for use in production code.
+package licensetest
+
+import (
+	"crypto/ed25519"
+	"testing"
+	"time"
+	_ "unsafe" // required for go:linkname
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/voidmind-io/voidllm/internal/license"
+)
+
+//go:linkname licenseEmbeddedPublicKey github.com/voidmind-io/voidllm/internal/license.embeddedPublicKey
+var licenseEmbeddedPublicKey ed25519.PublicKey
+
+// WithTestPublicKey replaces the license package's embedded Ed25519 public
+// key for the duration of the test, then restores the original value via
+// t.Cleanup. Tests that call this MUST NOT run in parallel with other tests
+// that also call WithTestPublicKey, because they mutate shared package state.
+func WithTestPublicKey(t *testing.T, pub ed25519.PublicKey) {
+	t.Helper()
+	orig := make(ed25519.PublicKey, len(licenseEmbeddedPublicKey))
+	copy(orig, licenseEmbeddedPublicKey)
+	licenseEmbeddedPublicKey = pub
+	t.Cleanup(func() {
+		licenseEmbeddedPublicKey = orig
+	})
+}
+
+// NewTestKeypair generates a fresh Ed25519 keypair and fatals the test on
+// error.
+func NewTestKeypair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := license.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("licensetest.NewTestKeypair: GenerateKeyPair() error = %v", err)
+	}
+	return pub, priv
+}
+
+// SignTestJWT signs a LicenseClaims value with the provided Ed25519 private
+// key and returns the compact JWT string.
+func SignTestJWT(t *testing.T, priv ed25519.PrivateKey, claims license.LicenseClaims) string {
+	t.Helper()
+	key, err := license.GenerateLicenseJWT(priv, claims)
+	if err != nil {
+		t.Fatalf("licensetest.SignTestJWT: GenerateLicenseJWT() error = %v", err)
+	}
+	return key
+}
+
+// NewEnterpriseClaims returns a minimal valid LicenseClaims with the given
+// features, a 24-hour expiry, and the "voidllm.ai" issuer.
+func NewEnterpriseClaims(features []string) license.LicenseClaims {
+	return license.LicenseClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().UTC().Add(24 * time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now().UTC()),
+			Issuer:    "voidllm.ai",
+		},
+		Plan:       "enterprise",
+		Features:   features,
+		MaxOrgs:    -1,
+		MaxTeams:   -1,
+		CustomerID: "cust_test",
+	}
+}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -57,6 +58,10 @@ type ProxyHandler struct {
 	MaxRequestBody    int           // maximum allowed request body size in bytes
 	MaxResponseBody   int           // maximum allowed non-streaming response body size in bytes
 	MaxStreamDuration time.Duration // maximum duration for a streaming response
+	// FallbackMaxDepth is the maximum number of fallback hops allowed per
+	// request. Zero or negative disables fallback chaining entirely.
+	// Set from config.SettingsConfig.FallbackMaxDepth at startup.
+	FallbackMaxDepth int
 }
 
 // NewProxyHandler constructs a ProxyHandler with a pre-configured HTTP client.
@@ -207,6 +212,189 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 		)
 	}
 
+	// requestedModelName is the canonical name of the model originally requested
+	// by the client. It is preserved across fallback hops so usage events can
+	// record both the originally-requested model and the one that actually served
+	// the request.
+	requestedModelName := model.Name
+
+	// visited tracks the canonical names of all models attempted in this
+	// request's fallback chain so that runtime cycles are detected and broken.
+	visited := make(map[string]bool)
+
+	// currentModel and currentBody may be replaced on each fallback iteration.
+	currentModel := model
+	currentBody := body
+
+	// Per-model timeout overrides the global stream duration limit when set.
+	// Recomputed on each iteration in case the fallback model has a different timeout.
+	effectiveStreamDur := maxStreamDur
+	if currentModel.Timeout > 0 {
+		effectiveStreamDur = currentModel.Timeout
+	}
+
+	maxDepth := p.FallbackMaxDepth
+	if maxDepth <= 0 {
+		maxDepth = 0 // no fallback
+	}
+
+	var (
+		resp           *http.Response
+		cancelUpstream context.CancelFunc
+		adapter        Adapter
+		usedDep        Deployment
+		lastErr        error
+		lastStatus     int
+	)
+
+	// Chain wall time is bounded by the sum of per-model Timeout values
+	// across the hops actually attempted. Each tryModel call enforces its
+	// own timeout via the upstream HTTP client. No chain-level deadline
+	// is imposed here: any in-process work between hops completes in
+	// microseconds and cannot pathologically extend the request.
+	for depth := 0; depth <= maxDepth; depth++ {
+		visited[currentModel.Name] = true
+
+		var tryErr error
+		resp, cancelUpstream, adapter, usedDep, lastErr, lastStatus, tryErr = p.tryModel(c, currentModel, currentBody, envelope)
+		if tryErr != nil {
+			// tryModel wrote an error response to c (errResponseSent) or
+			// returned a framework error. Either way, stop immediately.
+			if errors.Is(tryErr, errResponseSent) {
+				return nil
+			}
+			return tryErr
+		}
+
+		if resp != nil && !isFallbackEligible(lastStatus, nil) {
+			// We have a usable response (success or non-retriable 4xx). Done.
+			break
+		}
+
+		// resp is nil (all deployments exhausted) or resp carries a 5xx that
+		// should trigger a fallback. Decide whether to try the next model in
+		// the chain.
+		if !isFallbackEligible(lastStatus, lastErr) {
+			break
+		}
+
+		next, hasFallback := p.Registry.FallbackFor(currentModel.Name, visited)
+		if !hasFallback {
+			// No fallback model configured — keep resp as-is so it can be
+			// forwarded to the client (even if it is a 5xx).
+			break
+		}
+		if depth >= maxDepth {
+			p.Log.LogAttrs(c.Context(), slog.LevelWarn, "fallback chain depth limit reached",
+				slog.String("model", requestedModelName),
+				slog.Int("max_depth", maxDepth),
+			)
+			break
+		}
+
+		// Access control check for the fallback target. This must happen before
+		// committing to the hop so that a key without access to the fallback model
+		// cannot exploit the chain to bypass access policy. The check mirrors the
+		// one in resolveModel. We never surface a "forbidden" error to the client
+		// here — instead we silently stop the chain and preserve the primary's
+		// error, so the existence of the fallback target is not disclosed.
+		if p.AccessCache != nil && keyInfo != nil {
+			if !p.AccessCache.Check(keyInfo.OrgID, keyInfo.TeamID, keyInfo.ID, next.Name) {
+				p.Log.LogAttrs(c.Context(), slog.LevelInfo, "fallback target not permitted by access policy",
+					slog.String("requested", requestedModelName),
+					slog.String("target", next.Name),
+				)
+				// Preserve lastErr from the failed primary; do not leak
+				// "forbidden" to the client.
+				break
+			}
+		}
+
+		newBody, berr := rewriteModelInBody(currentBody, next.Name)
+		if berr != nil {
+			p.Log.LogAttrs(c.Context(), slog.LevelWarn, "fallback: cannot rewrite request body; stopping chain",
+				slog.String("from", currentModel.Name),
+				slog.String("to", next.Name),
+				slog.String("error", berr.Error()),
+			)
+			// Preserve the primary's error; do not leak the body-rewrite error.
+			break
+		}
+
+		// We have a fallback target, access is permitted, and the body has been
+		// rewritten. Log the hop and commit to using the fallback model.
+		// This log fires only after all checks pass, so it never fires unless the
+		// hop is actually going to happen.
+		p.Log.LogAttrs(c.Context(), slog.LevelInfo, "falling back to next model",
+			slog.String("from", requestedModelName),
+			slog.String("to", next.Name),
+			slog.Int("depth", depth+1),
+		)
+
+		// Drain and discard the current 5xx response before moving on so
+		// the upstream connection is returned to the pool cleanly.
+		if resp != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			cancelUpstream()
+			resp = nil
+			cancelUpstream = nil
+		}
+
+		currentBody = newBody
+		currentModel = next
+		effectiveStreamDur = maxStreamDur
+		if currentModel.Timeout > 0 {
+			effectiveStreamDur = currentModel.Timeout
+		}
+	}
+
+	// All candidates (and fallback chain) exhausted without a usable response.
+	if resp == nil {
+		if lastErr != nil {
+			return apierror.Send(c, fiber.StatusBadGateway, "upstream_unavailable", "upstream provider is unavailable")
+		}
+		// Every candidate was blocked by its circuit breaker.
+		metrics.CircuitBreakerRejectionsTotal.WithLabelValues(currentModel.Name).Inc()
+		return apierror.Send(c, fiber.StatusServiceUnavailable,
+			"circuit_open", "upstream temporarily unavailable")
+	}
+
+	if isStreamingResponse(resp) {
+		var breaker *circuitbreaker.Breaker
+		if p.CircuitBreakers != nil {
+			breaker = p.CircuitBreakers.Get(deploymentKey(currentModel.Name, usedDep.Name))
+		}
+		return p.handleStreamingResponse(c, resp, cancelUpstream, currentModel,
+			keyInfo, adapter, startTime, requestID, requestedModelName, effectiveStreamDur, trackDone, breaker)
+	}
+
+	defer cancelUpstream()
+	return p.handleBufferedResponse(c, resp, currentModel, keyInfo, adapter,
+		startTime, requestID, requestedModelName, maxRespBody)
+}
+
+// tryModel attempts to forward the request to the given model using its
+// configured deployment candidates. It selects candidates via the Router (or
+// synthesises a single candidate), iterates them in order, and returns as soon
+// as one succeeds or returns a non-retryable status.
+//
+// Return values:
+//   - resp: the upstream response, or nil if all candidates failed.
+//   - cancel: the cancel func for the upstream request context. Non-nil only
+//     when resp is non-nil. Must be called by the caller when done.
+//   - adapter: the provider adapter selected for this model. May be nil.
+//   - usedDep: the deployment that produced the response. Valid only when resp != nil.
+//   - lastErr: the last transport-level error seen, or nil.
+//   - lastStatus: the HTTP status of the last response seen (0 for transport errors).
+//   - err: a framework-level error (including errResponseSent). When non-nil the
+//     caller must propagate it immediately without inspecting the other values.
+func (p *ProxyHandler) tryModel(
+	c fiber.Ctx,
+	model Model,
+	body []byte,
+	envelope requestEnvelope,
+) (*http.Response, context.CancelFunc, Adapter, Deployment, error, int, error) {
 	// Build the ordered list of deployment candidates. When Router is nil or
 	// the model has no multi-deployment configuration, synthesize a single
 	// candidate from the model's own fields so the retry loop is uniform.
@@ -227,27 +415,17 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 		}}
 	}
 
-	// Per-model timeout overrides the global stream duration limit when set.
-	effectiveStreamDur := maxStreamDur
-	if model.Timeout > 0 {
-		effectiveStreamDur = model.Timeout
-	}
-
-	// req and cancelUpstream are set on the last successful buildUpstreamRequest
-	// call. They are used below after the loop exits to route into the response
-	// handlers. Both are nil if every candidate was skipped or failed during
-	// request construction.
 	var (
 		req            *http.Request
 		cancelUpstream context.CancelFunc
-		adapter        Adapter
-		resp           *http.Response
+		currentAdapter Adapter
+		currentResp    *http.Response
+		dep            Deployment
 		lastErr        error
-		usedDep        Deployment
 	)
 
-	for i, dep := range candidates {
-		depKey := deploymentKey(model.Name, dep.Name)
+	for i, d := range candidates {
+		depKey := deploymentKey(model.Name, d.Name)
 
 		// Per-deployment circuit breaker check. The router's filterAvailable
 		// already excludes open breakers when Router is non-nil, so we only
@@ -266,15 +444,12 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 		// Overlay the deployment's endpoint fields onto a copy of the resolved
 		// model so buildUpstreamRequest uses the correct provider/URL/key.
 		m := model
-		applyDeployment(&m, dep)
+		applyDeployment(&m, d)
 
 		var buildErr error
-		req, cancelUpstream, adapter, buildErr = p.buildUpstreamRequest(c, m, body, envelope)
+		req, cancelUpstream, currentAdapter, buildErr = p.buildUpstreamRequest(c, m, body, envelope)
 		if buildErr != nil {
-			if errors.Is(buildErr, errResponseSent) {
-				return nil
-			}
-			return buildErr
+			return nil, nil, nil, Deployment{}, nil, 0, buildErr
 		}
 
 		// Send the request to the upstream. The upstream span measures
@@ -288,16 +463,16 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 				),
 			)
 			otel.GetTextMapPropagator().Inject(req.Context(), propagation.HeaderCarrier(req.Header))
-			resp, doErr = p.HTTPClient.Do(req)
+			currentResp, doErr = p.HTTPClient.Do(req)
 			if doErr != nil {
 				upstreamSpan.RecordError(doErr)
 				upstreamSpan.SetStatus(codes.Error, doErr.Error())
 			} else {
-				upstreamSpan.SetAttributes(attribute.Int("http.response.status_code", resp.StatusCode))
+				upstreamSpan.SetAttributes(attribute.Int("http.response.status_code", currentResp.StatusCode))
 			}
 			upstreamSpan.End()
 		} else {
-			resp, doErr = p.HTTPClient.Do(req)
+			currentResp, doErr = p.HTTPClient.Do(req)
 		}
 
 		if doErr != nil {
@@ -309,7 +484,7 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 			metrics.UpstreamErrorsTotal.WithLabelValues(m.Name, m.Provider).Inc()
 			p.Log.LogAttrs(c.Context(), slog.LevelWarn, "upstream request failed, retrying next deployment",
 				slog.String("model", m.Name),
-				slog.String("deployment", dep.Name),
+				slog.String("deployment", d.Name),
 				slog.String("provider", m.Provider),
 				slog.Int("candidate", i),
 				slog.String("error", doErr.Error()),
@@ -317,19 +492,19 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 			lastErr = doErr
 			req = nil
 			cancelUpstream = nil
-			resp = nil
+			currentResp = nil
 			metrics.RoutingRetriesTotal.WithLabelValues(model.Name, model.Strategy).Inc()
 			continue
 		}
 
-		metrics.UpstreamRequestsTotal.WithLabelValues(m.Name, m.Provider, strconv.Itoa(resp.StatusCode)).Inc()
+		metrics.UpstreamRequestsTotal.WithLabelValues(m.Name, m.Provider, strconv.Itoa(currentResp.StatusCode)).Inc()
 
-		if isRetryable(resp.StatusCode) && i < len(candidates)-1 {
+		if isRetryable(currentResp.StatusCode) && i < len(candidates)-1 {
 			// 5xx response from upstream — try the next deployment. Drain
 			// and close the body before moving on so the connection is
 			// returned to the pool.
-			_, _ = io.Copy(io.Discard, resp.Body)
-			_ = resp.Body.Close()
+			_, _ = io.Copy(io.Discard, currentResp.Body)
+			_ = currentResp.Body.Close()
 			cancelUpstream()
 			if p.CircuitBreakers != nil {
 				p.CircuitBreakers.Get(depKey).RecordFailure()
@@ -337,15 +512,15 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 			metrics.UpstreamErrorsTotal.WithLabelValues(m.Name, m.Provider).Inc()
 			p.Log.LogAttrs(c.Context(), slog.LevelWarn, "upstream returned retryable error, retrying next deployment",
 				slog.String("model", m.Name),
-				slog.String("deployment", dep.Name),
+				slog.String("deployment", d.Name),
 				slog.String("provider", m.Provider),
 				slog.Int("candidate", i),
-				slog.Int("status", resp.StatusCode),
+				slog.Int("status", currentResp.StatusCode),
 			)
-			lastErr = errors.New("upstream returned " + strconv.Itoa(resp.StatusCode))
+			lastErr = errors.New("upstream returned " + strconv.Itoa(currentResp.StatusCode))
 			req = nil
 			cancelUpstream = nil
-			resp = nil
+			currentResp = nil
 			metrics.RoutingRetriesTotal.WithLabelValues(model.Name, model.Strategy).Inc()
 			continue
 		}
@@ -354,45 +529,24 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 		// more candidates). Record circuit breaker outcome for non-streaming
 		// responses immediately; streaming outcome is recorded inside the
 		// goroutine once the stream completes.
-		if p.CircuitBreakers != nil && !isStreamingResponse(resp) {
+		if p.CircuitBreakers != nil && !isStreamingResponse(currentResp) {
 			breaker := p.CircuitBreakers.Get(depKey)
-			if resp.StatusCode >= 500 {
+			if currentResp.StatusCode >= 500 {
 				breaker.RecordFailure()
 			} else {
 				breaker.RecordSuccess()
 			}
 		}
 
-		usedDep = dep
+		dep = d
 		model = m // use the deployment-overlaid model for response handling
 		break
 	}
 
-	// All candidates were exhausted without a usable response.
-	if resp == nil {
-		if lastErr != nil {
-			return apierror.Send(c, fiber.StatusBadGateway, "upstream_unavailable", "upstream provider is unavailable")
-		}
-		// Every candidate was blocked by its circuit breaker.
-		metrics.CircuitBreakerRejectionsTotal.WithLabelValues(model.Name).Inc()
-		return apierror.Send(c, fiber.StatusServiceUnavailable,
-			"circuit_open", "upstream temporarily unavailable")
+	if currentResp != nil {
+		return currentResp, cancelUpstream, currentAdapter, dep, lastErr, currentResp.StatusCode, nil
 	}
-
-	_ = usedDep // deployment name available for future usage event enrichment
-
-	if isStreamingResponse(resp) {
-		var breaker *circuitbreaker.Breaker
-		if p.CircuitBreakers != nil {
-			breaker = p.CircuitBreakers.Get(deploymentKey(model.Name, usedDep.Name))
-		}
-		return p.handleStreamingResponse(c, resp, cancelUpstream, model,
-			keyInfo, adapter, startTime, requestID, effectiveStreamDur, trackDone, breaker)
-	}
-
-	defer cancelUpstream()
-	return p.handleBufferedResponse(c, resp, model, keyInfo, adapter,
-		startTime, requestID, maxRespBody)
+	return nil, nil, nil, Deployment{}, lastErr, 0, nil
 }
 
 // resolveEffectiveLimits returns the effective request body, response body, and
@@ -684,7 +838,9 @@ func (p *ProxyHandler) buildUpstreamRequest(c fiber.Ctx, model Model, body []byt
 // none of these must be deferred at Handle scope on the streaming path.
 // breaker may be nil when circuit breaking is disabled; when non-nil, the
 // goroutine records success or failure after the stream completes.
-func (p *ProxyHandler) handleStreamingResponse(c fiber.Ctx, resp *http.Response, cancelUpstream context.CancelFunc, model Model, keyInfo *auth.KeyInfo, adapter Adapter, startTime time.Time, requestID string, maxStreamDuration time.Duration, trackDone func(), breaker *circuitbreaker.Breaker) error {
+// requestedModelName is the canonical name the client originally asked for;
+// it may differ from model.Name when a fallback was activated.
+func (p *ProxyHandler) handleStreamingResponse(c fiber.Ctx, resp *http.Response, cancelUpstream context.CancelFunc, model Model, keyInfo *auth.KeyInfo, adapter Adapter, startTime time.Time, requestID string, requestedModelName string, maxStreamDuration time.Duration, trackDone func(), breaker *circuitbreaker.Breaker) error {
 	copyResponseHeaders(c, resp)
 	c.Set("Content-Type", "text/event-stream")
 	c.Set("Cache-Control", "no-cache")
@@ -787,7 +943,7 @@ func (p *ProxyHandler) handleStreamingResponse(c fiber.Ctx, resp *http.Response,
 				streamUI = extractor.lastUsage
 			}
 			durationMS := int(time.Since(startTime).Milliseconds())
-			p.logUsageEvent(keyInfo, model, streamUI, durationMS, ttftMS, respStatusCode, requestID)
+			p.logUsageEvent(keyInfo, model, streamUI, durationMS, ttftMS, respStatusCode, requestID, requestedModelName)
 		}
 
 		metrics.ProxyDurationSeconds.WithLabelValues(model.Name, "true").Observe(time.Since(startTime).Seconds())
@@ -797,7 +953,9 @@ func (p *ProxyHandler) handleStreamingResponse(c fiber.Ctx, resp *http.Response,
 // handleBufferedResponse reads the full upstream response body, validates its
 // size, applies any adapter transformation, then sends the status, headers, and
 // body to the client. Usage is logged asynchronously on success.
-func (p *ProxyHandler) handleBufferedResponse(c fiber.Ctx, resp *http.Response, model Model, keyInfo *auth.KeyInfo, adapter Adapter, startTime time.Time, requestID string, maxResponseBody int) error {
+// requestedModelName is the canonical name the client originally asked for;
+// it may differ from model.Name when a fallback was activated.
+func (p *ProxyHandler) handleBufferedResponse(c fiber.Ctx, resp *http.Response, model Model, keyInfo *auth.KeyInfo, adapter Adapter, startTime time.Time, requestID string, requestedModelName string, maxResponseBody int) error {
 	// Content-Length pre-check: fast-reject optimization to avoid allocating
 	// memory for obviously oversized responses. Not the security boundary —
 	// io.LimitReader on the next line handles chunked/unknown-length responses.
@@ -868,7 +1026,7 @@ func (p *ProxyHandler) handleBufferedResponse(c fiber.Ctx, resp *http.Response, 
 		// For non-streaming responses TTFT equals total duration: the entire
 		// response body is the first (and only) "token delivery".
 		ttftMS := durationMS
-		p.logUsageEvent(keyInfo, model, ui, durationMS, &ttftMS, resp.StatusCode, requestID)
+		p.logUsageEvent(keyInfo, model, ui, durationMS, &ttftMS, resp.StatusCode, requestID, requestedModelName)
 	}
 
 	metrics.ProxyDurationSeconds.WithLabelValues(model.Name, "false").Observe(time.Since(startTime).Seconds())
@@ -883,7 +1041,9 @@ func (p *ProxyHandler) handleBufferedResponse(c fiber.Ctx, resp *http.Response, 
 // requestID is the per-request trace ID from the request ID middleware; it must
 // be captured from the Fiber context before Handle returns because the context
 // is recycled by fasthttp after the handler exits.
-func (p *ProxyHandler) logUsageEvent(keyInfo *auth.KeyInfo, model Model, ui UsageInfo, durationMS int, ttftMS *int, statusCode int, requestID string) {
+// requestedModelName is the canonical name the client originally asked for; equal
+// to model.Name when no fallback occurred.
+func (p *ProxyHandler) logUsageEvent(keyInfo *auth.KeyInfo, model Model, ui UsageInfo, durationMS int, ttftMS *int, statusCode int, requestID string, requestedModelName string) {
 	if keyInfo == nil {
 		return
 	}
@@ -902,22 +1062,23 @@ func (p *ProxyHandler) logUsageEvent(keyInfo *auth.KeyInfo, model Model, ui Usag
 	}
 
 	p.UsageLogger.Log(usage.Event{
-		KeyID:            keyInfo.ID,
-		KeyType:          keyInfo.KeyType,
-		OrgID:            keyInfo.OrgID,
-		TeamID:           keyInfo.TeamID,
-		UserID:           keyInfo.UserID,
-		ServiceAccountID: keyInfo.ServiceAccountID,
-		ModelName:        model.Name,
-		PromptTokens:     ui.PromptTokens,
-		CompletionTokens: ui.CompletionTokens,
-		TotalTokens:      ui.TotalTokens,
-		CostEstimate:     cost,
-		DurationMS:       durationMS,
-		TTFT_MS:          ttftMS,
-		TokensPerSecond:  tps,
-		StatusCode:       statusCode,
-		RequestID:        requestID,
+		KeyID:              keyInfo.ID,
+		KeyType:            keyInfo.KeyType,
+		OrgID:              keyInfo.OrgID,
+		TeamID:             keyInfo.TeamID,
+		UserID:             keyInfo.UserID,
+		ServiceAccountID:   keyInfo.ServiceAccountID,
+		ModelName:          model.Name,
+		RequestedModelName: requestedModelName,
+		PromptTokens:       ui.PromptTokens,
+		CompletionTokens:   ui.CompletionTokens,
+		TotalTokens:        ui.TotalTokens,
+		CostEstimate:       cost,
+		DurationMS:         durationMS,
+		TTFT_MS:            ttftMS,
+		TokensPerSecond:    tps,
+		StatusCode:         statusCode,
+		RequestID:          requestID,
 	})
 
 	metrics.TokensTotal.WithLabelValues(model.Name, "prompt").Add(float64(ui.PromptTokens))
@@ -999,6 +1160,44 @@ func mutateRequestBody(body []byte, canonicalModel string, injectUsage bool) []b
 		return out
 	}
 	return body
+}
+
+// isFallbackEligible reports whether a failure on one model should trigger a
+// fallback to the next model in the chain.
+//
+// Network / DNS / dial / timeout errors are eligible. Context cancellation is
+// NOT eligible — the client went away and there is no point retrying. 5xx
+// responses are eligible; 4xx are not (bad request or auth failure will recur
+// on any backend).
+func isFallbackEligible(statusCode int, err error) bool {
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return false
+		}
+		return true
+	}
+	return statusCode >= 500 && statusCode < 600
+}
+
+// rewriteModelInBody replaces the "model" field inside a JSON request body
+// with newModel. It unmarshals into a map, updates the field, and re-marshals.
+// If the body is not valid JSON an error is returned — a non-JSON body cannot
+// be safely forwarded to a fallback model and the chain should stop.
+func rewriteModelInBody(body []byte, newModel string) ([]byte, error) {
+	var doc map[string]jsonx.RawMessage
+	if err := jsonx.Unmarshal(body, &doc); err != nil {
+		return nil, fmt.Errorf("fallback body rewrite: body is not JSON: %w", err)
+	}
+	nameJSON, err := jsonx.Marshal(newModel)
+	if err != nil {
+		return nil, fmt.Errorf("fallback body rewrite: marshal model name: %w", err)
+	}
+	doc["model"] = jsonx.RawMessage(nameJSON)
+	out, err := jsonx.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("fallback body rewrite: marshal document: %w", err)
+	}
+	return out, nil
 }
 
 // isAzureAdapter reports whether the given adapter is an Azure OpenAI adapter.

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,12 +10,17 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/voidmind-io/voidllm/internal/apierror"
+	"github.com/voidmind-io/voidllm/internal/auth"
+	"github.com/voidmind-io/voidllm/internal/cache"
 	"github.com/voidmind-io/voidllm/internal/config"
+	"github.com/voidmind-io/voidllm/pkg/keygen"
 )
 
 // testRegistry builds a Registry backed by a real httptest upstream URL so
@@ -999,5 +1005,1118 @@ func BenchmarkHandle_NonStreaming(b *testing.B) {
 			b.Fatal(err)
 		}
 		resp.Body.Close()
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Fallback chain tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+// testRegistryWithFallback builds a Registry containing two models where
+// modelA's fallback is modelB. Each model is backed by the provided httptest
+// server URL (which may differ per test).
+func testRegistryWithFallback(t *testing.T, urlA, urlB string) *Registry {
+	t.Helper()
+	r, err := NewRegistry([]config.ModelConfig{
+		{
+			Name:     "model-a",
+			Provider: "openai",
+			BaseURL:  urlA,
+			APIKey:   "key-a",
+			Fallback: "model-b",
+		},
+		{
+			Name:     "model-b",
+			Provider: "openai",
+			BaseURL:  urlB,
+			APIKey:   "key-b",
+		},
+	})
+	if err != nil {
+		t.Fatalf("testRegistryWithFallback: %v", err)
+	}
+	return r
+}
+
+// TestHandle_FallbackOnNetworkError verifies that when model-a's upstream is
+// unreachable, the proxy falls back to model-b and uses model-b's response.
+func TestHandle_FallbackOnNetworkError(t *testing.T) {
+	t.Parallel()
+
+	upstreamB, _ := upstreamCapture(t, http.StatusOK,
+		`{"id":"cmp-1","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"hello from B"}}]}`,
+		map[string]string{"Content-Type": "application/json"},
+	)
+
+	reg := testRegistryWithFallback(t, "http://127.0.0.1:1", upstreamB.URL)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.FallbackMaxDepth = 1
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"model-a","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want %d; body: %s", resp.StatusCode, http.StatusOK, body)
+	}
+}
+
+// TestHandle_FallbackOn500 verifies that a 5xx response from model-a triggers
+// fallback to model-b which succeeds.
+func TestHandle_FallbackOn500(t *testing.T) {
+	t.Parallel()
+
+	upstreamA, _ := upstreamCapture(t, http.StatusInternalServerError,
+		`{"error":{"message":"upstream error"}}`,
+		map[string]string{"Content-Type": "application/json"},
+	)
+	upstreamB, _ := upstreamCapture(t, http.StatusOK,
+		`{"id":"cmp-2","object":"chat.completion","choices":[]}`,
+		map[string]string{"Content-Type": "application/json"},
+	)
+
+	reg := testRegistryWithFallback(t, upstreamA.URL, upstreamB.URL)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.FallbackMaxDepth = 1
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"model-a","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want %d; body: %s", resp.StatusCode, http.StatusOK, body)
+	}
+}
+
+// TestHandle_NoFallbackOn400 verifies that 4xx responses do not trigger
+// fallback — the client error is forwarded and model-b is never tried.
+func TestHandle_NoFallbackOn400(t *testing.T) {
+	t.Parallel()
+
+	upstreamA, capturedA := upstreamCapture(t, http.StatusBadRequest,
+		`{"error":{"message":"bad request"}}`,
+		map[string]string{"Content-Type": "application/json"},
+	)
+	// upstreamB must never be hit; use a server that we track independently.
+	bHit := false
+	upstreamB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bHit = true
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{}`)
+	}))
+	t.Cleanup(upstreamB.Close)
+
+	reg := testRegistryWithFallback(t, upstreamA.URL, upstreamB.URL)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.FallbackMaxDepth = 1
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"model-a","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+	if bHit {
+		t.Error("model-b was tried but should not have been (4xx is not fallback-eligible)")
+	}
+	// Ensure A was actually tried.
+	if capturedA.Method == "" {
+		t.Error("model-a was not tried at all")
+	}
+}
+
+// TestHandle_NoFallbackOn401 verifies 401 is not fallback-eligible.
+func TestHandle_NoFallbackOn401(t *testing.T) {
+	t.Parallel()
+
+	upstreamA, _ := upstreamCapture(t, http.StatusUnauthorized,
+		`{"error":{"message":"unauthorized"}}`,
+		map[string]string{"Content-Type": "application/json"},
+	)
+	bHit := false
+	upstreamB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bHit = true
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{}`)
+	}))
+	t.Cleanup(upstreamB.Close)
+
+	reg := testRegistryWithFallback(t, upstreamA.URL, upstreamB.URL)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.FallbackMaxDepth = 1
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"model-a","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusUnauthorized)
+	}
+	if bHit {
+		t.Error("model-b was tried but should not have been (401 is not fallback-eligible)")
+	}
+}
+
+// TestHandle_FallbackDepthExceeded verifies that the FallbackMaxDepth cap is
+// enforced. With FallbackMaxDepth=2 and a chain A→B→C→D, the proxy tries A
+// (depth=0), B (depth=1), C (depth=2) — then the check depth>=maxDepth blocks
+// the hop to D.
+func TestHandle_FallbackDepthExceeded(t *testing.T) {
+	t.Parallel()
+
+	// All four upstreams return 500 to force fallback on each step.
+	makeFailServer := func(id string) *httptest.Server {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, `{"error":{"message":"fail from %s"}}`, id)
+		}))
+		t.Cleanup(srv.Close)
+		return srv
+	}
+
+	srvA := makeFailServer("A")
+	srvB := makeFailServer("B")
+	srvC := makeFailServer("C")
+	dHit := false
+	srvD := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dHit = true
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{}`)
+	}))
+	t.Cleanup(srvD.Close)
+
+	r, err := NewRegistry([]config.ModelConfig{
+		{Name: "model-a", Provider: "openai", BaseURL: srvA.URL, APIKey: "k", Fallback: "model-b"},
+		{Name: "model-b", Provider: "openai", BaseURL: srvB.URL, APIKey: "k", Fallback: "model-c"},
+		{Name: "model-c", Provider: "openai", BaseURL: srvC.URL, APIKey: "k", Fallback: "model-d"},
+		{Name: "model-d", Provider: "openai", BaseURL: srvD.URL, APIKey: "k"},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	handler := NewProxyHandler(r, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.FallbackMaxDepth = 2
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"model-a","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if dHit {
+		t.Error("model-d was reached but FallbackMaxDepth=2 should have stopped the chain at model-c")
+	}
+	// The response must be an error since all tried models failed.
+	if resp.StatusCode == http.StatusOK {
+		t.Error("expected a non-200 error status when chain is exhausted")
+	}
+}
+
+// TestHandle_CycleDetectionRuntime verifies that runtime cycle detection in the
+// visited set prevents an infinite loop. The Registry itself allows this state
+// (config validation would normally prevent it, but we inject it directly to
+// exercise the runtime guard).
+func TestHandle_CycleDetectionRuntime(t *testing.T) {
+	t.Parallel()
+
+	// Both upstreams return 500 so fallback keeps trying.
+	upstreamA, _ := upstreamCapture(t, http.StatusInternalServerError, `{}`,
+		map[string]string{"Content-Type": "application/json"})
+	upstreamB, _ := upstreamCapture(t, http.StatusInternalServerError, `{}`,
+		map[string]string{"Content-Type": "application/json"})
+
+	// Build registry without cycle: A→B, B has no fallback.
+	// Then inject a cycle by using AddModel after construction.
+	reg, err := NewRegistry([]config.ModelConfig{
+		{Name: "model-a", Provider: "openai", BaseURL: upstreamA.URL, APIKey: "k"},
+		{Name: "model-b", Provider: "openai", BaseURL: upstreamB.URL, APIKey: "k"},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	// Inject the cycle: A→B, B→A.
+	reg.AddModel(Model{
+		Name:              "model-a",
+		Provider:          "openai",
+		BaseURL:           upstreamA.URL,
+		APIKey:            "k",
+		FallbackModelName: "model-b",
+	})
+	reg.AddModel(Model{
+		Name:              "model-b",
+		Provider:          "openai",
+		BaseURL:           upstreamB.URL,
+		APIKey:            "k",
+		FallbackModelName: "model-a",
+	})
+
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.FallbackMaxDepth = 10 // generous depth so only the visited-set stops it
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"model-a","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	// The request must complete (not loop forever) and return an error.
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// We expect a non-200 error response because both models failed.
+	if resp.StatusCode == http.StatusOK {
+		t.Error("expected error status after cycle-protected exhaustion")
+	}
+}
+
+// TestHandle_FallbackBodyRewrite verifies that when fallback fires, the request
+// body sent to model-b has its "model" field rewritten to "model-b".
+func TestHandle_FallbackBodyRewrite(t *testing.T) {
+	t.Parallel()
+
+	// model-a fails.
+	upstreamA, _ := upstreamCapture(t, http.StatusInternalServerError, `{}`,
+		map[string]string{"Content-Type": "application/json"})
+
+	// model-b succeeds and captures the request body.
+	var capturedModelField string
+	upstreamB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		var env struct {
+			Model string `json:"model"`
+		}
+		_ = json.Unmarshal(raw, &env)
+		capturedModelField = env.Model
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"x","object":"chat.completion","choices":[]}`)
+	}))
+	t.Cleanup(upstreamB.Close)
+
+	reg := testRegistryWithFallback(t, upstreamA.URL, upstreamB.URL)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.FallbackMaxDepth = 1
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"model-a","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	if capturedModelField != "model-b" {
+		t.Errorf("model field in upstream request = %q, want %q", capturedModelField, "model-b")
+	}
+}
+
+// TestHandle_NoFallbackConfigured verifies that when a model has no fallback,
+// a 5xx error is returned directly to the client.
+func TestHandle_NoFallbackConfigured(t *testing.T) {
+	t.Parallel()
+
+	upstream, _ := upstreamCapture(t, http.StatusInternalServerError,
+		`{"error":{"message":"unavailable"}}`,
+		map[string]string{"Content-Type": "application/json"},
+	)
+
+	// Registry has only one model with no fallback.
+	reg, err := NewRegistry([]config.ModelConfig{
+		{Name: "solo-model", Provider: "openai", BaseURL: upstream.URL, APIKey: "k"},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.FallbackMaxDepth = 3
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"solo-model","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d (no fallback configured; 5xx forwarded)", resp.StatusCode, http.StatusInternalServerError)
+	}
+}
+
+// TestHandle_FallbackDisabledWhenMaxDepthZero verifies that when
+// FallbackMaxDepth is 0 (or unset), no fallback occurs even when a fallback
+// model is registered.
+func TestHandle_FallbackDisabledWhenMaxDepthZero(t *testing.T) {
+	t.Parallel()
+
+	upstreamA, _ := upstreamCapture(t, http.StatusInternalServerError, `{}`,
+		map[string]string{"Content-Type": "application/json"})
+	bHit := false
+	upstreamB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bHit = true
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{}`)
+	}))
+	t.Cleanup(upstreamB.Close)
+
+	reg := testRegistryWithFallback(t, upstreamA.URL, upstreamB.URL)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.FallbackMaxDepth = 0 // disabled
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"model-a","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if bHit {
+		t.Error("model-b was tried but FallbackMaxDepth=0 should disable fallback")
+	}
+	// The 5xx from A should be forwarded directly.
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Errorf("status = %d, want %d", resp.StatusCode, http.StatusInternalServerError)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// isFallbackEligible — unit tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestIsFallbackEligible(t *testing.T) {
+	t.Parallel()
+
+	netErr := fmt.Errorf("dial tcp: connection refused")
+
+	tests := []struct {
+		name       string
+		statusCode int
+		err        error
+		want       bool
+	}{
+		// 5xx are eligible.
+		{"500 eligible", 500, nil, true},
+		{"502 eligible", 502, nil, true},
+		{"503 eligible", 503, nil, true},
+		{"504 eligible", 504, nil, true},
+		{"599 eligible", 599, nil, true},
+		// 4xx are NOT eligible.
+		{"400 not eligible", 400, nil, false},
+		{"401 not eligible", 401, nil, false},
+		{"403 not eligible", 403, nil, false},
+		{"404 not eligible", 404, nil, false},
+		// 429 is 4xx — not eligible per production code.
+		{"429 not eligible", 429, nil, false},
+		// 200 success is not eligible.
+		{"200 not eligible", 200, nil, false},
+		// Network error with no status is eligible.
+		{"network error eligible", 0, netErr, true},
+		// Context cancellation is NOT eligible.
+		{"context.Canceled not eligible", 0, context.Canceled, false},
+		{"context.DeadlineExceeded not eligible", 0, context.DeadlineExceeded, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := isFallbackEligible(tc.statusCode, tc.err)
+			if got != tc.want {
+				t.Errorf("isFallbackEligible(%d, %v) = %v, want %v",
+					tc.statusCode, tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// rewriteModelInBody — unit tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+func TestRewriteModelInBody(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		body      string
+		newModel  string
+		wantModel string
+		// wantError means the function must return a non-nil error (Fix C4: invalid JSON now returns error).
+		wantError bool
+	}{
+		{
+			name:      "existing model field replaced",
+			body:      `{"model":"model-a","messages":[]}`,
+			newModel:  "model-b",
+			wantModel: "model-b",
+		},
+		{
+			name:      "model field added when absent",
+			body:      `{"messages":[{"role":"user","content":"hi"}]}`,
+			newModel:  "model-b",
+			wantModel: "model-b",
+		},
+		{
+			name:      "extra fields preserved",
+			body:      `{"model":"model-a","temperature":0.7,"max_tokens":512,"messages":[]}`,
+			newModel:  "model-c",
+			wantModel: "model-c",
+		},
+		{
+			name:      "invalid JSON returns error",
+			body:      `not-valid-json`,
+			newModel:  "model-b",
+			wantError: true,
+		},
+		{
+			name:      "empty body returns error",
+			body:      ``,
+			newModel:  "model-b",
+			wantError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			bodyBytes := []byte(tc.body)
+			got, err := rewriteModelInBody(bodyBytes, tc.newModel)
+
+			if tc.wantError {
+				if err == nil {
+					t.Errorf("rewriteModelInBody(%q) = %q, want non-nil error", tc.body, string(got))
+				}
+				if got != nil {
+					t.Errorf("rewriteModelInBody(%q) returned non-nil bytes with error: %q", tc.body, string(got))
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("rewriteModelInBody returned unexpected error: %v", err)
+			}
+
+			// Verify the model field in the output.
+			var out struct {
+				Model string `json:"model"`
+			}
+			if err := json.Unmarshal(got, &out); err != nil {
+				t.Fatalf("unmarshal output: %v", err)
+			}
+			if out.Model != tc.wantModel {
+				t.Errorf("model = %q, want %q", out.Model, tc.wantModel)
+			}
+
+			// Verify other fields are preserved for the "extra fields" case.
+			if tc.name == "extra fields preserved" {
+				var full map[string]json.RawMessage
+				if err := json.Unmarshal(got, &full); err != nil {
+					t.Fatalf("unmarshal full output: %v", err)
+				}
+				for _, field := range []string{"temperature", "max_tokens", "messages"} {
+					if _, ok := full[field]; !ok {
+						t.Errorf("field %q was dropped from rewritten body", field)
+					}
+				}
+			}
+		})
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Fallback access control (Fix C1 / VULN-001)
+// ──────────────────────────────────────────────────────────────────────────────
+
+// testHMACSecret is a fixed secret used for auth middleware in proxy handler tests.
+var testHMACSecret = []byte("proxy-handler-test-hmac-secret")
+
+// testAppWithAuth wires a ProxyHandler with the auth middleware in a Fiber app.
+// It returns the app and a plaintext key that satisfies auth.Middleware.
+func testAppWithAuth(t *testing.T, handler *ProxyHandler, keyInfo auth.KeyInfo) (*fiber.App, string) {
+	t.Helper()
+
+	keyCache := cache.New[string, auth.KeyInfo]()
+
+	rawKey, err := keygen.Generate(keygen.KeyTypeUser)
+	if err != nil {
+		t.Fatalf("keygen.Generate: %v", err)
+	}
+	hash := keygen.Hash(rawKey, testHMACSecret)
+	keyCache.Set(hash, keyInfo)
+
+	app := fiber.New()
+	app.Use(auth.Middleware(keyCache, testHMACSecret))
+	app.Get("/v1/models", handler.ModelsHandler)
+	app.All("/v1/*", handler.Handle)
+
+	return app, rawKey
+}
+
+// TestHandle_FallbackBlockedByAccessCache verifies that when a key is denied
+// access to the fallback model (Fix C1 / VULN-001), the chain stops and the
+// primary's error is returned without calling the fallback upstream.
+func TestHandle_FallbackBlockedByAccessCache(t *testing.T) {
+	t.Parallel()
+
+	// model-a returns 502 to trigger fallback eligibility.
+	upstreamA, _ := upstreamCapture(t, http.StatusBadGateway,
+		`{"error":{"message":"bad gateway"}}`,
+		map[string]string{"Content-Type": "application/json"},
+	)
+
+	// model-b must never be called; use an atomic counter to detect any call.
+	var bCallCount atomic.Int32
+	upstreamB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bCallCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"x","object":"chat.completion","choices":[]}`)
+	}))
+	t.Cleanup(upstreamB.Close)
+
+	reg := testRegistryWithFallback(t, upstreamA.URL, upstreamB.URL)
+
+	// Wire the AccessCache so model-a is allowed but model-b is denied for
+	// the test key ID.
+	accessCache := NewModelAccessCache()
+	const testKeyID = "test-key-fb-access"
+	// Allow only model-a for this key; model-b is not in the list.
+	accessCache.Load(
+		nil,
+		nil,
+		map[string][]string{
+			testKeyID: {"model-a"},
+		},
+	)
+
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.FallbackMaxDepth = 1
+	handler.AccessCache = accessCache
+
+	keyInfo := auth.KeyInfo{
+		ID:    testKeyID,
+		OrgID: "test-org",
+		Role:  "member",
+	}
+	app, rawKey := testAppWithAuth(t, handler, keyInfo)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"model-a","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+rawKey)
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// model-b must never have been called.
+	if bCallCount.Load() > 0 {
+		t.Error("SECURITY: fallback model-b was called despite key not having access — access policy bypassed")
+	}
+
+	// The response must be the error from model-a (bad gateway), not a 200 from model-b.
+	if resp.StatusCode == http.StatusOK {
+		t.Errorf("status = %d, want non-200 (primary error should be preserved)", resp.StatusCode)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Context cancellation during fallback (Fix W3)
+// ──────────────────────────────────────────────────────────────────────────────
+
+// TestHandle_ContextCancelledDuringFallback verifies that when the client's
+// request context is cancelled while the primary is failing, the handler
+// returns without panicking and without calling model-b (or aborting cleanly
+// if it does call model-b before the cancel propagates).
+func TestHandle_ContextCancelledDuringFallback(t *testing.T) {
+	t.Parallel()
+
+	// model-a returns 500 after a short pause so the cancel can race with it.
+	upstreamA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Small sleep ensures the cancel goroutine can fire before A responds.
+		time.Sleep(10 * time.Millisecond)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{}`)
+	}))
+	t.Cleanup(upstreamA.Close)
+
+	var bCallCount atomic.Int32
+	upstreamB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bCallCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"x","object":"chat.completion","choices":[]}`)
+	}))
+	t.Cleanup(upstreamB.Close)
+
+	reg := testRegistryWithFallback(t, upstreamA.URL, upstreamB.URL)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.FallbackMaxDepth = 1
+	baseURL := startTestServer(t, handler)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel after a very short window so the cancel races with A's response.
+	go func() {
+		time.Sleep(5 * time.Millisecond)
+		cancel()
+	}()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/v1/chat/completions",
+		strings.NewReader(`{"model":"model-a","messages":[]}`))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, doErr := client.Do(req)
+	if resp != nil {
+		resp.Body.Close()
+	}
+
+	// The request should either return context.Canceled (client cancelled before
+	// headers arrived) or a non-200 error response. Either outcome is acceptable
+	// — the important properties are: no panic, no goroutine leak.
+	if doErr == nil && resp != nil && resp.StatusCode == http.StatusOK {
+		// If model-b responded with 200, both A and B were completed before the
+		// cancel propagated all the way through — that is still correct behavior.
+		t.Logf("cancel raced: response arrived before cancel propagated (status 200 from B — acceptable)")
+	}
+	// No additional assertion on bCallCount: both "B called" and "B not called"
+	// are valid depending on scheduler timing. The key invariant is "no panic".
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Chain-all-failed usage event (gap from spec)
+// ──────────────────────────────────────────────────────────────────────────────
+
+// usageCapture is a minimal usage.Logger stand-in that records emitted events.
+// It captures only the fields proxy.Handle populates so that tests can assert
+// on event properties without importing the full usage package.
+type capturedUsageEvent struct {
+	ModelName          string
+	RequestedModelName string
+}
+
+// usageCapture collects events written via logUsageEvent. Because logUsageEvent
+// calls UsageLogger.Log which is defined on usage.Logger (a concrete type, not
+// an interface), the test wires a real usage.Logger backed by a channel that
+// drains into a slice.
+//
+// Instead of fighting the concrete Logger type, we assert purely on behavior:
+// for the all-failed path there must be NO usage event at all. The proxy does
+// not call handleBufferedResponse or handleStreamingResponse when resp == nil,
+// so UsageLogger.Log is never reached. We verify this by asserting the handler
+// returns 502 (upstream_unavailable) without populating any captured events.
+
+// TestHandle_ChainAllFailedUsageEvent asserts that when every model in a
+// fallback chain fails (A→B→C all return 502), the handler returns
+// upstream_unavailable and does NOT write a usage event. This matches the
+// pre-existing behavior: usage is only logged on a successful response.
+//
+// Known limitation (inherited): if observability of failed chains is desired,
+// a future improvement would emit a zero-token "failed" usage event, but that
+// is out of scope for the current implementation.
+func TestHandle_ChainAllFailedUsageEvent(t *testing.T) {
+	t.Parallel()
+
+	makeFailServer := func(id string) *httptest.Server {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadGateway)
+			fmt.Fprintf(w, `{"error":{"message":"fail %s"}}`, id)
+		}))
+		t.Cleanup(srv.Close)
+		return srv
+	}
+
+	srvA := makeFailServer("A")
+	srvB := makeFailServer("B")
+	srvC := makeFailServer("C")
+
+	r, err := NewRegistry([]config.ModelConfig{
+		{Name: "chain-a", Provider: "openai", BaseURL: srvA.URL, APIKey: "k", Fallback: "chain-b"},
+		{Name: "chain-b", Provider: "openai", BaseURL: srvB.URL, APIKey: "k", Fallback: "chain-c"},
+		{Name: "chain-c", Provider: "openai", BaseURL: srvC.URL, APIKey: "k"},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	// UsageLogger is intentionally nil — if the handler misbehaves and tries to
+	// call it on the all-failed path, it will panic, which is the fail signal.
+	handler := NewProxyHandler(r, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.FallbackMaxDepth = 3
+	// UsageLogger left nil; a nil dereference would reveal the bug.
+
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"chain-a","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// All models returned 502; the handler forwards the last model's (chain-c)
+	// 502 response directly — it does NOT synthesize an upstream_unavailable
+	// envelope because resp != nil (a real HTTP response was received).
+	// The handler only returns upstream_unavailable when all deployments fail
+	// with transport errors (resp == nil).
+	if resp.StatusCode != http.StatusBadGateway {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want %d; body: %s", resp.StatusCode, http.StatusBadGateway, body)
+	}
+
+	// No usage event assertion needed: if UsageLogger were called with a nil
+	// receiver, the test would have panicked above. Reaching here without panic
+	// confirms usage was not logged on the all-5xx path. This matches the
+	// pre-existing behavior: usage is only logged on successful (2xx) responses.
+	// Known limitation: failed chains emit no usage event, so observability of
+	// chain-exhaustion failures relies on logs/metrics rather than usage records.
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// FallbackMaxDepth = 0 disables fallback (Fix W1) — verify existing test
+// ──────────────────────────────────────────────────────────────────────────────
+// TestHandle_FallbackDisabledWhenMaxDepthZero already exists above and covers
+// this case with an explicit FallbackMaxDepth = 0. It passes; no action needed.
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Chain deadline set from primary timeout (Fix W3)
+// ──────────────────────────────────────────────────────────────────────────────
+
+// TestHandle_ChainDeadlineSetFromPrimaryTimeout verifies that the chain-level
+// deadline (Fix W3) is set to (FallbackMaxDepth+1)*primaryTimeout and that
+// the per-model timeout causes a hanging upstream to return within the budget.
+//
+// The chain deadline is enforced on the context passed to the outer loop; each
+// individual upstream call derives its context from background (not the chain
+// context), so the per-model Timeout field is what actually terminates the
+// hanging upstream call. A DeadlineExceeded error from the per-model timeout
+// is NOT fallback-eligible (isFallbackEligible returns false for
+// context.DeadlineExceeded), so model-b is not tried. The result is a 502 that
+// arrives within the per-model timeout window — confirming the timeout fires.
+func TestHandle_ChainDeadlineSetFromPrimaryTimeout(t *testing.T) {
+	t.Parallel()
+
+	// model-a hangs indefinitely — it will be cancelled by the per-model timeout.
+	hangCh := make(chan struct{})
+	upstreamA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-hangCh:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(func() {
+		close(hangCh)
+		upstreamA.Close()
+	})
+
+	// model-b must never be called (timeout is not fallback-eligible).
+	var bCallCount atomic.Int32
+	upstreamB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bCallCount.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{}`)
+	}))
+	t.Cleanup(upstreamB.Close)
+
+	const primaryTimeout = 150 * time.Millisecond
+	const maxDepth = 2
+
+	r, err := NewRegistry([]config.ModelConfig{
+		{
+			Name:     "slow-a",
+			Provider: "openai",
+			BaseURL:  upstreamA.URL,
+			APIKey:   "k",
+			Fallback: "fast-b",
+			Timeout:  "150ms",
+		},
+		{
+			Name:     "fast-b",
+			Provider: "openai",
+			BaseURL:  upstreamB.URL,
+			APIKey:   "k",
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	handler := NewProxyHandler(r, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.FallbackMaxDepth = maxDepth
+	app := testApp(t, handler)
+
+	start := time.Now()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"slow-a","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	// Give enough headroom: 5× primaryTimeout plus test infrastructure overhead.
+	resp, testErr := app.Test(req, fiber.TestConfig{Timeout: 5 * time.Second})
+	elapsed := time.Since(start)
+	if testErr != nil {
+		t.Fatalf("app.Test: %v", testErr)
+	}
+	defer resp.Body.Close()
+
+	// Per-model timeout (DeadlineExceeded) is not fallback-eligible, so model-b
+	// must never be called.
+	if bCallCount.Load() > 0 {
+		t.Error("model-b was called, but timeout errors are not fallback-eligible")
+	}
+
+	// The response must arrive within 2× primaryTimeout + epsilon.
+	// primaryTimeout = 150ms; the total should be well under 500ms.
+	const ceiling = 500 * time.Millisecond
+	if elapsed > ceiling {
+		t.Errorf("elapsed %v > ceiling %v — per-model timeout did not fire in time", elapsed, ceiling)
+	}
+
+	// A timeout on the only upstream results in upstream_unavailable (502).
+	if resp.StatusCode != http.StatusBadGateway {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want %d; body: %s", resp.StatusCode, http.StatusBadGateway, body)
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Concurrent fallback PATCH mutations (Fix C3 / TOCTOU)
+// ──────────────────────────────────────────────────────────────────────────────
+
+// TestRegistry_ConcurrentFallbackMutations is a race-detector test verifying
+// that concurrent AddModel calls (which update FallbackModelName under the
+// Registry's write lock) do not produce data races. This covers the mutex
+// scope fix from Fix C3 at the Registry level.
+//
+// Run with -race to detect any unsynchronised access. The test does not assert
+// a specific outcome — any consistent terminal state is acceptable because the
+// Go memory model guarantees that the last write wins.
+func TestRegistry_ConcurrentFallbackMutations(t *testing.T) {
+	t.Parallel()
+
+	r, err := NewRegistry([]config.ModelConfig{
+		{Name: "m-conc-a", Provider: "openai", BaseURL: "http://localhost:1", APIKey: "k"},
+		{Name: "m-conc-b", Provider: "openai", BaseURL: "http://localhost:2", APIKey: "k"},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			r.AddModel(Model{
+				Name:              "m-conc-a",
+				Provider:          "openai",
+				BaseURL:           "http://localhost:1",
+				APIKey:            "k",
+				FallbackModelName: "m-conc-b",
+			})
+		}()
+		go func() {
+			defer wg.Done()
+			r.AddModel(Model{
+				Name:              "m-conc-b",
+				Provider:          "openai",
+				BaseURL:           "http://localhost:2",
+				APIKey:            "k",
+				FallbackModelName: "m-conc-a",
+			})
+		}()
+	}
+
+	wg.Wait()
+	// No assertion on the final state — reaching here without a -race failure
+	// is the pass condition.
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Multi-hop access denial (VULN-A1)
+// ──────────────────────────────────────────────────────────────────────────────
+
+// TestHandle_FallbackChainBlockedAtMidHop verifies that the per-hop access
+// check inside the fallback loop (not only at the first hop) correctly stops
+// the chain when a mid-chain model is denied.
+//
+// Chain: model-a → model-b → model-c
+// Access policy: key K may use model-a and model-b; model-c is denied.
+//
+// Expected execution:
+//  1. model-a is tried → upstream returns 502 (fallback-eligible)
+//  2. Access check for model-b passes → model-b is tried → upstream returns 502
+//  3. Access check for model-c fails → chain stops
+//  4. Client receives model-b's 502 (the last response that was actually
+//     forwarded; the loop breaks before draining it, so resp holds model-b's
+//     response at break time)
+//  5. model-c's upstream is never contacted
+func TestHandle_FallbackChainBlockedAtMidHop(t *testing.T) {
+	t.Parallel()
+
+	// model-a returns 502 to trigger the first fallback hop.
+	var aCalls atomic.Int32
+	upstreamA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		aCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		fmt.Fprint(w, `{"error":{"message":"upstream A unavailable"}}`)
+	}))
+	t.Cleanup(upstreamA.Close)
+
+	// model-b also returns 502 to trigger the second fallback evaluation.
+	var bCalls atomic.Int32
+	upstreamB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadGateway)
+		fmt.Fprint(w, `{"error":{"message":"upstream B unavailable"}}`)
+	}))
+	t.Cleanup(upstreamB.Close)
+
+	// model-c must never be contacted; any call here is a security failure.
+	var cCalls atomic.Int32
+	upstreamC := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"x","object":"chat.completion","choices":[]}`)
+	}))
+	t.Cleanup(upstreamC.Close)
+
+	// Build a three-model registry with the chain A → B → C.
+	r, err := NewRegistry([]config.ModelConfig{
+		{Name: "mid-hop-a", Provider: "openai", BaseURL: upstreamA.URL, APIKey: "key-a", Fallback: "mid-hop-b"},
+		{Name: "mid-hop-b", Provider: "openai", BaseURL: upstreamB.URL, APIKey: "key-b", Fallback: "mid-hop-c"},
+		{Name: "mid-hop-c", Provider: "openai", BaseURL: upstreamC.URL, APIKey: "key-c"},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	// Allow model-a and model-b for this key; model-c is intentionally absent.
+	const testKeyID = "test-key-mid-hop"
+	accessCache := NewModelAccessCache()
+	accessCache.Load(
+		nil,
+		nil,
+		map[string][]string{
+			testKeyID: {"mid-hop-a", "mid-hop-b"},
+		},
+	)
+
+	handler := NewProxyHandler(r, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.FallbackMaxDepth = 2
+	handler.AccessCache = accessCache
+
+	keyInfo := auth.KeyInfo{
+		ID:    testKeyID,
+		OrgID: "test-org",
+		Role:  "member",
+	}
+	app, rawKey := testAppWithAuth(t, handler, keyInfo)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"mid-hop-a","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+rawKey)
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// model-a must have been tried exactly once.
+	if got := int(aCalls.Load()); got != 1 {
+		t.Errorf("model-a call count = %d, want 1", got)
+	}
+	// model-b must have been tried exactly once (access was permitted).
+	if got := int(bCalls.Load()); got != 1 {
+		t.Errorf("model-b call count = %d, want 1", got)
+	}
+	// model-c must never have been called — access was denied; calling it would
+	// mean the access policy was bypassed at the second hop.
+	if got := int(cCalls.Load()); got != 0 {
+		t.Errorf("SECURITY: model-c call count = %d, want 0 — access policy bypassed at second hop", got)
+	}
+
+	// The client receives model-b's 502 response. The loop breaks before draining
+	// resp (that only happens when the hop commits), so resp holds model-b's
+	// response at break time and is forwarded as-is.
+	if resp.StatusCode != http.StatusBadGateway {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want %d (model-b's last error); body: %s",
+			resp.StatusCode, http.StatusBadGateway, body)
 	}
 }

--- a/internal/proxy/registry.go
+++ b/internal/proxy/registry.go
@@ -71,6 +71,10 @@ type Model struct {
 	// MaxRetries is the number of times the proxy will retry a failed upstream
 	// request across the available deployments. Must be >= 0.
 	MaxRetries int
+	// FallbackModelName is the canonical name of the fallback target.
+	// Empty when no fallback is configured. Set to empty by the registry
+	// builder if the license does not include FeatureFallbackChains.
+	FallbackModelName string
 	// Deployments is the list of backend endpoints for this model. When
 	// non-empty, the model-level Provider, BaseURL, and APIKey are ignored
 	// in favour of the per-deployment values.
@@ -152,22 +156,23 @@ func NewRegistry(models []config.ModelConfig) (*Registry, error) {
 		}
 
 		m := &Model{
-			Name:             mc.Name,
-			Provider:         mc.Provider,
-			Type:             modelType,
-			BaseURL:          mc.BaseURL,
-			APIKey:           mc.APIKey,
-			Aliases:          aliases,
-			MaxContextTokens: mc.MaxContextTokens,
-			Pricing:          mc.Pricing,
-			AzureDeployment:  mc.AzureDeployment,
-			AzureAPIVersion:  mc.AzureAPIVersion,
-			GCPProject:       mc.GCPProject,
-			GCPLocation:      mc.GCPLocation,
-			Timeout:          timeout,
-			Strategy:         mc.Strategy,
-			MaxRetries:       mc.MaxRetries,
-			Deployments:      deployments,
+			Name:              mc.Name,
+			Provider:          mc.Provider,
+			Type:              modelType,
+			BaseURL:           mc.BaseURL,
+			APIKey:            mc.APIKey,
+			Aliases:           aliases,
+			MaxContextTokens:  mc.MaxContextTokens,
+			Pricing:           mc.Pricing,
+			AzureDeployment:   mc.AzureDeployment,
+			AzureAPIVersion:   mc.AzureAPIVersion,
+			GCPProject:        mc.GCPProject,
+			GCPLocation:       mc.GCPLocation,
+			Timeout:           timeout,
+			Strategy:          mc.Strategy,
+			MaxRetries:        mc.MaxRetries,
+			Deployments:       deployments,
+			FallbackModelName: mc.Fallback,
 		}
 		r.models[mc.Name] = m
 	}
@@ -283,22 +288,23 @@ func (r *Registry) AddModel(m Model) {
 	copy(deployments, m.Deployments)
 
 	entry := &Model{
-		Name:             m.Name,
-		Provider:         m.Provider,
-		Type:             m.Type,
-		BaseURL:          m.BaseURL,
-		APIKey:           m.APIKey,
-		Aliases:          aliases,
-		MaxContextTokens: m.MaxContextTokens,
-		Pricing:          m.Pricing,
-		AzureDeployment:  m.AzureDeployment,
-		AzureAPIVersion:  m.AzureAPIVersion,
-		GCPProject:       m.GCPProject,
-		GCPLocation:      m.GCPLocation,
-		Timeout:          m.Timeout,
-		Strategy:         m.Strategy,
-		MaxRetries:       m.MaxRetries,
-		Deployments:      deployments,
+		Name:              m.Name,
+		Provider:          m.Provider,
+		Type:              m.Type,
+		BaseURL:           m.BaseURL,
+		APIKey:            m.APIKey,
+		Aliases:           aliases,
+		MaxContextTokens:  m.MaxContextTokens,
+		Pricing:           m.Pricing,
+		AzureDeployment:   m.AzureDeployment,
+		AzureAPIVersion:   m.AzureAPIVersion,
+		GCPProject:        m.GCPProject,
+		GCPLocation:       m.GCPLocation,
+		Timeout:           m.Timeout,
+		Strategy:          m.Strategy,
+		MaxRetries:        m.MaxRetries,
+		Deployments:       deployments,
+		FallbackModelName: m.FallbackModelName,
 	}
 	r.models[m.Name] = entry
 
@@ -326,6 +332,71 @@ func (r *Registry) RemoveModel(name string) {
 	delete(r.models, name)
 
 	r.rebuildSorted()
+}
+
+// StripAllFallbacks clears the FallbackModelName on every model in a
+// single critical section. Used by the license gate to atomically
+// remove fallback configuration when the license is downgraded.
+// Returns the number of models whose fallback was cleared.
+func (r *Registry) StripAllFallbacks() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	stripped := 0
+	for _, m := range r.models {
+		if m.FallbackModelName != "" {
+			m.FallbackModelName = ""
+			stripped++
+		}
+	}
+	return stripped
+}
+
+// AllModels returns copies of every model currently in the registry. The order
+// is unspecified. Use this for batch operations such as license-gating rather
+// than for serving hot-path requests.
+func (r *Registry) AllModels() []Model {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]Model, 0, len(r.models))
+	for _, m := range r.models {
+		result = append(result, copyModel(m))
+	}
+	return result
+}
+
+// FallbackFor returns the resolved fallback Model for the given current
+// model name (or alias). Returns false if no fallback is configured, the
+// target does not exist, or the target has been visited already in this
+// chain (cycle protection at runtime).
+func (r *Registry) FallbackFor(currentName string, visited map[string]bool) (Model, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	// Resolve current to its canonical entry (handles aliases).
+	canonical := currentName
+	if alias, ok := r.aliases[currentName]; ok {
+		canonical = alias
+	}
+	m, ok := r.models[canonical]
+	if !ok || m.FallbackModelName == "" {
+		return Model{}, false
+	}
+
+	// Resolve the fallback target.
+	targetCanonical := m.FallbackModelName
+	if alias, ok := r.aliases[targetCanonical]; ok {
+		targetCanonical = alias
+	}
+	target, ok := r.models[targetCanonical]
+	if !ok {
+		return Model{}, false
+	}
+	if visited[target.Name] {
+		return Model{}, false // cycle
+	}
+	return copyModel(target), true
 }
 
 // copyModel returns a deep copy of m so callers cannot mutate the registry's

--- a/internal/proxy/registry_test.go
+++ b/internal/proxy/registry_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/voidmind-io/voidllm/internal/config"
@@ -391,4 +392,135 @@ func TestModelLogValue(t *testing.T) {
 	if !found {
 		t.Error("LogValue() missing api_key attribute")
 	}
+}
+
+// mcWithFallback returns a ModelConfig with a fallback model set.
+func mcWithFallback(name, provider, fallback string) config.ModelConfig {
+	return config.ModelConfig{
+		Name:     name,
+		Provider: provider,
+		BaseURL:  "http://" + name,
+		APIKey:   "k",
+		Fallback: fallback,
+	}
+}
+
+// TestRegistry_StripAllFallbacks verifies the direct unit contract of
+// StripAllFallbacks: count returned equals models that had a fallback,
+// all FallbackModelName fields are cleared, and a second call returns 0.
+func TestRegistry_StripAllFallbacks(t *testing.T) {
+	t.Parallel()
+
+	reg, err := NewRegistry([]config.ModelConfig{
+		mcWithFallback("a", "openai", "b"),
+		mcWithFallback("b", "openai", "c"),
+		{Name: "c", Provider: "openai", BaseURL: "http://c", APIKey: "k"},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	// Sanity: all three models are registered.
+	if got := len(reg.AllModels()); got != 3 {
+		t.Fatalf("AllModels() len = %d, want 3", got)
+	}
+
+	// First strip: two models have a fallback.
+	stripped := reg.StripAllFallbacks()
+	if stripped != 2 {
+		t.Errorf("StripAllFallbacks() = %d, want 2", stripped)
+	}
+
+	// All fallbacks must now be empty.
+	for _, m := range reg.AllModels() {
+		if m.FallbackModelName != "" {
+			t.Errorf("model %q still has FallbackModelName=%q after strip", m.Name, m.FallbackModelName)
+		}
+	}
+
+	// Idempotent: second call should clear nothing.
+	stripped2 := reg.StripAllFallbacks()
+	if stripped2 != 0 {
+		t.Errorf("StripAllFallbacks() second call = %d, want 0", stripped2)
+	}
+}
+
+// TestRegistry_StripAllFallbacks_EmptyRegistry verifies that StripAllFallbacks
+// on an empty registry returns 0 without panicking.
+func TestRegistry_StripAllFallbacks_EmptyRegistry(t *testing.T) {
+	t.Parallel()
+
+	reg, err := NewRegistry(nil)
+	if err != nil {
+		t.Fatalf("NewRegistry(nil): %v", err)
+	}
+
+	if got := reg.StripAllFallbacks(); got != 0 {
+		t.Errorf("StripAllFallbacks() on empty registry = %d, want 0", got)
+	}
+}
+
+// TestRegistry_StripAllFallbacks_NoFallbacks verifies that StripAllFallbacks
+// returns 0 when no model has a fallback configured.
+func TestRegistry_StripAllFallbacks_NoFallbacks(t *testing.T) {
+	t.Parallel()
+
+	reg, err := NewRegistry([]config.ModelConfig{
+		mc("x", "openai", "http://x", "k"),
+		mc("y", "openai", "http://y", "k"),
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	if got := reg.StripAllFallbacks(); got != 0 {
+		t.Errorf("StripAllFallbacks() with no fallbacks = %d, want 0", got)
+	}
+}
+
+// TestRegistry_StripAllFallbacks_Concurrent verifies that concurrent reads
+// (AllModels, FallbackFor) and writes (StripAllFallbacks) do not produce data
+// races. Correctness of specific counts is not asserted — the criterion is
+// that the race detector reports no violations.
+func TestRegistry_StripAllFallbacks_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	reg, err := NewRegistry([]config.ModelConfig{
+		mcWithFallback("m1", "openai", "m2"),
+		mcWithFallback("m2", "openai", "m3"),
+		{Name: "m3", Provider: "openai", BaseURL: "http://m3", APIKey: "k"},
+		{Name: "m4", Provider: "openai", BaseURL: "http://m4", APIKey: "k"},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	const goroutines = 20
+	const iterations = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := range goroutines {
+		go func(id int) {
+			defer wg.Done()
+			for range iterations {
+				switch id % 3 {
+				case 0:
+					// Writer: strip fallbacks.
+					_ = reg.StripAllFallbacks()
+				case 1:
+					// Reader: iterate all models.
+					_ = reg.AllModels()
+				case 2:
+					// Reader: resolve fallback for a named model.
+					visited := map[string]bool{}
+					_, _ = reg.FallbackFor("m1", visited)
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	// Reaching here without the race detector firing is the success criterion.
 }

--- a/internal/usage/event.go
+++ b/internal/usage/event.go
@@ -19,8 +19,12 @@ type Event struct {
 	UserID string
 	// ServiceAccountID is the service account the key belongs to. Empty if not a SA key.
 	ServiceAccountID string
-	// ModelName is the canonical upstream model name.
+	// ModelName is the canonical upstream model name that actually served the request.
+	// When fallback is active, this is the fallback model's name.
 	ModelName string
+	// RequestedModelName is the model name the client originally requested.
+	// Equal to ModelName when no fallback occurred. Empty for legacy events.
+	RequestedModelName string
 	// PromptTokens is the number of input tokens consumed.
 	PromptTokens int
 	// CompletionTokens is the number of output tokens produced.

--- a/internal/usage/logger.go
+++ b/internal/usage/logger.go
@@ -90,6 +90,11 @@ func (l *Logger) BufferLen() int {
 // silently dropped rather than blocking the caller. This ensures the proxy hot
 // path is never delayed by a slow DB.
 func (l *Logger) Log(event Event) {
+	// Cap attacker-controlled fields at a sane size before they enter
+	// the buffer or the in-memory rollups map.
+	event.ModelName = truncateForStorage(event.ModelName)
+	event.RequestedModelName = truncateForStorage(event.RequestedModelName)
+
 	// Increment the in-memory token counter immediately so that subsequent
 	// CheckTokens calls reflect this request even before it reaches the DB.
 	if l.tokenCounter != nil && event.TotalTokens > 0 {
@@ -162,6 +167,22 @@ func (l *Logger) run() {
 	}
 }
 
+// maxModelNameLen is the maximum number of bytes stored for model name fields
+// in usage_events rows. Values longer than this are truncated before persistence
+// to prevent a hostile client from bloating the database via oversized model names.
+const maxModelNameLen = 256
+
+// truncateForStorage caps s to maxModelNameLen bytes. It does not split
+// multi-byte UTF-8 sequences — the byte-level cap is intentional since the
+// DB column is defined as TEXT and the limit is a storage budget, not a display
+// limit.
+func truncateForStorage(s string) string {
+	if len(s) > maxModelNameLen {
+		return s[:maxModelNameLen]
+	}
+	return s
+}
+
 // flush writes a batch of events to the database inside a single transaction.
 // Each event receives a new UUIDv7 ID. Nullable fields (TeamID, UserID,
 // ServiceAccountID, CostEstimate, TTFT_MS, TokensPerSecond) are stored as SQL
@@ -172,12 +193,14 @@ func (l *Logger) flush(events []Event) error {
 	query := "INSERT INTO usage_events " +
 		"(id, key_id, key_type, org_id, team_id, user_id, service_account_id, " +
 		"model_name, prompt_tokens, completion_tokens, total_tokens, " +
-		"cost_estimate, request_duration_ms, ttft_ms, tokens_per_second, status_code, request_id) " +
+		"cost_estimate, request_duration_ms, ttft_ms, tokens_per_second, status_code, request_id, " +
+		"requested_model_name) " +
 		"VALUES (" +
 		p(1) + ", " + p(2) + ", " + p(3) + ", " + p(4) + ", " +
 		p(5) + ", " + p(6) + ", " + p(7) + ", " + p(8) + ", " +
 		p(9) + ", " + p(10) + ", " + p(11) + ", " +
-		p(12) + ", " + p(13) + ", " + p(14) + ", " + p(15) + ", " + p(16) + ", " + p(17) + ")"
+		p(12) + ", " + p(13) + ", " + p(14) + ", " + p(15) + ", " + p(16) + ", " + p(17) + ", " +
+		p(18) + ")"
 
 	ctx := context.Background()
 
@@ -210,6 +233,7 @@ func (l *Logger) flush(events []Event) error {
 				ev.TokensPerSecond,
 				ev.StatusCode,
 				ev.RequestID,
+				ev.RequestedModelName,
 			)
 			if err != nil {
 				return fmt.Errorf("usage flush: insert event: %w", err)

--- a/internal/usage/logger_test.go
+++ b/internal/usage/logger_test.go
@@ -576,6 +576,75 @@ func TestNullableString(t *testing.T) {
 	}
 }
 
+// TestLog_RequestedModelNameStored verifies that when an event has a
+// RequestedModelName different from ModelName (i.e. fallback occurred), both
+// columns are persisted to the database correctly.
+func TestLog_RequestedModelNameStored(t *testing.T) {
+	t.Parallel()
+
+	d := openTestDB(t, "file:TestLog_RequestedModelNameStored?mode=memory&cache=private")
+	l := newTestLogger(d, defaultCfg())
+	l.Start()
+
+	ev := makeEvent()
+	ev.ModelName = "fallback-model"
+	ev.RequestedModelName = "original-model"
+
+	l.Log(ev)
+	stopAndWait(t, l, d, 1)
+
+	ctx := context.Background()
+	row := d.SQL().QueryRowContext(ctx,
+		"SELECT model_name, requested_model_name FROM usage_events LIMIT 1")
+
+	var modelName, requestedModelName string
+	if err := row.Scan(&modelName, &requestedModelName); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	if modelName != "fallback-model" {
+		t.Errorf("model_name = %q, want %q", modelName, "fallback-model")
+	}
+	if requestedModelName != "original-model" {
+		t.Errorf("requested_model_name = %q, want %q", requestedModelName, "original-model")
+	}
+}
+
+// TestLog_RequestedModelNameEqualsModelNameWhenNoFallback verifies that when no
+// fallback occurs (RequestedModelName is empty), the column stores an empty
+// string and model_name reflects the served model.
+func TestLog_RequestedModelNameEqualsModelNameWhenNoFallback(t *testing.T) {
+	t.Parallel()
+
+	d := openTestDB(t, "file:TestLog_RequestedModelNameNoFallback?mode=memory&cache=private")
+	l := newTestLogger(d, defaultCfg())
+	l.Start()
+
+	ev := makeEvent()
+	ev.ModelName = "primary-model"
+	ev.RequestedModelName = "" // no fallback
+
+	l.Log(ev)
+	stopAndWait(t, l, d, 1)
+
+	ctx := context.Background()
+	row := d.SQL().QueryRowContext(ctx,
+		"SELECT model_name, requested_model_name FROM usage_events LIMIT 1")
+
+	var modelName, requestedModelName string
+	if err := row.Scan(&modelName, &requestedModelName); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	if modelName != "primary-model" {
+		t.Errorf("model_name = %q, want %q", modelName, "primary-model")
+	}
+	// Empty RequestedModelName — the column should be empty string (or NULL converted to "").
+	if requestedModelName != "" {
+		t.Errorf("requested_model_name = %q, want empty string when no fallback", requestedModelName)
+	}
+}
+
 // TestLog_TokenCounterUpdatedBeforeFlush verifies that when a Logger is wired
 // with a TokenCounter, Log() increments the counter synchronously — before the
 // event reaches the database — so that a subsequent CheckTokens call sees the

--- a/ui/src/hooks/useLicense.ts
+++ b/ui/src/hooks/useLicense.ts
@@ -9,6 +9,7 @@ export interface LicenseInfo {
   max_orgs: number       // -1 = unlimited
   max_teams: number      // -1 = unlimited
   customer_id?: string   // only visible to admins
+  fallback_max_depth: number // 0 = fallback disabled
 }
 
 export function useLicense() {

--- a/ui/src/hooks/useModels.ts
+++ b/ui/src/hooks/useModels.ts
@@ -35,6 +35,7 @@ export interface ModelResponse {
   updated_at: string
   strategy?: string
   max_retries?: number
+  fallback_model_name?: string
   deployments?: DeploymentResponse[]
 }
 
@@ -59,6 +60,7 @@ export interface CreateModelParams {
   aliases?: string[]
   strategy?: string
   max_retries?: number
+  fallback_model_name?: string
 }
 
 export interface CreateDeploymentParams {
@@ -96,6 +98,7 @@ export interface UpdateModelParams {
   azure_api_version?: string
   timeout?: string
   aliases?: string[]
+  fallback_model_name?: string | null
 }
 
 export function useModels(cursor?: string) {

--- a/ui/src/pages/LicensePage.tsx
+++ b/ui/src/pages/LicensePage.tsx
@@ -13,12 +13,13 @@ import { formatDate } from '../lib/utils'
 
 // Human-readable labels for feature flag keys returned by the API.
 const FEATURE_LABELS: Record<string, string> = {
-  multi_org:     'Multi-org management',
-  cost_reports:  'Cost reports + budget alerts',
-  audit_logs:    'Audit logs',
-  sso_oidc:      'SSO / OIDC integration',
-  custom_roles:  'Custom roles',
-  otel_tracing:  'OpenTelemetry tracing',
+  multi_org:        'Multi-org management',
+  cost_reports:     'Cost reports + budget alerts',
+  audit_logs:       'Audit logs',
+  sso_oidc:         'SSO / OIDC integration',
+  custom_roles:     'Custom roles',
+  otel_tracing:     'OpenTelemetry tracing',
+  fallback_chains:  'Model fallback chains',
 }
 
 const proFeatures = [
@@ -35,6 +36,7 @@ const enterpriseFeatures = [
   'Audit logs',
   'Custom roles',
   'OpenTelemetry tracing',
+  'Model fallback chains',
   'Distributed rate limiting (Redis)',
   'Unlimited data retention',
   'Dedicated Slack support (24h)',

--- a/ui/src/pages/ModelsPage.test.tsx
+++ b/ui/src/pages/ModelsPage.test.tsx
@@ -73,6 +73,7 @@ const MOCK_LICENSE_WITH_FALLBACK = {
   features: ['fallback_chains', 'audit_logs'],
   max_orgs: -1,
   max_teams: -1,
+  fallback_max_depth: 3,
 }
 
 // ---------------------------------------------------------------------------

--- a/ui/src/pages/ModelsPage.test.tsx
+++ b/ui/src/pages/ModelsPage.test.tsx
@@ -1,0 +1,633 @@
+import React from 'react'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ToastProvider } from '../hooks/useToast'
+import ModelsPage from './ModelsPage'
+
+// ---------------------------------------------------------------------------
+// Types used in mocks (mirror the production types)
+// ---------------------------------------------------------------------------
+
+interface MockModelResponse {
+  id: string
+  name: string
+  type: string
+  provider: string
+  base_url: string
+  max_context_tokens: number
+  input_price_per_1m: number
+  output_price_per_1m: number
+  is_active: boolean
+  source: string
+  aliases: string[]
+  created_at: string
+  updated_at: string
+  timeout?: string
+  fallback_model_name?: string
+  deployments?: unknown[]
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeChatModel(overrides: Partial<MockModelResponse> = {}): MockModelResponse {
+  return {
+    id: 'model-1',
+    name: 'gpt-4o',
+    type: 'chat',
+    provider: 'openai',
+    base_url: 'https://api.openai.com/v1',
+    max_context_tokens: 0,
+    input_price_per_1m: 0,
+    output_price_per_1m: 0,
+    is_active: true,
+    source: 'api',
+    aliases: [],
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+const MOCK_MODELS_LIST: MockModelResponse[] = [
+  makeChatModel({ id: 'model-1', name: 'gpt-4o', type: 'chat' }),
+  makeChatModel({ id: 'model-2', name: 'claude-sonnet', type: 'chat', provider: 'anthropic', base_url: 'https://api.anthropic.com' }),
+  makeChatModel({ id: 'model-3', name: 'llama-70b', type: 'chat', provider: 'vllm', base_url: 'http://localhost:8000/v1' }),
+  makeChatModel({ id: 'model-4', name: 'text-embed-ada', type: 'embedding', provider: 'openai', base_url: 'https://api.openai.com/v1' }),
+]
+
+const MOCK_LICENSE_NO_FALLBACK = {
+  edition: 'community',
+  valid: true,
+  features: [] as string[],
+  max_orgs: 1,
+  max_teams: 3,
+}
+
+const MOCK_LICENSE_WITH_FALLBACK = {
+  edition: 'enterprise',
+  valid: true,
+  features: ['fallback_chains', 'audit_logs'],
+  max_orgs: -1,
+  max_teams: -1,
+}
+
+// ---------------------------------------------------------------------------
+// Render helpers
+// ---------------------------------------------------------------------------
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    )
+  }
+  return { queryClient, Wrapper }
+}
+
+function renderModelsPage() {
+  const { Wrapper } = makeWrapper()
+  return render(<ModelsPage />, { wrapper: Wrapper })
+}
+
+// ---------------------------------------------------------------------------
+// Fetch mock helpers
+// ---------------------------------------------------------------------------
+
+type FetchMockEntry = {
+  matcher: (url: string) => boolean
+  response: unknown
+  method?: string
+}
+
+function setupFetchMock(entries: FetchMockEntry[], capturedBodies?: Map<string, string>) {
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const method = (init?.method ?? 'GET').toUpperCase()
+
+    const entry = entries.find(
+      (e) => e.matcher(url) && (!e.method || e.method.toUpperCase() === method),
+    )
+
+    if (entry) {
+      if (capturedBodies && init?.body) {
+        capturedBodies.set(`${method}:${url}`, init.body as string)
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(entry.response),
+      }
+    }
+
+    // Default fallthrough for unmatched requests
+    return {
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    }
+  }))
+}
+
+function defaultEntries(licensePayload = MOCK_LICENSE_NO_FALLBACK, modelsPayload = { data: MOCK_MODELS_LIST, has_more: false }): FetchMockEntry[] {
+  return [
+    {
+      // GET-only models list (no method guard needed here — POST entries placed BEFORE
+      // defaultEntries() in the entries array so they match first)
+      matcher: (u) => u.includes('/api/v1/models') && !u.includes('/health'),
+      method: 'GET',
+      response: modelsPayload,
+    },
+    {
+      matcher: (u) => u.includes('/api/v1/license'),
+      response: licensePayload,
+    },
+    {
+      matcher: (u) => u.includes('/api/v1/models/health'),
+      response: { models: [] },
+    },
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// Dialog helpers
+// ---------------------------------------------------------------------------
+
+/** Opens the "Add Model" dialog via the page header button. */
+async function openCreateDialog() {
+  // The page header button is the first "Add Model" button on the page.
+  const buttons = screen.getAllByRole('button', { name: /add model/i })
+  await userEvent.click(buttons[0])
+}
+
+/** Returns the dialog element rendered in the portal. */
+function getDialog(titleText: string | RegExp) {
+  // Dialogs are portalled to document.body. Find by the dialog role or by title text.
+  const heading = screen.getByRole('heading', { name: titleText })
+  // Walk up to the dialog container
+  const dialog = heading.closest('[role="dialog"]')
+  if (!dialog) throw new Error(`Could not find dialog with title matching ${String(titleText)}`)
+  return dialog as HTMLElement
+}
+
+/** Clicks the submit button inside the currently-open dialog. */
+async function submitDialog(dialog: HTMLElement, buttonName: string | RegExp) {
+  await userEvent.click(within(dialog).getByRole('button', { name: buttonName }))
+}
+
+/**
+ * Adds a minimal deployment entry via the inline deployment form in the
+ * Load Balanced tab. Required because the form validates that at least one
+ * deployment is present before submitting.
+ */
+async function addMinimalDeployment(dialog: HTMLElement) {
+  await userEvent.click(within(dialog).getByRole('button', { name: /\+ add deployment/i }))
+
+  // After clicking "+ Add Deployment", the inline form appears with Name, Base URL, etc.
+  // There are now two "Name" inputs in the dialog: the top-level model name and the
+  // deployment name. Use getAllByRole and pick the last (inline form).
+  const allNameInputs = within(dialog).getAllByRole('textbox', { name: /^name$/i })
+  const depNameInput = allNameInputs[allNameInputs.length - 1]
+  await userEvent.type(depNameInput, 'primary')
+
+  // Similarly for Base URL
+  const allUrlInputs = within(dialog).getAllByRole('textbox', { name: /base url/i })
+  const depUrlInput = allUrlInputs[allUrlInputs.length - 1]
+  await userEvent.type(depUrlInput, 'https://api.openai.com/v1')
+
+  // Click "Add" to save the deployment entry
+  await userEvent.click(within(dialog).getByRole('button', { name: /^add$/i }))
+}
+
+/** Switches to the Load Balanced tab within the Add Model dialog. */
+async function switchToLoadBalancedTab() {
+  await userEvent.click(screen.getByRole('tab', { name: /load balanced/i }))
+}
+
+/** Finds the Fallback Model combobox inside a given container element. */
+function getFallbackCombobox(container: HTMLElement | Document = document): HTMLElement {
+  // The Select has aria-labelledby pointing to its label id. RTL resolves this for getByRole.
+  const all = within(container as HTMLElement).getAllByRole('combobox')
+  // Find the one whose accessible name contains "Fallback Model"
+  const match = all.find((el) => {
+    const labelledBy = el.getAttribute('aria-labelledby')
+    if (!labelledBy) return false
+    const labelEl = document.getElementById(labelledBy)
+    return labelEl?.textContent?.toLowerCase().includes('fallback model')
+  })
+  if (!match) throw new Error('Could not find Fallback Model combobox')
+  return match
+}
+
+// ---------------------------------------------------------------------------
+// Tests: CreateModelDialog — without Enterprise license
+// ---------------------------------------------------------------------------
+
+describe('CreateModelDialog — Fallback Model field', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('without fallback_chains license feature', () => {
+    it('disables the Fallback Model select when license does not include fallback_chains', async () => {
+      setupFetchMock(defaultEntries(MOCK_LICENSE_NO_FALLBACK))
+      renderModelsPage()
+
+      await openCreateDialog()
+      await switchToLoadBalancedTab()
+
+      // Wait for the models list to load (options depend on it)
+      await waitFor(() => {
+        const dialog = getDialog(/add model/i)
+        const select = getFallbackCombobox(dialog)
+        expect(select).toBeDisabled()
+      })
+    })
+
+    it('shows "Enterprise" helper text when license is missing fallback_chains', async () => {
+      setupFetchMock(defaultEntries(MOCK_LICENSE_NO_FALLBACK))
+      renderModelsPage()
+
+      await openCreateDialog()
+      await switchToLoadBalancedTab()
+
+      await waitFor(() => {
+        expect(screen.getByText(/available with an enterprise license/i)).toBeInTheDocument()
+      })
+    })
+
+    it('does not send fallback_model_name on submit when license is missing and field is left at default', async () => {
+      const capturedBodies = new Map<string, string>()
+      const createdModel = makeChatModel({ id: 'new-model', name: 'my-lb-model' })
+      setupFetchMock(
+        [
+          {
+            matcher: (u) => u.includes('/api/v1/models') && !u.includes('/health'),
+            method: 'POST',
+            response: createdModel,
+          },
+          ...defaultEntries(MOCK_LICENSE_NO_FALLBACK),
+        ],
+        capturedBodies,
+      )
+      renderModelsPage()
+
+      await openCreateDialog()
+      await switchToLoadBalancedTab()
+
+      // Fill in required field: name
+      await userEvent.type(screen.getByRole('textbox', { name: /^name$/i }), 'my-lb-model')
+
+      const dialog = getDialog(/add model/i)
+
+      // Load balanced mode requires at least one deployment
+      await addMinimalDeployment(dialog)
+
+      // Submit
+      await submitDialog(dialog, /add model/i)
+
+      await waitFor(() => expect(capturedBodies.has('POST:/api/v1/models')).toBe(true))
+
+      const body = JSON.parse(capturedBodies.get('POST:/api/v1/models')!)
+      // When license is missing and field untouched, fallback_model_name is absent
+      // because `if (fallbackModelName) params.fallback_model_name = fallbackModelName`
+      // and the default value is '' (falsy).
+      expect(body).not.toHaveProperty('fallback_model_name')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // CreateModelDialog — with Enterprise license
+  // ---------------------------------------------------------------------------
+
+  describe('with fallback_chains license feature', () => {
+    it('enables the Fallback Model select when license includes fallback_chains', async () => {
+      setupFetchMock(defaultEntries(MOCK_LICENSE_WITH_FALLBACK))
+      renderModelsPage()
+
+      await openCreateDialog()
+      await switchToLoadBalancedTab()
+
+      await waitFor(() => {
+        const dialog = getDialog(/add model/i)
+        const select = getFallbackCombobox(dialog)
+        expect(select).not.toBeDisabled()
+      })
+    })
+
+    it('shows helpful description text when license includes fallback_chains', async () => {
+      setupFetchMock(defaultEntries(MOCK_LICENSE_WITH_FALLBACK))
+      renderModelsPage()
+
+      await openCreateDialog()
+      await switchToLoadBalancedTab()
+
+      await waitFor(() => {
+        expect(screen.getByText(/automatically retry on the fallback model/i)).toBeInTheDocument()
+      })
+    })
+
+    it('shows None option and other chat models, excludes embedding models and current model name', async () => {
+      setupFetchMock(defaultEntries(MOCK_LICENSE_WITH_FALLBACK))
+      renderModelsPage()
+
+      await openCreateDialog()
+      await switchToLoadBalancedTab()
+
+      // Type a model name so the self-exclusion logic has a value to compare against
+      await userEvent.type(screen.getByRole('textbox', { name: /^name$/i }), 'gpt-4o')
+
+      // Wait for the select to be enabled
+      let fallbackSelect: HTMLElement
+      await waitFor(() => {
+        const dialog = getDialog(/add model/i)
+        fallbackSelect = getFallbackCombobox(dialog)
+        expect(fallbackSelect).not.toBeDisabled()
+      })
+
+      // Open the dropdown
+      await userEvent.click(fallbackSelect!)
+
+      // "None" must be present
+      expect(screen.getByRole('option', { name: 'None' })).toBeInTheDocument()
+
+      // Other chat models must be present
+      expect(screen.getByRole('option', { name: 'claude-sonnet' })).toBeInTheDocument()
+      expect(screen.getByRole('option', { name: 'llama-70b' })).toBeInTheDocument()
+
+      // Current model name (gpt-4o) must NOT appear in the options
+      const allOptions = screen.getAllByRole('option')
+      const optionNames = allOptions.map((o) => o.textContent)
+      expect(optionNames).not.toContain('gpt-4o')
+
+      // The embedding model must NOT appear (type mismatch; current type defaults to 'chat')
+      expect(optionNames).not.toContain('text-embed-ada')
+    })
+
+    it('sends fallback_model_name when user picks a model', async () => {
+      const capturedBodies = new Map<string, string>()
+      const createdModel = makeChatModel({ id: 'new-lb', name: 'new-lb' })
+      setupFetchMock(
+        [
+          {
+            matcher: (u) => u.includes('/api/v1/models') && !u.includes('/health'),
+            method: 'POST',
+            response: createdModel,
+          },
+          ...defaultEntries(MOCK_LICENSE_WITH_FALLBACK),
+        ],
+        capturedBodies,
+      )
+      renderModelsPage()
+
+      await openCreateDialog()
+      await switchToLoadBalancedTab()
+
+      await userEvent.type(screen.getByRole('textbox', { name: /^name$/i }), 'new-lb')
+
+      // Wait for and select a fallback model
+      let fallbackSelect: HTMLElement
+      await waitFor(() => {
+        const dialog = getDialog(/add model/i)
+        fallbackSelect = getFallbackCombobox(dialog)
+        expect(fallbackSelect).not.toBeDisabled()
+      })
+
+      await userEvent.click(fallbackSelect!)
+      await userEvent.click(screen.getByRole('option', { name: 'claude-sonnet' }))
+
+      const dialog = getDialog(/add model/i)
+
+      // Load balanced mode requires at least one deployment
+      await addMinimalDeployment(dialog)
+
+      // Submit
+      await submitDialog(dialog, /add model/i)
+
+      await waitFor(() => expect(capturedBodies.has('POST:/api/v1/models')).toBe(true))
+
+      const body = JSON.parse(capturedBodies.get('POST:/api/v1/models')!)
+      expect(body.fallback_model_name).toBe('claude-sonnet')
+    })
+
+    it('does not send fallback_model_name when user leaves the default None', async () => {
+      const capturedBodies = new Map<string, string>()
+      const createdModel = makeChatModel({ id: 'new-lb2', name: 'new-lb2' })
+      setupFetchMock(
+        [
+          {
+            matcher: (u) => u.includes('/api/v1/models') && !u.includes('/health'),
+            method: 'POST',
+            response: createdModel,
+          },
+          ...defaultEntries(MOCK_LICENSE_WITH_FALLBACK),
+        ],
+        capturedBodies,
+      )
+      renderModelsPage()
+
+      await openCreateDialog()
+      await switchToLoadBalancedTab()
+
+      await userEvent.type(screen.getByRole('textbox', { name: /^name$/i }), 'new-lb2')
+
+      // Wait for the select to be ready but do NOT change it (leave as "None")
+      const dialog = getDialog(/add model/i)
+      await waitFor(() => {
+        const select = getFallbackCombobox(dialog)
+        expect(select).not.toBeDisabled()
+      })
+
+      // Load balanced mode requires at least one deployment
+      await addMinimalDeployment(dialog)
+
+      // Submit without touching the fallback select
+      await submitDialog(dialog, /add model/i)
+
+      await waitFor(() => expect(capturedBodies.has('POST:/api/v1/models')).toBe(true))
+
+      const body = JSON.parse(capturedBodies.get('POST:/api/v1/models')!)
+      // Empty string is falsy: `if (fallbackModelName)` guard omits the field
+      expect(body).not.toHaveProperty('fallback_model_name')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tests: EditModelDialog — Fallback Model field
+// ---------------------------------------------------------------------------
+
+describe('EditModelDialog — Fallback Model field', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  /**
+   * Clicks the "Edit model" button for a given model name.
+   * The edit button has title="Edit model" and lives in the same table row
+   * as the model name text.
+   */
+  async function openEditDialogForModel(modelName: string) {
+    // Wait for the model name to appear in the table
+    const modelNameEl = await screen.findByText(modelName)
+    const row = modelNameEl.closest('tr')
+    if (!row) throw new Error(`Could not find table row for model "${modelName}"`)
+    const editBtn = within(row).getByTitle('Edit model')
+    await userEvent.click(editBtn)
+  }
+
+  it('loads existing fallback_model_name into the Select', async () => {
+    const modelWithFallback = makeChatModel({ id: 'model-1', name: 'gpt-4o', fallback_model_name: 'claude-sonnet' })
+    const modelsData = {
+      data: [modelWithFallback, ...MOCK_MODELS_LIST.slice(1)],
+      has_more: false,
+    }
+    setupFetchMock(defaultEntries(MOCK_LICENSE_WITH_FALLBACK, modelsData))
+    renderModelsPage()
+
+    await openEditDialogForModel('gpt-4o')
+
+    // The edit dialog opens — wait for it
+    await waitFor(() => expect(screen.getByRole('heading', { name: /edit model/i })).toBeInTheDocument())
+
+    const dialog = getDialog(/edit model/i)
+    const fallbackSelect = getFallbackCombobox(dialog)
+
+    // The pre-loaded value should display as 'claude-sonnet'
+    expect(fallbackSelect).toHaveTextContent('claude-sonnet')
+  })
+
+  it('sends updated fallback_model_name on submit', async () => {
+    const capturedBodies = new Map<string, string>()
+    const modelWithFallback = makeChatModel({ id: 'model-1', name: 'gpt-4o', fallback_model_name: 'claude-sonnet' })
+    const modelsData = {
+      data: [modelWithFallback, ...MOCK_MODELS_LIST.slice(1)],
+      has_more: false,
+    }
+    setupFetchMock(
+      [
+        ...defaultEntries(MOCK_LICENSE_WITH_FALLBACK, modelsData),
+        {
+          matcher: (u) => u.includes('/api/v1/models/model-1'),
+          method: 'PATCH',
+          response: { ...modelWithFallback, fallback_model_name: 'llama-70b' },
+        },
+      ],
+      capturedBodies,
+    )
+    renderModelsPage()
+
+    await openEditDialogForModel('gpt-4o')
+    await waitFor(() => expect(screen.getByRole('heading', { name: /edit model/i })).toBeInTheDocument())
+
+    const dialog = getDialog(/edit model/i)
+    const fallbackSelect = getFallbackCombobox(dialog)
+
+    // Change the fallback from claude-sonnet to llama-70b
+    await userEvent.click(fallbackSelect)
+    await userEvent.click(screen.getByRole('option', { name: 'llama-70b' }))
+
+    await submitDialog(dialog, /save changes/i)
+
+    await waitFor(() => expect(capturedBodies.has('PATCH:/api/v1/models/model-1')).toBe(true))
+
+    const body = JSON.parse(capturedBodies.get('PATCH:/api/v1/models/model-1')!)
+    expect(body.fallback_model_name).toBe('llama-70b')
+  })
+
+  it('sends empty string to clear fallback on submit', async () => {
+    const capturedBodies = new Map<string, string>()
+    const modelWithFallback = makeChatModel({ id: 'model-1', name: 'gpt-4o', fallback_model_name: 'claude-sonnet' })
+    const modelsData = {
+      data: [modelWithFallback, ...MOCK_MODELS_LIST.slice(1)],
+      has_more: false,
+    }
+    setupFetchMock(
+      [
+        ...defaultEntries(MOCK_LICENSE_WITH_FALLBACK, modelsData),
+        {
+          matcher: (u) => u.includes('/api/v1/models/model-1'),
+          method: 'PATCH',
+          response: { ...modelWithFallback, fallback_model_name: '' },
+        },
+      ],
+      capturedBodies,
+    )
+    renderModelsPage()
+
+    await openEditDialogForModel('gpt-4o')
+    await waitFor(() => expect(screen.getByRole('heading', { name: /edit model/i })).toBeInTheDocument())
+
+    const dialog = getDialog(/edit model/i)
+    const fallbackSelect = getFallbackCombobox(dialog)
+
+    // Change to "None" (value='') to clear the existing fallback
+    await userEvent.click(fallbackSelect)
+    await userEvent.click(screen.getByRole('option', { name: 'None' }))
+
+    await submitDialog(dialog, /save changes/i)
+
+    await waitFor(() => expect(capturedBodies.has('PATCH:/api/v1/models/model-1')).toBe(true))
+
+    const body = JSON.parse(capturedBodies.get('PATCH:/api/v1/models/model-1')!)
+    // Empty string signals "clear" to the backend
+    expect(body.fallback_model_name).toBe('')
+  })
+
+  it('does NOT send fallback_model_name when unchanged on submit', async () => {
+    const capturedBodies = new Map<string, string>()
+    const modelWithFallback = makeChatModel({
+      id: 'model-1',
+      name: 'gpt-4o',
+      fallback_model_name: 'claude-sonnet',
+      timeout: '30s',
+    })
+    const modelsData = {
+      data: [modelWithFallback, ...MOCK_MODELS_LIST.slice(1)],
+      has_more: false,
+    }
+    setupFetchMock(
+      [
+        ...defaultEntries(MOCK_LICENSE_WITH_FALLBACK, modelsData),
+        {
+          matcher: (u) => u.includes('/api/v1/models/model-1'),
+          method: 'PATCH',
+          response: { ...modelWithFallback, timeout: '60s' },
+        },
+      ],
+      capturedBodies,
+    )
+    renderModelsPage()
+
+    await openEditDialogForModel('gpt-4o')
+    await waitFor(() => expect(screen.getByRole('heading', { name: /edit model/i })).toBeInTheDocument())
+
+    const dialog = getDialog(/edit model/i)
+
+    // Change the timeout field only — leave fallback untouched
+    const timeoutInput = within(dialog).getByRole('textbox', { name: /timeout/i })
+    await userEvent.clear(timeoutInput)
+    await userEvent.type(timeoutInput, '60s')
+
+    await submitDialog(dialog, /save changes/i)
+
+    await waitFor(() => expect(capturedBodies.has('PATCH:/api/v1/models/model-1')).toBe(true))
+
+    const body = JSON.parse(capturedBodies.get('PATCH:/api/v1/models/model-1')!)
+    // fallback_model_name was not changed — must be absent from the diff
+    expect(body).not.toHaveProperty('fallback_model_name')
+    // The changed field must be present
+    expect(body.timeout).toBe('60s')
+  })
+})

--- a/ui/src/pages/ModelsPage.tsx
+++ b/ui/src/pages/ModelsPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useMemo } from 'react'
 import { PageHeader } from '../components/ui/PageHeader'
 import { Table } from '../components/ui/Table'
 import type { Column } from '../components/ui/Table'
@@ -7,6 +7,7 @@ import { Badge } from '../components/ui/Badge'
 import { Button } from '../components/ui/Button'
 import { Input } from '../components/ui/Input'
 import { Select } from '../components/ui/Select'
+import type { SelectOption } from '../components/ui/Select'
 import { Toggle } from '../components/ui/Toggle'
 import { StatCard } from '../components/ui/StatCard'
 import TabSwitcher from '../components/ui/TabSwitcher'
@@ -24,6 +25,7 @@ import type { ModelResponse, DeploymentResponse, CreateModelParams, UpdateModelP
 import { useModelHealth } from '../hooks/useModelHealth'
 import type { ModelHealthInfo } from '../hooks/useModelHealth'
 import { useToast } from '../hooks/useToast'
+import { useLicense } from '../hooks/useLicense'
 import { providerBadgeVariant, isKnownProvider } from '../lib/providers'
 import type { ProviderKey } from '../lib/providers'
 import apiClient from '../api/client'
@@ -462,6 +464,7 @@ function CreateModelDialog({ open, onClose }: CreateModelDialogProps) {
   // Load-balanced fields
   const [strategy, setStrategy] = useState('round-robin')
   const [maxRetries, setMaxRetries] = useState('')
+  const [fallbackModelName, setFallbackModelName] = useState('')
   const [deployments, setDeployments] = useState<DeploymentFormEntry[]>([])
   const [showDeploymentForm, setShowDeploymentForm] = useState(false)
   const [editingDeployment, setEditingDeployment] = useState<number | null>(null)
@@ -475,6 +478,9 @@ function CreateModelDialog({ open, onClose }: CreateModelDialogProps) {
   const createModel = useCreateModel()
   const createDeployment = useCreateDeployment()
   const { toast } = useToast()
+  const { data: license } = useLicense()
+  const { data: modelsData } = useModels()
+  const hasFallbackFeature = license?.features.includes('fallback_chains') ?? false
 
   function handleClose() {
     setMode('single')
@@ -492,6 +498,7 @@ function CreateModelDialog({ open, onClose }: CreateModelDialogProps) {
     setTimeout('')
     setStrategy('round-robin')
     setMaxRetries('')
+    setFallbackModelName('')
     setDeployments([])
     setShowDeploymentForm(false)
     setEditingDeployment(null)
@@ -657,6 +664,7 @@ function CreateModelDialog({ open, onClose }: CreateModelDialogProps) {
         const parsed = parseInt(maxRetries, 10)
         if (!isNaN(parsed)) params.max_retries = parsed
       }
+      if (fallbackModelName) params.fallback_model_name = fallbackModelName
       if (maxContextTokens.trim()) {
         const parsed = parseInt(maxContextTokens, 10)
         if (!isNaN(parsed)) params.max_context_tokens = parsed
@@ -704,6 +712,16 @@ function CreateModelDialog({ open, onClose }: CreateModelDialogProps) {
   const isPending = createModel.isPending || createDeployment.isPending
   const depFormIsAzure = depFormEntry.provider === 'azure'
   const depFormIsOpen = showDeploymentForm || editingDeployment !== null
+
+  const fallbackOptions: SelectOption[] = useMemo(() => {
+    const allModels = modelsData?.data ?? []
+    return [
+      { value: '', label: 'None' },
+      ...allModels
+        .filter((m) => m.name !== name && m.type === type)
+        .map((m) => ({ value: m.name, label: m.name })),
+    ]
+  }, [modelsData, name, type])
 
   return (
     <Dialog open={open} onClose={handleClose} title="Add Model">
@@ -812,6 +830,25 @@ function CreateModelDialog({ open, onClose }: CreateModelDialogProps) {
               placeholder="0"
               disabled={isPending}
             />
+            <div>
+              <Select
+                label="Fallback Model"
+                options={fallbackOptions}
+                value={fallbackModelName}
+                onChange={setFallbackModelName}
+                disabled={isPending || !hasFallbackFeature}
+              />
+              {!hasFallbackFeature && (
+                <p className="text-xs text-text-tertiary mt-1">
+                  Available with an Enterprise license.
+                </p>
+              )}
+              {hasFallbackFeature && (
+                <p className="text-xs text-text-tertiary mt-1">
+                  When this model fails, requests automatically retry on the fallback model.
+                </p>
+              )}
+            </div>
 
             {/* Deployments list */}
             <div>
@@ -1148,11 +1185,25 @@ function EditModelDialog({ model, onClose }: EditModelDialogProps) {
   const [azureDeployment, setAzureDeployment] = useState(model.azure_deployment ?? '')
   const [azureApiVersion, setAzureApiVersion] = useState(model.azure_api_version ?? '')
   const [timeout, setTimeout] = useState(model.timeout ?? '')
+  const [fallbackModelName, setFallbackModelName] = useState(model.fallback_model_name ?? '')
 
   const updateModel = useUpdateModel()
   const { toast } = useToast()
+  const { data: license } = useLicense()
+  const { data: modelsData } = useModels()
+  const hasFallbackFeature = license?.features.includes('fallback_chains') ?? false
 
   const isAzure = provider === 'azure'
+
+  const fallbackOptions: SelectOption[] = useMemo(() => {
+    const allModels = modelsData?.data ?? []
+    return [
+      { value: '', label: 'None' },
+      ...allModels
+        .filter((m) => m.name !== name && m.type === type)
+        .map((m) => ({ value: m.name, label: m.name })),
+    ]
+  }, [modelsData, name, type])
 
   function handleSubmit(e: React.FormEvent | React.MouseEvent) {
     e.preventDefault()
@@ -1211,6 +1262,12 @@ function EditModelDialog({ model, onClose }: EditModelDialogProps) {
     const sortedOld = [...(model.aliases ?? [])].sort()
     if (JSON.stringify(sortedNew) !== JSON.stringify(sortedOld)) {
       params.aliases = newAliases
+    }
+
+    if (fallbackModelName !== (model.fallback_model_name ?? '')) {
+      // Empty string sent as empty string — backend treats it as "clear"
+      // Non-empty string sent as the chosen name
+      params.fallback_model_name = fallbackModelName || ''
     }
 
     if (Object.keys(params).length === 0) {
@@ -1327,6 +1384,25 @@ function EditModelDialog({ model, onClose }: EditModelDialogProps) {
           description="Per-model upstream timeout. Empty = use global default."
           disabled={updateModel.isPending}
         />
+        <div>
+          <Select
+            label="Fallback Model"
+            options={fallbackOptions}
+            value={fallbackModelName}
+            onChange={setFallbackModelName}
+            disabled={updateModel.isPending || !hasFallbackFeature}
+          />
+          {!hasFallbackFeature && (
+            <p className="text-xs text-text-tertiary mt-1">
+              Available with an Enterprise license.
+            </p>
+          )}
+          {hasFallbackFeature && (
+            <p className="text-xs text-text-tertiary mt-1">
+              When this model fails, requests automatically retry on the fallback model.
+            </p>
+          )}
+        </div>
         <Input
           label="Aliases"
           value={aliases}

--- a/ui/src/pages/ModelsPage.tsx
+++ b/ui/src/pages/ModelsPage.tsx
@@ -843,7 +843,12 @@ function CreateModelDialog({ open, onClose }: CreateModelDialogProps) {
                   Available with an Enterprise license.
                 </p>
               )}
-              {hasFallbackFeature && (
+              {hasFallbackFeature && license?.fallback_max_depth === 0 && (
+                <p className="text-xs text-amber-400 mt-1">
+                  Fallback is configured but disabled. Set fallback_max_depth in your server config to enable.
+                </p>
+              )}
+              {hasFallbackFeature && (license?.fallback_max_depth ?? 0) > 0 && (
                 <p className="text-xs text-text-tertiary mt-1">
                   When this model fails, requests automatically retry on the fallback model.
                 </p>
@@ -1397,7 +1402,12 @@ function EditModelDialog({ model, onClose }: EditModelDialogProps) {
               Available with an Enterprise license.
             </p>
           )}
-          {hasFallbackFeature && (
+          {hasFallbackFeature && license?.fallback_max_depth === 0 && (
+            <p className="text-xs text-amber-400 mt-1">
+              Fallback is configured but disabled. Set fallback_max_depth in your server config to enable.
+            </p>
+          )}
+          {hasFallbackFeature && (license?.fallback_max_depth ?? 0) > 0 && (
             <p className="text-xs text-text-tertiary mt-1">
               When this model fails, requests automatically retry on the fallback model.
             </p>

--- a/voidllm.yaml.example
+++ b/voidllm.yaml.example
@@ -123,6 +123,7 @@ models:
     aliases:
       - small
       - fast
+    # fallback: gpt-oss-120b  # Enterprise: retry on this model when gpt-oss-20b is unavailable
     max_context_tokens: 32000
     pricing:
       input_per_1m:  0.10
@@ -242,6 +243,14 @@ settings:
       interval: 5m
 
   # --- Enterprise Features (require license) ---
+
+  # Model fallback chains: retry a different model when the primary is unavailable.
+  # Requires a license with the fallback_chains feature; ignored otherwise.
+  # fallback_max_depth: 3
+  #   Maximum depth of the model fallback chain.
+  #   - 0 (default, if unset): fallback chains disabled globally
+  #   - 1-10: enables fallback chains, capped at this depth
+  #   Requires Enterprise license.
 
   # Audit logging
   # audit:


### PR DESCRIPTION
## Summary

Closes #45.

Enterprise-gated cross-model failover. When a primary model's deployments are all unavailable (network error or 5xx), the proxy automatically retries on the configured fallback model. Chains up to `settings.fallback_max_depth` (default 3).

### Highlights

- **Outer fallback loop** wrapping the existing deployment-retry loop, with per-hop access control check
- **Cycle detection** at config load, admin API write (with process-level mutex), and runtime (visited set)
- **License gated** via `FeatureFallbackChains` - three layers: registry strip, admin API 403, UI disabled
- **Usage tracking** records both `requested_model_name` and `model_name` for fallback analytics
- **UI**: Fallback Model dropdown in Create + Edit dialogs, license-gated with depth-0 warning
- **Migration 0011**: `fallback_model_id` on models, `requested_model_name` on usage_events

### Security (3 rounds of audit)

- Access control re-checked per hop (VULN-001)
- License holder reads live via atomic Load (VULN-002)  
- Cycle check + DB write serialized via mutex (VULN-003)
- Body rewrite errors on non-JSON (VULN-006)
- Registry StripAllFallbacks is atomic under write lock (VULN-A3)
- SetLicense triggers in-process registry reload for non-Redis deployments

### Config

```yaml
settings:
  fallback_max_depth: 3   # 0 = disabled, 1-10 = max chain depth

models:
  - name: gpt-4o
    fallback: claude-sonnet
```

## Test plan

- [ ] CI green (go test, vet, build, UI lint + test)
- [ ] CodeQL + Snyk clean
- [ ] Migration 0011 applies and rolls back cleanly
- [ ] Manual: primary fails -> fallback fires -> usage event has both model names