### PR TITLE
feat: Code Mode response unwrapping, schema inference, description polish

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -756,6 +756,7 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 		db:           database,
 		log:          log,
 		maxToolCalls: cfg.Settings.MCP.CodeMode.MaxToolCalls,
+		schemaTTL:    cfg.Settings.MCP.CodeMode.SchemaTTL,
 		serverCache:  mcpServerCache,
 		codePool:     adminHandler.CodePool,
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -756,7 +756,7 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 		db:           database,
 		log:          log,
 		maxToolCalls: cfg.Settings.MCP.CodeMode.MaxToolCalls,
-		schemaTTL:    cfg.Settings.MCP.CodeMode.SchemaTTL,
+		schemaTTL:    *cfg.Settings.MCP.CodeMode.SchemaTTL,
 		serverCache:  mcpServerCache,
 		codePool:     adminHandler.CodePool,
 	}

--- a/internal/app/code_mode.go
+++ b/internal/app/code_mode.go
@@ -24,6 +24,9 @@ type codeModeDB interface {
 	ListMCPServersByTeam(ctx context.Context, teamID, orgID string) ([]db.MCPServer, error)
 	CheckMCPAccess(ctx context.Context, orgID, teamID, keyID, serverID string) (bool, error)
 	ListBlockedToolNames(ctx context.Context, serverID string) ([]string, error)
+	SaveOutputSchema(ctx context.Context, serverID, toolName string, schema jsonx.RawMessage) error
+	GetAllOutputSchemas(ctx context.Context, serverID string, maxAge time.Duration) (map[string]jsonx.RawMessage, error)
+	IsOutputSchemaStale(ctx context.Context, serverID, toolName string, maxAge time.Duration) (bool, error)
 }
 
 // mcpServerByIDer is the subset of proxy.MCPServerCache used by codeModeService
@@ -31,6 +34,10 @@ type codeModeDB interface {
 type mcpServerByIDer interface {
 	GetByID(serverID string) (*db.MCPServer, bool)
 }
+
+// searchToolsLimit is the maximum number of matched tools returned by
+// SearchMCPTools. Matches VoidMCP's hard limit to keep responses tractable.
+const searchToolsLimit = 50
 
 // codeModeService holds the dependencies for the three Code Mode VoidLLMDeps
 // closures (ExecuteCode, ListAccessibleMCPServers, SearchMCPTools) and the
@@ -43,6 +50,8 @@ type codeModeService struct {
 	db           codeModeDB
 	log          *slog.Logger
 	maxToolCalls int
+	// schemaTTL is the TTL for inferred output schemas (from config).
+	schemaTTL time.Duration
 	// serverCache resolves server IDs to aliases for TypeScript type generation.
 	serverCache mcpServerByIDer
 	// codePool is optional; when non-nil the pool's Available count is recorded
@@ -208,6 +217,14 @@ func (s *codeModeService) ExecuteCode(ctx context.Context, code string, serverAl
 		return s.callMCPTool(callCtx, kiAuth, serverAlias, toolName, args, true, executionID)
 	})
 
+	aliasToServerID := make(map[string]string, len(servers))
+	for _, sv := range servers {
+		if len(wantSet) > 0 && !wantSet[sv.Alias] {
+			continue
+		}
+		aliasToServerID[sv.Alias] = sv.ID
+	}
+
 	start := time.Now()
 	result, execErr := s.executor.Execute(ctx, mcp.ExecuteParams{
 		Code:         code,
@@ -215,6 +232,26 @@ func (s *codeModeService) ExecuteCode(ctx context.Context, code string, serverAl
 		CallTool:     callTool,
 		MaxToolCalls: s.maxToolCalls,
 		ExecutionID:  executionID,
+		OnToolResult: func(alias, toolName string, result jsonx.RawMessage) {
+			serverID, ok := aliasToServerID[alias]
+			if !ok {
+				return
+			}
+			// Use a 5-second timeout: the hook runs in a goroutine that
+			// outlives the request, but must not pin the goroutine
+			// indefinitely on a slow or contended DB write.
+			hctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			stale, err := s.db.IsOutputSchemaStale(hctx, serverID, toolName, s.schemaTTL)
+			if err != nil || !stale {
+				return
+			}
+			schema := mcp.InferSchema(result)
+			if schema == nil {
+				return
+			}
+			_ = s.db.SaveOutputSchema(hctx, serverID, toolName, schema)
+		},
 	})
 	duration := time.Since(start)
 
@@ -281,17 +318,20 @@ func (s *codeModeService) ListAccessibleMCPServers(ctx context.Context, codeMode
 }
 
 // SearchMCPTools searches tool schemas across accessible MCP servers by
-// keyword. query is matched case-insensitively against tool name and
-// description. serverAliases restricts the search scope when non-empty.
-// Returns nil when the tool cache is nil (Code Mode disabled).
-func (s *codeModeService) SearchMCPTools(ctx context.Context, query string, serverAliases []string) ([]map[string]any, error) {
+// keyword and returns a TypeScript text block ready for LLM consumption.
+// query is matched case-insensitively against tool name and description.
+// serverAliases restricts the search scope when non-empty (nil = all).
+// Returns an empty string when the tool cache is nil (Code Mode disabled).
+// At most searchToolsLimit tools are returned; when query == "*" and results
+// were truncated a notice is appended.
+func (s *codeModeService) SearchMCPTools(ctx context.Context, query string, serverAliases []string) (string, error) {
 	if s.toolCache == nil {
-		return nil, nil
+		return "", nil
 	}
 
 	servers, listErr := s.accessibleServers(ctx, true)
 	if listErr != nil {
-		return nil, fmt.Errorf("search mcp tools: list servers: %w", listErr)
+		return "", fmt.Errorf("search mcp tools: list servers: %w", listErr)
 	}
 
 	wantSet := make(map[string]bool, len(serverAliases))
@@ -300,8 +340,16 @@ func (s *codeModeService) SearchMCPTools(ctx context.Context, query string, serv
 	}
 
 	queryLower := strings.ToLower(query)
-	var matches []map[string]any
+	matched := make(map[string][]mcp.Tool)
+	matchedServerIDs := make(map[string]struct{})
+	matchCount := 0
+	totalAvailable := 0
+	capped := false
+
 	for _, sv := range servers {
+		if capped {
+			break
+		}
 		if len(wantSet) > 0 && !wantSet[sv.Alias] {
 			continue
 		}
@@ -327,19 +375,55 @@ func (s *codeModeService) SearchMCPTools(ctx context.Context, query string, serv
 			if blockedSet[t.Name] {
 				continue
 			}
-			if strings.Contains(strings.ToLower(t.Name), queryLower) ||
-				strings.Contains(strings.ToLower(t.Description), queryLower) {
-				matches = append(matches, map[string]any{
-					"server":       sv.Alias,
-					"server_name":  sv.Name,
-					"name":         t.Name,
-					"description":  t.Description,
-					"input_schema": t.InputSchema,
-				})
+			if !strings.Contains(strings.ToLower(t.Name), queryLower) &&
+				!strings.Contains(strings.ToLower(t.Description), queryLower) {
+				continue
 			}
+			totalAvailable++
+			if matchCount >= searchToolsLimit {
+				capped = true
+				break
+			}
+			matched[sv.Alias] = append(matched[sv.Alias], t)
+			matchedServerIDs[sv.ID] = struct{}{}
+			matchCount++
 		}
 	}
-	return matches, nil
+
+	if matchCount == 0 {
+		return fmt.Sprintf("No tools found matching %q.", query), nil
+	}
+
+	outputSchemas := make(map[string]map[string]jsonx.RawMessage, len(matchedServerIDs))
+	for serverID := range matchedServerIDs {
+		if s.serverCache == nil {
+			continue
+		}
+		sv, ok := s.serverCache.GetByID(serverID)
+		if !ok {
+			continue
+		}
+		schemas, schemaErr := s.db.GetAllOutputSchemas(ctx, serverID, s.schemaTTL)
+		if schemaErr != nil {
+			s.log.LogAttrs(ctx, slog.LevelWarn, "search mcp tools: get output schemas",
+				slog.String("server", sv.Alias),
+				slog.String("error", schemaErr.Error()))
+			continue
+		}
+		if len(schemas) > 0 {
+			outputSchemas[sv.Alias] = schemas
+		}
+	}
+
+	types := mcp.GenerateToolTypeDefs(matched, outputSchemas)
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Found %d tool(s) matching %q:\n\n", matchCount, query)
+	sb.WriteString(types)
+	if query == "*" && matchCount < totalAvailable {
+		fmt.Fprintf(&sb, "\n(showing %d of %d tools)\n", matchCount, totalAvailable)
+	}
+	return sb.String(), nil
 }
 
 // toolsListHook returns an mcp.OnToolsListHook that injects TypeScript type
@@ -370,13 +454,26 @@ func (s *codeModeService) toolsListHook() mcp.OnToolsListHook {
 			byAlias[serverID] = serverToolList
 		}
 
-		types := mcp.GenerateToolTypeDefs(byAlias)
+		// The hook runs on every tools/list request. Bound the per-server schema
+		// reads so a slow or stuck DB cannot pin the handler.
+		outputSchemas := make(map[string]map[string]jsonx.RawMessage, len(allCached))
+		hctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		for serverID := range allCached {
+			if s.serverCache != nil {
+				if server, ok := s.serverCache.GetByID(serverID); ok {
+					schemas, err := s.db.GetAllOutputSchemas(hctx, serverID, s.schemaTTL)
+					if err == nil && len(schemas) > 0 {
+						outputSchemas[server.Alias] = schemas
+					}
+				}
+			}
+		}
+		types := mcp.GenerateToolTypeDefs(byAlias, outputSchemas)
 		if types == "" {
 			return tools
 		}
-		desc := "Execute JavaScript code in a sandboxed WASM runtime.\n\n" +
-			"## Available Tools\n\n" + types + "\n\n" +
-			"Call tools via `await tools.serverAlias.toolName(args)`. Return a value as the result."
+		desc := mcp.CodeModeDescription() + "\n\n## Available Tools\n\n" + types
 		for i := range tools {
 			if tools[i].Name == "execute_code" {
 				tools[i].Description = desc

--- a/internal/app/code_mode.go
+++ b/internal/app/code_mode.go
@@ -250,7 +250,12 @@ func (s *codeModeService) ExecuteCode(ctx context.Context, code string, serverAl
 			if schema == nil {
 				return
 			}
-			_ = s.db.SaveOutputSchema(hctx, serverID, toolName, schema)
+			if saveErr := s.db.SaveOutputSchema(hctx, serverID, toolName, schema); saveErr != nil {
+				s.log.LogAttrs(hctx, slog.LevelWarn, "schema inference: save failed",
+					slog.String("server_id", serverID),
+					slog.String("tool", toolName),
+					slog.String("error", saveErr.Error()))
+			}
 		},
 	})
 	duration := time.Since(start)
@@ -344,12 +349,8 @@ func (s *codeModeService) SearchMCPTools(ctx context.Context, query string, serv
 	matchedServerIDs := make(map[string]struct{})
 	matchCount := 0
 	totalAvailable := 0
-	capped := false
 
 	for _, sv := range servers {
-		if capped {
-			break
-		}
 		if len(wantSet) > 0 && !wantSet[sv.Alias] {
 			continue
 		}
@@ -380,13 +381,11 @@ func (s *codeModeService) SearchMCPTools(ctx context.Context, query string, serv
 				continue
 			}
 			totalAvailable++
-			if matchCount >= searchToolsLimit {
-				capped = true
-				break
+			if matchCount < searchToolsLimit {
+				matched[sv.Alias] = append(matched[sv.Alias], t)
+				matchedServerIDs[sv.ID] = struct{}{}
+				matchCount++
 			}
-			matched[sv.Alias] = append(matched[sv.Alias], t)
-			matchedServerIDs[sv.ID] = struct{}{}
-			matchCount++
 		}
 	}
 
@@ -420,7 +419,7 @@ func (s *codeModeService) SearchMCPTools(ctx context.Context, query string, serv
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "Found %d tool(s) matching %q:\n\n", matchCount, query)
 	sb.WriteString(types)
-	if query == "*" && matchCount < totalAvailable {
+	if totalAvailable > matchCount {
 		fmt.Fprintf(&sb, "\n(showing %d of %d tools)\n", matchCount, totalAvailable)
 	}
 	return sb.String(), nil

--- a/internal/app/code_mode_test.go
+++ b/internal/app/code_mode_test.go
@@ -15,7 +15,9 @@ import (
 	"time"
 
 	"github.com/voidmind-io/voidllm/internal/auth"
+	"github.com/voidmind-io/voidllm/internal/config"
 	"github.com/voidmind-io/voidllm/internal/db"
+	"github.com/voidmind-io/voidllm/internal/jsonx"
 	"github.com/voidmind-io/voidllm/internal/mcp"
 )
 
@@ -37,6 +39,9 @@ type mockCodeModeDB struct {
 	blockedTools map[string][]string
 	// listErr is returned by all List* methods when non-nil.
 	listErr error
+	// outputSchemasByServerID maps serverID → (toolName → schema JSON) for
+	// GetAllOutputSchemas. When nil the method returns nil, nil (no schemas).
+	outputSchemasByServerID map[string]map[string]jsonx.RawMessage
 }
 
 func (m *mockCodeModeDB) ListMCPServers(_ context.Context) ([]db.MCPServer, error) {
@@ -72,6 +77,21 @@ func (m *mockCodeModeDB) ListBlockedToolNames(_ context.Context, serverID string
 		return nil, nil
 	}
 	return append([]string(nil), m.blockedTools[serverID]...), nil
+}
+
+func (m *mockCodeModeDB) SaveOutputSchema(_ context.Context, _, _ string, _ jsonx.RawMessage) error {
+	return nil
+}
+
+func (m *mockCodeModeDB) GetAllOutputSchemas(_ context.Context, serverID string, _ time.Duration) (map[string]jsonx.RawMessage, error) {
+	if m.outputSchemasByServerID == nil {
+		return nil, nil
+	}
+	return m.outputSchemasByServerID[serverID], nil
+}
+
+func (m *mockCodeModeDB) IsOutputSchemaStale(_ context.Context, _, _ string, _ time.Duration) (bool, error) {
+	return true, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -604,6 +624,24 @@ func TestListAccessibleMCPServers_NilCache(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// SearchMCPTools helpers
+// ---------------------------------------------------------------------------
+
+func assertContainsSearch(t *testing.T, got, substr string) {
+	t.Helper()
+	if !strings.Contains(got, substr) {
+		t.Errorf("search result missing %q\ngot: %s", substr, got)
+	}
+}
+
+func assertNotContainsSearch(t *testing.T, got, substr string) {
+	t.Helper()
+	if strings.Contains(got, substr) {
+		t.Errorf("search result should not contain %q\ngot: %s", substr, got)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // SearchMCPTools tests
 // ---------------------------------------------------------------------------
 
@@ -633,12 +671,10 @@ func TestSearchMCPTools_KeywordMatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SearchMCPTools() error = %v", err)
 	}
-	if len(result) != 1 {
-		t.Fatalf("got %d results, want 1", len(result))
-	}
-	if result[0]["name"] != "find_documents" {
-		t.Errorf("got tool %q, want %q", result[0]["name"], "find_documents")
-	}
+	assertContainsSearch(t, result, `Found `)
+	assertContainsSearch(t, result, `"find"`)
+	assertContainsSearch(t, result, `function find_documents(`)
+	assertContainsSearch(t, result, `declare namespace tools_search_srv`)
 }
 
 func TestSearchMCPTools_DescriptionMatch(t *testing.T) {
@@ -667,12 +703,9 @@ func TestSearchMCPTools_DescriptionMatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SearchMCPTools() error = %v", err)
 	}
-	if len(result) != 1 {
-		t.Fatalf("got %d results, want 1", len(result))
-	}
-	if result[0]["name"] != "beta" {
-		t.Errorf("got tool %q, want %q", result[0]["name"], "beta")
-	}
+	// "beta" matched via description; "alpha" must not appear.
+	assertContainsSearch(t, result, `function beta(`)
+	assertNotContainsSearch(t, result, `function alpha(`)
 }
 
 func TestSearchMCPTools_CaseInsensitive(t *testing.T) {
@@ -714,9 +747,8 @@ func TestSearchMCPTools_CaseInsensitive(t *testing.T) {
 			if err != nil {
 				t.Fatalf("SearchMCPTools(%q) error = %v", tc2.query, err)
 			}
-			if len(result) != 1 {
-				t.Errorf("query %q: got %d results, want 1", tc2.query, len(result))
-			}
+			// Original casing of the tool name must be preserved in output.
+			assertContainsSearch(t, result, `function ReadFile(`)
 		})
 	}
 }
@@ -750,12 +782,8 @@ func TestSearchMCPTools_FiltersBlocked(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SearchMCPTools() error = %v", err)
 	}
-	if len(result) != 1 {
-		t.Fatalf("got %d results, want 1 (blocked tool must be excluded)", len(result))
-	}
-	if result[0]["name"] != "safe_tool" {
-		t.Errorf("expected safe_tool, got %q", result[0]["name"])
-	}
+	assertContainsSearch(t, result, `function safe_tool(`)
+	assertNotContainsSearch(t, result, `function danger_tool(`)
 }
 
 func TestSearchMCPTools_ServerFilter(t *testing.T) {
@@ -787,17 +815,91 @@ func TestSearchMCPTools_ServerFilter(t *testing.T) {
 
 	ctx := ctxWithIdentity(mcp.KeyIdentity{OrgID: orgID, KeyID: "key-sf", Role: "member"})
 
-	// Restrict to "first" only — should get exactly 1 result even though
-	// "second" also has a tool named "lookup".
+	// Restrict to "first" only — should include server_a namespace and exclude server_b.
 	result, err := svc.SearchMCPTools(ctx, "lookup", []string{"first"})
 	if err != nil {
 		t.Fatalf("SearchMCPTools() error = %v", err)
 	}
-	if len(result) != 1 {
-		t.Fatalf("got %d results, want 1", len(result))
+	assertContainsSearch(t, result, `declare namespace tools.first`)
+	assertNotContainsSearch(t, result, `declare namespace tools.second`)
+}
+
+func TestSearchMCPTools_SurfacesInferredTypes(t *testing.T) {
+	t.Parallel()
+
+	orgID := "org-infer-search"
+	sv := db.MCPServer{
+		ID:              "sv-infer-search",
+		Alias:           "infer-srv",
+		Name:            "Infer Server",
+		OrgID:           ptrStr(orgID),
+		CodeModeEnabled: true,
 	}
-	if result[0]["server"] != "first" {
-		t.Errorf("got server %q, want %q", result[0]["server"], "first")
+
+	// Output schema for "my_infer_tool" — simple object with id (number) and name (string).
+	schemaJSON := jsonx.RawMessage(`{"type":"object","properties":{"id":{"type":"number"},"name":{"type":"string"}}}`)
+
+	mock := &mockCodeModeDB{
+		orgServers: map[string][]db.MCPServer{orgID: {sv}},
+		outputSchemasByServerID: map[string]map[string]jsonx.RawMessage{
+			sv.ID: {"my_infer_tool": schemaJSON},
+		},
+	}
+	tools := []mcp.Tool{
+		{Name: "my_infer_tool", Description: "A tool with inferred output schema"},
+	}
+	tc := newPreloadedCache(t, map[string][]mcp.Tool{sv.ID: tools})
+
+	serverCache := &staticServerCache{
+		byID: map[string]*db.MCPServer{sv.ID: &sv},
+	}
+
+	svc := &codeModeService{
+		db:          mock,
+		toolCache:   tc,
+		serverCache: serverCache,
+		log:         newDiscardLogger(),
+	}
+
+	ctx := ctxWithIdentity(mcp.KeyIdentity{OrgID: orgID, KeyID: "key-infer-s", Role: "member"})
+	result, err := svc.SearchMCPTools(ctx, "my_infer_tool", nil)
+	if err != nil {
+		t.Fatalf("SearchMCPTools() error = %v", err)
+	}
+
+	assertContainsSearch(t, result, `Promise<{ id: number; name: string }>`)
+	assertContainsSearch(t, result, `// inferred - could depend on previous query`)
+	// Ensure the inferred type replaced Promise<any> for this tool.
+	assertNotContainsSearch(t, result, `Promise<any>`)
+}
+
+func TestSearchMCPTools_NoResults(t *testing.T) {
+	t.Parallel()
+
+	orgID := "org-noresults"
+	sv := db.MCPServer{
+		ID:              "sv-noresults",
+		Alias:           "noresults-srv",
+		Name:            "No Results Server",
+		OrgID:           ptrStr(orgID),
+		CodeModeEnabled: true,
+	}
+	mock := &mockCodeModeDB{
+		orgServers: map[string][]db.MCPServer{orgID: {sv}},
+	}
+	tc := newPreloadedCache(t, map[string][]mcp.Tool{
+		sv.ID: {{Name: "some_tool", Description: "Does something"}},
+	})
+	svc := &codeModeService{db: mock, toolCache: tc, log: newDiscardLogger()}
+
+	ctx := ctxWithIdentity(mcp.KeyIdentity{OrgID: orgID, KeyID: "key-nr", Role: "member"})
+	result, err := svc.SearchMCPTools(ctx, "xyzzyfooBarNonExistent", nil)
+	if err != nil {
+		t.Fatalf("SearchMCPTools() error = %v", err)
+	}
+	const want = `No tools found matching "xyzzyfooBarNonExistent".`
+	if result != want {
+		t.Errorf("SearchMCPTools() = %q, want %q", result, want)
 	}
 }
 
@@ -1214,5 +1316,365 @@ func TestToolsListHook_NoExecuteCodeTool(t *testing.T) {
 	// execute_code is not in the list — other tools must be unchanged.
 	if got[0].Description != "lists models" {
 		t.Errorf("description changed to %q", got[0].Description)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Schema inference integration tests — real SQLite DB, real Executor
+// ---------------------------------------------------------------------------
+
+// staticServerCache is a minimal mcpServerByIDer that serves a fixed map of
+// server ID → MCPServer for use in schema-inference tests.
+type staticServerCache struct {
+	byID map[string]*db.MCPServer
+}
+
+func (s *staticServerCache) GetByID(serverID string) (*db.MCPServer, bool) {
+	sv, ok := s.byID[serverID]
+	return sv, ok
+}
+
+// openTestDBForSchemaTests opens an isolated in-memory SQLite DB, runs all
+// migrations, and registers cleanup. The dsn suffix must be unique per test.
+func openTestDBForSchemaTests(t *testing.T) *db.DB {
+	t.Helper()
+	// Use test name sanitised to a safe URI filename component.
+	safeName := strings.NewReplacer("/", "_", " ", "_", "#", "_", "=", "_").Replace(t.Name())
+	cfg := config.DatabaseConfig{
+		Driver:          "sqlite",
+		DSN:             "file:" + safeName + "?mode=memory&cache=private",
+		MaxOpenConns:    1,
+		MaxIdleConns:    1,
+		ConnMaxLifetime: time.Minute,
+	}
+	ctx := context.Background()
+	d, err := db.Open(ctx, cfg)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	if err := db.RunMigrations(ctx, d.SQL(), d.Dialect(), slog.New(slog.DiscardHandler)); err != nil {
+		t.Fatalf("RunMigrations: %v", err)
+	}
+	return d
+}
+
+// createTestMCPServer inserts a global builtin MCP server and returns it.
+// Using source="builtin" avoids the need for an org row (no FK) and bypasses
+// the MCP access check so any identity can access the server.
+func createTestMCPServer(t *testing.T, database *db.DB, alias string) *db.MCPServer {
+	t.Helper()
+	enabled := true
+	sv, err := database.CreateMCPServer(context.Background(), db.CreateMCPServerParams{
+		Name:            "Test " + alias,
+		Alias:           alias,
+		URL:             "https://mcp.test/" + alias,
+		AuthType:        "none",
+		Source:          "builtin",
+		CodeModeEnabled: &enabled,
+	})
+	if err != nil {
+		t.Fatalf("CreateMCPServer(%q): %v", alias, err)
+	}
+	return sv
+}
+
+// pollUntilSchemaInferred polls the DB until a schema row exists for
+// (serverID, toolName) or the deadline passes. It fails the test if no row
+// appears within the timeout.
+func pollUntilSchemaInferred(t *testing.T, database *db.DB, serverID, toolName string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		stale, err := database.IsOutputSchemaStale(context.Background(), serverID, toolName, time.Hour)
+		if err != nil {
+			t.Fatalf("IsOutputSchemaStale: %v", err)
+		}
+		if !stale {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("schema for (%s, %s) was not inferred within %s", serverID, toolName, timeout)
+}
+
+// readInferredAt returns the raw inferred_at string for a (serverID, toolName)
+// row directly from the underlying sql.DB. It fails the test if the row is missing.
+func readInferredAt(t *testing.T, database *db.DB, serverID, toolName string) string {
+	t.Helper()
+	var inferredAt string
+	err := database.SQL().QueryRowContext(
+		context.Background(),
+		"SELECT inferred_at FROM output_schemas WHERE server_id = ? AND tool_name = ?",
+		serverID, toolName,
+	).Scan(&inferredAt)
+	if err != nil {
+		t.Fatalf("readInferredAt(%s, %s): %v", serverID, toolName, err)
+	}
+	return inferredAt
+}
+
+// setupSchemaInferenceTest builds a codeModeService wired to a real SQLite DB
+// and a mock callMCPTool that returns the given JSON payload.
+// The MCP server is created as a global builtin so no org FK is required.
+// Returns the service, the database, and the MCPServer that was created.
+func setupSchemaInferenceTest(t *testing.T, alias string, schemaTTL time.Duration, toolPayload json.RawMessage) (*codeModeService, *db.DB, *db.MCPServer) {
+	t.Helper()
+
+	database := openTestDBForSchemaTests(t)
+	sv := createTestMCPServer(t, database, alias)
+
+	// Tool cache keyed by server ID — must match what ExecuteCode uses.
+	tc := newPreloadedCache(t, map[string][]mcp.Tool{
+		sv.ID: {{Name: "my_tool", Description: "A tool"}},
+	})
+
+	executor := newTestExecutor(t)
+
+	caller := func(_ context.Context, _ *auth.KeyInfo, _, _ string, _ json.RawMessage, _ bool, _ string) (json.RawMessage, error) {
+		return toolPayload, nil
+	}
+
+	serverCache := &staticServerCache{
+		byID: map[string]*db.MCPServer{sv.ID: sv},
+	}
+
+	svc := &codeModeService{
+		executor:     executor,
+		toolCache:    tc,
+		callMCPTool:  caller,
+		db:           database,
+		log:          newDiscardLogger(),
+		maxToolCalls: 10,
+		schemaTTL:    schemaTTL,
+		serverCache:  serverCache,
+	}
+	return svc, database, sv
+}
+
+// TestCodeMode_InfersSchemaOnFirstCall verifies that calling a tool whose
+// response is {"users":[{"id":1,"name":"a"}]} causes the schema to be
+// persisted and then surfaced as a typed Promise in toolsListHook output.
+func TestCodeMode_InfersSchemaOnFirstCall(t *testing.T) {
+	t.Parallel()
+
+	const alias = "testsrv"
+
+	toolPayload := json.RawMessage(`{"users":[{"id":1,"name":"a"}]}`)
+
+	svc, database, sv := setupSchemaInferenceTest(t, alias, time.Hour, toolPayload)
+
+	// system_admin with no OrgID/TeamID triggers ListMCPServers; builtin servers
+	// bypass the MCP access check so no access record is needed.
+	ctx := ctxWithIdentity(mcp.KeyIdentity{KeyID: "key-infer", Role: "system_admin"})
+
+	// Execute code that calls the tool.
+	result, err := svc.ExecuteCode(ctx, `
+		async function run() {
+			const r = await tools["`+alias+`"].my_tool({});
+			return JSON.stringify(r);
+		}
+		await run();
+	`, nil)
+	if err != nil {
+		t.Fatalf("ExecuteCode: %v", err)
+	}
+	if result.Error != "" {
+		t.Fatalf("ExecuteCode result.Error = %q", result.Error)
+	}
+
+	// Wait for the async OnToolResult goroutine to write the schema.
+	pollUntilSchemaInferred(t, database, sv.ID, "my_tool", 500*time.Millisecond)
+
+	// Now call toolsListHook and verify the execute_code description contains
+	// the inferred TypeScript return type.
+	hook := svc.toolsListHook()
+	inputTools := []mcp.Tool{
+		{Name: "execute_code", Description: "original"},
+	}
+	got := hook(inputTools)
+
+	if len(got) != 1 {
+		t.Fatalf("hook returned %d tools, want 1", len(got))
+	}
+	desc := got[0].Description
+
+	// {"users":[{"id":1,"name":"a"}]} infers:
+	//   object with property "users" of type Array<{ id: number; name: string }>
+	// schemaToTypeScript produces: { users: Array<{ id: number; name: string }> }
+	const wantType = "Promise<{ users: Array<{ id: number; name: string }> }>"
+	if !strings.Contains(desc, wantType) {
+		t.Errorf("description does not contain %q\ngot: %s", wantType, desc)
+	}
+
+	const wantComment = "// inferred - could depend on previous query"
+	if !strings.Contains(desc, wantComment) {
+		t.Errorf("description does not contain %q\ngot: %s", wantComment, desc)
+	}
+}
+
+// TestCodeMode_TTLPreventsReinference verifies that a second tool call within
+// the schema TTL does not update the inferred_at timestamp.
+func TestCodeMode_TTLPreventsReinference(t *testing.T) {
+	t.Parallel()
+
+	const alias = "ttlsrv"
+
+	toolPayload := json.RawMessage(`{"value":1}`)
+
+	svc, database, sv := setupSchemaInferenceTest(t, alias, time.Hour, toolPayload)
+
+	ctx := ctxWithIdentity(mcp.KeyIdentity{KeyID: "key-ttl", Role: "system_admin"})
+
+	callScript := `
+		async function run() {
+			const r = await tools["` + alias + `"].my_tool({});
+			return JSON.stringify(r);
+		}
+		await run();
+	`
+
+	// First call — schema should be inferred and persisted.
+	if _, err := svc.ExecuteCode(ctx, callScript, nil); err != nil {
+		t.Fatalf("first ExecuteCode: %v", err)
+	}
+	pollUntilSchemaInferred(t, database, sv.ID, "my_tool", 500*time.Millisecond)
+	firstInferredAt := readInferredAt(t, database, sv.ID, "my_tool")
+
+	// Second call — within the 1h TTL so schema is not stale; inferred_at must be unchanged.
+	if _, err := svc.ExecuteCode(ctx, callScript, nil); err != nil {
+		t.Fatalf("second ExecuteCode: %v", err)
+	}
+	// Brief pause to let the goroutine run if it was (incorrectly) triggered.
+	time.Sleep(100 * time.Millisecond)
+
+	secondInferredAt := readInferredAt(t, database, sv.ID, "my_tool")
+	if firstInferredAt != secondInferredAt {
+		t.Errorf("inferred_at changed on second call within TTL:\n  first  = %s\n  second = %s", firstInferredAt, secondInferredAt)
+	}
+}
+
+// TestCodeMode_ZeroTTLAllowsIndefiniteCache verifies that schemaTTL=0 means
+// "never stale" — a row that already exists is never overwritten on re-calls.
+func TestCodeMode_ZeroTTLAllowsIndefiniteCache(t *testing.T) {
+	t.Parallel()
+
+	const alias = "zerosrv"
+
+	toolPayload := json.RawMessage(`{"ok":true}`)
+
+	svc, database, sv := setupSchemaInferenceTest(t, alias, 0, toolPayload)
+
+	ctx := ctxWithIdentity(mcp.KeyIdentity{KeyID: "key-zero", Role: "system_admin"})
+
+	callScript := `
+		async function run() {
+			const r = await tools["` + alias + `"].my_tool({});
+			return JSON.stringify(r);
+		}
+		await run();
+	`
+
+	// First call — schema is written because no row exists yet (missing = stale).
+	if _, err := svc.ExecuteCode(ctx, callScript, nil); err != nil {
+		t.Fatalf("first ExecuteCode: %v", err)
+	}
+	pollUntilSchemaInferred(t, database, sv.ID, "my_tool", 500*time.Millisecond)
+	firstInferredAt := readInferredAt(t, database, sv.ID, "my_tool")
+
+	// Second call — schemaTTL=0 means the existing row is never stale; no update.
+	if _, err := svc.ExecuteCode(ctx, callScript, nil); err != nil {
+		t.Fatalf("second ExecuteCode: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	secondInferredAt := readInferredAt(t, database, sv.ID, "my_tool")
+	if firstInferredAt != secondInferredAt {
+		t.Errorf("inferred_at changed with schemaTTL=0 (should never re-infer):\n  first  = %s\n  second = %s", firstInferredAt, secondInferredAt)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// toolsListHook description-content regression test (L-013)
+// ---------------------------------------------------------------------------
+
+// TestToolsListHook_InjectsCodeModePreference verifies that the dynamic hook
+// appends the full "## Available Tools" section to the execute_code description
+// and that the result retains all STRONG PREFERENCE / PATTERNS / NOTE guidance
+// from the static CodeModeDescription(). It also asserts that the old trailing
+// "Call tools via `await tools.serverAlias.toolName(args)`" sentence, which
+// was removed during L-013, is no longer present.
+func TestToolsListHook_InjectsCodeModePreference(t *testing.T) {
+	t.Parallel()
+
+	// Seed the tool cache with one server that has one tool with a required
+	// string parameter — GenerateToolTypeDefs will emit a Promise<any> signature.
+	tc := newPreloadedCache(t, map[string][]mcp.Tool{
+		"myserver": {
+			{
+				Name:        "fetch_data",
+				Description: "Fetches data by ID",
+				InputSchema: mcp.InputSchema{
+					Type: "object",
+					Properties: map[string]mcp.Property{
+						"id": {Type: "string", Description: "Record ID"},
+					},
+					Required: []string{"id"},
+				},
+			},
+		},
+	})
+
+	svc := &codeModeService{
+		db:        &mockCodeModeDB{},
+		toolCache: tc,
+		log:       newDiscardLogger(),
+	}
+
+	hook := svc.toolsListHook()
+
+	// The hook receives the static description that RegisterCodeModeTools wires.
+	inputTools := []mcp.Tool{
+		{
+			Name:        "execute_code",
+			Description: mcp.CodeModeDescription(),
+		},
+	}
+
+	got := hook(inputTools)
+	if len(got) != 1 {
+		t.Fatalf("hook changed tool count: got %d, want 1", len(got))
+	}
+
+	desc := got[0].Description
+
+	// Static guidance must survive the hook — if STRONG PREFERENCE disappears the
+	// LLM loses critical workflow instructions.
+	if !strings.Contains(desc, "STRONG PREFERENCE") {
+		t.Errorf("execute_code description after hook missing STRONG PREFERENCE;\ngot: %s", desc)
+	}
+
+	// Dynamic section must be appended with blank-line padding so the markdown
+	// heading renders correctly for the LLM.
+	if !strings.Contains(desc, "\n\n## Available Tools\n\n") {
+		t.Errorf("execute_code description after hook missing '\\n\\n## Available Tools\\n\\n' (with surrounding blank lines);\ngot: %s", desc)
+	}
+
+	// TypeScript type definitions must appear (Promise<any> is the default for a
+	// tool whose output schema has not yet been inferred).
+	if !strings.Contains(desc, "Promise<") {
+		t.Errorf("execute_code description after hook missing TypeScript Promise type;\ngot: %s", desc)
+	}
+
+	// The specific tool name injected by the cache must appear.
+	if !strings.Contains(desc, "fetch_data") {
+		t.Errorf("execute_code description after hook missing tool name 'fetch_data';\ngot: %s", desc)
+	}
+
+	// The old trailing call-syntax sentence was dropped in L-013.  If it comes
+	// back a refactor has reintroduced it — that would be a regression.
+	const droppedSentence = "Call tools via `await tools.serverAlias.toolName(args)`"
+	if strings.Contains(desc, droppedSentence) {
+		t.Errorf("execute_code description contains dropped sentence %q — was it re-added by mistake?", droppedSentence)
 	}
 }

--- a/internal/app/code_mode_test.go
+++ b/internal/app/code_mode_test.go
@@ -6,11 +6,14 @@ package app
 // an in-process mcp.Executor / mcp.ToolCache — no real database, no real HTTP.
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -39,6 +42,8 @@ type mockCodeModeDB struct {
 	blockedTools map[string][]string
 	// listErr is returned by all List* methods when non-nil.
 	listErr error
+	// saveErr is returned by SaveOutputSchema when non-nil.
+	saveErr error
 	// outputSchemasByServerID maps serverID → (toolName → schema JSON) for
 	// GetAllOutputSchemas. When nil the method returns nil, nil (no schemas).
 	outputSchemasByServerID map[string]map[string]jsonx.RawMessage
@@ -80,7 +85,7 @@ func (m *mockCodeModeDB) ListBlockedToolNames(_ context.Context, serverID string
 }
 
 func (m *mockCodeModeDB) SaveOutputSchema(_ context.Context, _, _ string, _ jsonx.RawMessage) error {
-	return nil
+	return m.saveErr
 }
 
 func (m *mockCodeModeDB) GetAllOutputSchemas(_ context.Context, serverID string, _ time.Duration) (map[string]jsonx.RawMessage, error) {
@@ -1677,4 +1682,186 @@ func TestToolsListHook_InjectsCodeModePreference(t *testing.T) {
 	if strings.Contains(desc, droppedSentence) {
 		t.Errorf("execute_code description contains dropped sentence %q — was it re-added by mistake?", droppedSentence)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// SaveOutputSchema error logging test
+// ---------------------------------------------------------------------------
+
+// TestExecuteCode_SaveOutputSchemaError_Logged verifies that when SaveOutputSchema
+// returns an error the codeModeService logs a WARN-level message containing the
+// expected message text and the underlying error string. The OnToolResult hook
+// runs in a goroutine after ExecuteCode returns, so the test polls for the log
+// entry with a short deadline.
+func TestExecuteCode_SaveOutputSchemaError_Logged(t *testing.T) {
+	t.Parallel()
+
+	const orgID = "org-save-err"
+	sv := db.MCPServer{
+		ID:              "sv-save-err",
+		Alias:           "save-err-srv",
+		Name:            "Save Err Server",
+		OrgID:           ptrStr(orgID),
+		CodeModeEnabled: true,
+	}
+
+	// SaveOutputSchema will return this error.
+	saveError := errors.New("disk full")
+
+	mock := &mockCodeModeDB{
+		orgServers: map[string][]db.MCPServer{orgID: {sv}},
+		saveErr:    saveError,
+		// IsOutputSchemaStale returns true (default in the mock), so the
+		// OnToolResult hook will proceed past the stale check and attempt to save.
+	}
+
+	tools := []mcp.Tool{
+		{
+			Name:        "my_tool",
+			Description: "A tool with valid JSON output",
+			InputSchema: mcp.InputSchema{Type: "object"},
+		},
+	}
+	tc := newPreloadedCache(t, map[string][]mcp.Tool{sv.ID: tools})
+	executor := newTestExecutor(t)
+
+	// Caller returns valid JSON so InferSchema produces a non-nil schema, which
+	// triggers the SaveOutputSchema path inside OnToolResult.
+	caller := func(_ context.Context, _ *auth.KeyInfo, _, _ string, _ json.RawMessage, _ bool, _ string) (json.RawMessage, error) {
+		return json.RawMessage(`{"result":"ok","count":1}`), nil
+	}
+
+	serverCache := &staticServerCache{
+		byID: map[string]*db.MCPServer{sv.ID: &sv},
+	}
+
+	// Wire a real JSON handler that captures log output to a buffer.
+	var buf syncBuffer
+	testLogger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+
+	svc := &codeModeService{
+		executor:     executor,
+		toolCache:    tc,
+		callMCPTool:  caller,
+		db:           mock,
+		log:          testLogger,
+		maxToolCalls: 10,
+		schemaTTL:    time.Hour,
+		serverCache:  serverCache,
+	}
+
+	ctx := ctxWithIdentity(mcp.KeyIdentity{OrgID: orgID, KeyID: "key-save-err", Role: "member"})
+	result, err := svc.ExecuteCode(ctx, `
+		async function run() {
+			const r = await tools["save-err-srv"].my_tool({});
+			return JSON.stringify(r);
+		}
+		await run();
+	`, nil)
+	if err != nil {
+		t.Fatalf("ExecuteCode() unexpected error: %v", err)
+	}
+	if result.Error != "" {
+		t.Fatalf("ExecuteCode() result.Error = %q, want empty", result.Error)
+	}
+
+	// The OnToolResult goroutine is fire-and-forget. Poll for the log line with
+	// a short deadline — 500 ms is generous for an in-process write.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		logged := buf.String()
+		if strings.Contains(logged, "schema inference: save failed") &&
+			strings.Contains(logged, "disk full") {
+			return // success
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Errorf("log did not contain expected WARN message within deadline\ngot: %s", buf.String())
+}
+
+// ---------------------------------------------------------------------------
+// SearchMCPTools: totalAvailable exceeds limit
+// ---------------------------------------------------------------------------
+
+// TestSearchMCPTools_TotalAvailableExceedsLimit verifies that when more than
+// searchToolsLimit tools match a query the result contains both the cap notice
+// "(showing N of M tools)" and that the cap reflects the actual counts. The
+// test seeds 60 matching tools so both the 50-tool cap and the truncation
+// notice are exercised.
+func TestSearchMCPTools_TotalAvailableExceedsLimit(t *testing.T) {
+	t.Parallel()
+
+	const orgID = "org-overlimit"
+	sv := db.MCPServer{
+		ID:              "sv-overlimit",
+		Alias:           "overlimit-srv",
+		Name:            "Over Limit Server",
+		OrgID:           ptrStr(orgID),
+		CodeModeEnabled: true,
+	}
+	mock := &mockCodeModeDB{
+		orgServers: map[string][]db.MCPServer{orgID: {sv}},
+	}
+
+	// Seed 60 tools whose names all contain the substring "match".
+	const totalTools = 60
+	toolList := make([]mcp.Tool, totalTools)
+	for i := range totalTools {
+		toolList[i] = mcp.Tool{
+			Name:        fmt.Sprintf("match_%02d", i),
+			Description: "matches the query",
+		}
+	}
+	tc := newPreloadedCache(t, map[string][]mcp.Tool{sv.ID: toolList})
+
+	svc := &codeModeService{
+		db:        mock,
+		toolCache: tc,
+		log:       newDiscardLogger(),
+	}
+
+	ctx := ctxWithIdentity(mcp.KeyIdentity{OrgID: orgID, KeyID: "key-ol", Role: "member"})
+	result, err := svc.SearchMCPTools(ctx, "match", nil)
+	if err != nil {
+		t.Fatalf("SearchMCPTools() error = %v", err)
+	}
+
+	// The cap notice must appear because totalAvailable (60) > matchCount (50).
+	wantNotice := fmt.Sprintf("(showing %d of %d tools)", searchToolsLimit, totalTools)
+	if !strings.Contains(result, wantNotice) {
+		t.Errorf("result missing truncation notice %q\ngot: %s", wantNotice, result)
+	}
+
+	// The header line must reflect the capped count (50), not the total (60).
+	wantHeader := fmt.Sprintf("Found %d tool(s) matching", searchToolsLimit)
+	if !strings.Contains(result, wantHeader) {
+		t.Errorf("result missing header %q\ngot: %s", wantHeader, result)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// syncBuffer is a bytes.Buffer wrapper that is safe for concurrent use.
+// It is used in tests where a goroutine writes log output via slog while
+// the test goroutine reads back the accumulated content.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (sb *syncBuffer) Write(p []byte) (int, error) {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	return sb.buf.Write(p)
+}
+
+func (sb *syncBuffer) String() string {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	return sb.buf.String()
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -360,6 +360,10 @@ type CodeModeConfig struct {
 	// single Code Mode execution. Prevents runaway scripts from making
 	// unbounded upstream calls. Default: 50. Valid range: [1, 1000].
 	MaxToolCalls int `yaml:"max_tool_calls"`
+	// SchemaTTL is the maximum age of an inferred output schema before it is
+	// re-inferred on the next tool call. Zero means never re-infer after the
+	// first successful inference. Defaults to 168h (7 days) if unset.
+	SchemaTTL time.Duration `yaml:"schema_ttl"`
 }
 
 // IsEnabled returns true only when Code Mode has been explicitly enabled via
@@ -791,6 +795,9 @@ func (c *Config) setDefaults() {
 		}
 		if c.Settings.MCP.CodeMode.MaxToolCalls == 0 {
 			c.Settings.MCP.CodeMode.MaxToolCalls = 50
+		}
+		if c.Settings.MCP.CodeMode.SchemaTTL == 0 {
+			c.Settings.MCP.CodeMode.SchemaTTL = 168 * time.Hour
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -361,9 +361,11 @@ type CodeModeConfig struct {
 	// unbounded upstream calls. Default: 50. Valid range: [1, 1000].
 	MaxToolCalls int `yaml:"max_tool_calls"`
 	// SchemaTTL is the maximum age of an inferred output schema before it is
-	// re-inferred on the next tool call. Zero means never re-infer after the
-	// first successful inference. Defaults to 168h (7 days) if unset.
-	SchemaTTL time.Duration `yaml:"schema_ttl"`
+	// re-inferred on the next tool call. Defaults to 168h (7 days) when unset.
+	// Set explicitly to 0 to disable re-inference after the first successful
+	// inference. Pointer type lets the YAML parser distinguish "absent"
+	// (apply default) from "explicitly zero" (never re-infer).
+	SchemaTTL *time.Duration `yaml:"schema_ttl"`
 }
 
 // IsEnabled returns true only when Code Mode has been explicitly enabled via
@@ -796,8 +798,9 @@ func (c *Config) setDefaults() {
 		if c.Settings.MCP.CodeMode.MaxToolCalls == 0 {
 			c.Settings.MCP.CodeMode.MaxToolCalls = 50
 		}
-		if c.Settings.MCP.CodeMode.SchemaTTL == 0 {
-			c.Settings.MCP.CodeMode.SchemaTTL = 168 * time.Hour
+		if c.Settings.MCP.CodeMode.SchemaTTL == nil {
+			d := 168 * time.Hour
+			c.Settings.MCP.CodeMode.SchemaTTL = &d
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1515,6 +1515,75 @@ func TestLoad_FallbackToDefaultsPicksUpAdminKey(t *testing.T) {
 	}
 }
 
+// ---- setDefaults — SchemaTTL pointer semantics -----------------------------
+
+// ptrDuration returns a pointer to a time.Duration value. Used to set
+// CodeModeConfig.SchemaTTL explicitly in tests.
+func ptrDuration(d time.Duration) *time.Duration { return &d }
+
+// minimalValidYAMLWithCodeMode returns a valid config YAML with code_mode
+// enabled. Individual tests set or omit schema_ttl as needed.
+func minimalValidYAMLWithCodeMode(codeModeBlock string) string {
+	return `
+server:
+  proxy:
+    port: 8080
+database:
+  driver: sqlite
+  dsn: voidllm.db
+settings:
+  encryption_key: aaaaaaaaaaaaaaaa
+  usage:
+    buffer_size: 100
+  mcp:
+    code_mode:
+      enabled: true
+` + codeModeBlock
+}
+
+// TestSetDefaults_SchemaTTL_NilDefaultsTo168h verifies that when CodeMode is
+// enabled but schema_ttl is absent from YAML (nil pointer), setDefaults fills
+// it in as 168h (7 days).
+func TestSetDefaults_SchemaTTL_NilDefaultsTo168h(t *testing.T) {
+	t.Parallel()
+
+	// No schema_ttl key at all — SchemaTTL pointer stays nil after unmarshal.
+	path := writeTemp(t, "voidllm.yaml", minimalValidYAMLWithCodeMode(""))
+	cfg, _, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	if cfg.Settings.MCP.CodeMode.SchemaTTL == nil {
+		t.Fatal("SchemaTTL is nil after setDefaults, want 168h")
+	}
+	if got := *cfg.Settings.MCP.CodeMode.SchemaTTL; got != 168*time.Hour {
+		t.Errorf("*SchemaTTL = %v, want %v", got, 168*time.Hour)
+	}
+}
+
+// TestSetDefaults_SchemaTTL_ExplicitZeroIsPreserved verifies that when
+// schema_ttl is explicitly set to 0s in YAML the value is preserved as 0 after
+// setDefaults — it must NOT be overwritten to the 168h default. This locks in
+// the fix that distinguishes "absent" (nil → default) from "explicitly zero"
+// (non-nil zero → keep as-is).
+func TestSetDefaults_SchemaTTL_ExplicitZeroIsPreserved(t *testing.T) {
+	t.Parallel()
+
+	path := writeTemp(t, "voidllm.yaml", minimalValidYAMLWithCodeMode("      schema_ttl: 0s\n"))
+	cfg, _, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	if cfg.Settings.MCP.CodeMode.SchemaTTL == nil {
+		t.Fatal("SchemaTTL is nil after setDefaults, want explicit 0")
+	}
+	if got := *cfg.Settings.MCP.CodeMode.SchemaTTL; got != 0 {
+		t.Errorf("*SchemaTTL = %v, want 0 (explicit zero must not be overwritten to 168h)", got)
+	}
+}
+
 // ---- Load — full integration -----------------------------------------------
 
 func TestLoad_FullConfig(t *testing.T) {

--- a/internal/db/migrations/0012_output_schemas.down.sql
+++ b/internal/db/migrations/0012_output_schemas.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_output_schemas_server;
+DROP TABLE IF EXISTS output_schemas;

--- a/internal/db/migrations/0012_output_schemas.up.sql
+++ b/internal/db/migrations/0012_output_schemas.up.sql
@@ -1,0 +1,13 @@
+-- Migration: 0012_output_schemas.up.sql
+-- Description: Stores inferred JSON Schema documents for MCP tool outputs, keyed by server and tool name.
+
+CREATE TABLE output_schemas (
+    id            TEXT PRIMARY KEY,
+    server_id     TEXT NOT NULL REFERENCES mcp_servers(id) ON DELETE CASCADE,
+    tool_name     TEXT NOT NULL,
+    schema_json   TEXT NOT NULL,
+    inferred_at   TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (server_id, tool_name)
+);
+
+CREATE INDEX idx_output_schemas_server ON output_schemas (server_id);

--- a/internal/db/output_schemas.go
+++ b/internal/db/output_schemas.go
@@ -1,0 +1,121 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/voidmind-io/voidllm/internal/jsonx"
+)
+
+// sqliteTimestampLayout is the format produced by SQLite's CURRENT_TIMESTAMP
+// function when the column type is TEXT. PostgreSQL uses RFC3339.
+const sqliteTimestampLayout = "2006-01-02 15:04:05"
+
+// SaveOutputSchema upserts the inferred JSON Schema for a single tool on the
+// given MCP server. If a row already exists for the (server_id, tool_name) pair
+// its schema_json and inferred_at are updated to the new values.
+func (d *DB) SaveOutputSchema(ctx context.Context, serverID, toolName string, schema jsonx.RawMessage) error {
+	id, err := uuid.NewV7()
+	if err != nil {
+		return fmt.Errorf("save output schema: generate id: %w", err)
+	}
+
+	p := d.dialect.Placeholder
+	query := "INSERT INTO output_schemas (id, server_id, tool_name, schema_json, inferred_at) " +
+		"VALUES (" + p(1) + ", " + p(2) + ", " + p(3) + ", " + p(4) + ", CURRENT_TIMESTAMP) " +
+		"ON CONFLICT(server_id, tool_name) DO UPDATE SET " +
+		"schema_json = excluded.schema_json, inferred_at = CURRENT_TIMESTAMP"
+
+	if _, err := d.sql.ExecContext(ctx, query, id.String(), serverID, toolName, string(schema)); err != nil {
+		return fmt.Errorf("save output schema (%s, %s): %w", serverID, toolName, translateError(err))
+	}
+	return nil
+}
+
+// GetAllOutputSchemas returns all stored output schemas for the given MCP server
+// as a map of tool name to raw JSON schema. When maxAge is greater than zero,
+// rows whose inferred_at timestamp is older than maxAge are excluded from the
+// result. When maxAge is zero or negative all rows are returned regardless of age.
+func (d *DB) GetAllOutputSchemas(ctx context.Context, serverID string, maxAge time.Duration) (map[string]jsonx.RawMessage, error) {
+	p := d.dialect.Placeholder
+	query := "SELECT tool_name, schema_json, inferred_at FROM output_schemas WHERE server_id = " + p(1)
+
+	rows, err := d.sql.QueryContext(ctx, query, serverID)
+	if err != nil {
+		return nil, fmt.Errorf("get all output schemas query: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]jsonx.RawMessage)
+	for rows.Next() {
+		var toolName, schemaJSON, inferredAtRaw string
+		if scanErr := rows.Scan(&toolName, &schemaJSON, &inferredAtRaw); scanErr != nil {
+			return nil, fmt.Errorf("get all output schemas scan: %w", scanErr)
+		}
+		if maxAge > 0 {
+			inferredAt, parseErr := parseTimestamp(inferredAtRaw)
+			if parseErr != nil {
+				return nil, fmt.Errorf("get all output schemas: parse inferred_at %q: %w", inferredAtRaw, parseErr)
+			}
+			if time.Since(inferredAt) > maxAge {
+				continue
+			}
+		}
+		result[toolName] = jsonx.RawMessage(schemaJSON)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("get all output schemas rows: %w", err)
+	}
+
+	return result, nil
+}
+
+// IsOutputSchemaStale reports whether the stored output schema for the given
+// (serverID, toolName) pair is absent or older than maxAge. A missing row is
+// treated as stale so the caller re-infers the schema. When maxAge is zero or
+// negative the schema is never considered stale provided a row exists.
+func (d *DB) IsOutputSchemaStale(ctx context.Context, serverID, toolName string, maxAge time.Duration) (bool, error) {
+	p := d.dialect.Placeholder
+	query := "SELECT inferred_at FROM output_schemas WHERE server_id = " + p(1) + " AND tool_name = " + p(2)
+
+	var inferredAtRaw string
+	err := d.sql.QueryRowContext(ctx, query, serverID, toolName).Scan(&inferredAtRaw)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return true, nil
+		}
+		return false, fmt.Errorf("is output schema stale (%s, %s): %w", serverID, toolName, err)
+	}
+
+	if maxAge <= 0 {
+		return false, nil
+	}
+
+	inferredAt, parseErr := parseTimestamp(inferredAtRaw)
+	if parseErr != nil {
+		return false, fmt.Errorf("is output schema stale: parse inferred_at %q: %w", inferredAtRaw, parseErr)
+	}
+
+	return time.Since(inferredAt) > maxAge, nil
+}
+
+// parseTimestamp parses a TEXT timestamp as written by CURRENT_TIMESTAMP from
+// either SQLite ("2006-01-02 15:04:05") or PostgreSQL (RFC3339 / RFC3339Nano).
+// All values are interpreted as UTC.
+func parseTimestamp(s string) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
+		return t, nil
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		return t, nil
+	}
+	if t, err := time.Parse(sqliteTimestampLayout, s); err == nil {
+		return t.UTC(), nil
+	}
+	return time.Time{}, fmt.Errorf("unrecognised timestamp format %q", s)
+}

--- a/internal/db/output_schemas_test.go
+++ b/internal/db/output_schemas_test.go
@@ -1,0 +1,281 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/voidmind-io/voidllm/internal/jsonx"
+)
+
+const sqliteTimestampFmt = "2006-01-02 15:04:05"
+
+// mustSaveOutputSchema saves an output schema and fails the test on error.
+func mustSaveOutputSchema(t *testing.T, d *DB, serverID, toolName string, schema jsonx.RawMessage) {
+	t.Helper()
+	if err := d.SaveOutputSchema(context.Background(), serverID, toolName, schema); err != nil {
+		t.Fatalf("mustSaveOutputSchema(server=%q, tool=%q): %v", serverID, toolName, err)
+	}
+}
+
+// ageOutputSchema sets the inferred_at column for a (server, tool) row to a
+// specific time, allowing staleness tests to work without sleeping.
+func ageOutputSchema(t *testing.T, d *DB, serverID, toolName string, age time.Time) {
+	t.Helper()
+	ts := age.UTC().Format(sqliteTimestampFmt)
+	_, err := d.sql.ExecContext(
+		context.Background(),
+		"UPDATE output_schemas SET inferred_at = ? WHERE server_id = ? AND tool_name = ?",
+		ts, serverID, toolName,
+	)
+	if err != nil {
+		t.Fatalf("ageOutputSchema(%q, %q, %q): %v", serverID, toolName, ts, err)
+	}
+}
+
+// ---- SaveOutputSchema --------------------------------------------------------
+
+func TestSaveOutputSchema_Inserts(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	server := mustCreateMCPServer(t, d, defaultMCPParams("schema-insert"))
+
+	schema := jsonx.RawMessage(`{"type":"object","properties":{"id":{"type":"number"}}}`)
+	mustSaveOutputSchema(t, d, server.ID, "list_repos", schema)
+
+	schemas, err := d.GetAllOutputSchemas(context.Background(), server.ID, 0)
+	if err != nil {
+		t.Fatalf("GetAllOutputSchemas() error = %v, want nil", err)
+	}
+	if len(schemas) != 1 {
+		t.Fatalf("GetAllOutputSchemas() len = %d, want 1", len(schemas))
+	}
+	got, ok := schemas["list_repos"]
+	if !ok {
+		t.Fatalf("GetAllOutputSchemas(): key %q missing from result %v", "list_repos", schemas)
+	}
+
+	// Compare parsed representations to be key-order agnostic.
+	var gotMap, wantMap map[string]any
+	if err := jsonx.Unmarshal(got, &gotMap); err != nil {
+		t.Fatalf("unmarshal got schema: %v", err)
+	}
+	if err := jsonx.Unmarshal(schema, &wantMap); err != nil {
+		t.Fatalf("unmarshal want schema: %v", err)
+	}
+	if gotMap["type"] != wantMap["type"] {
+		t.Errorf("schema type = %q, want %q", gotMap["type"], wantMap["type"])
+	}
+}
+
+func TestSaveOutputSchema_Upserts(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	server := mustCreateMCPServer(t, d, defaultMCPParams("schema-upsert"))
+
+	schemaA := jsonx.RawMessage(`{"type":"string"}`)
+	schemaB := jsonx.RawMessage(`{"type":"number"}`)
+
+	mustSaveOutputSchema(t, d, server.ID, "my_tool", schemaA)
+	mustSaveOutputSchema(t, d, server.ID, "my_tool", schemaB)
+
+	schemas, err := d.GetAllOutputSchemas(context.Background(), server.ID, 0)
+	if err != nil {
+		t.Fatalf("GetAllOutputSchemas() error = %v, want nil", err)
+	}
+	if len(schemas) != 1 {
+		t.Fatalf("GetAllOutputSchemas() len = %d, want 1 after upsert", len(schemas))
+	}
+
+	// Verify the stored value is schemaB.
+	got := schemas["my_tool"]
+	var gotMap map[string]any
+	if err := jsonx.Unmarshal(got, &gotMap); err != nil {
+		t.Fatalf("unmarshal stored schema: %v", err)
+	}
+	if gotMap["type"] != "number" {
+		t.Errorf("upserted schema type = %q, want %q", gotMap["type"], "number")
+	}
+
+	// Confirm exactly one row in the table.
+	var rowCount int
+	if err := d.sql.QueryRowContext(
+		context.Background(),
+		"SELECT COUNT(*) FROM output_schemas WHERE server_id = ? AND tool_name = ?",
+		server.ID, "my_tool",
+	).Scan(&rowCount); err != nil {
+		t.Fatalf("count query: %v", err)
+	}
+	if rowCount != 1 {
+		t.Errorf("output_schemas row count = %d, want 1 after upsert", rowCount)
+	}
+}
+
+// ---- GetAllOutputSchemas -----------------------------------------------------
+
+func TestGetAllOutputSchemas_FiltersStale(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	server := mustCreateMCPServer(t, d, defaultMCPParams("schema-stale-filter"))
+
+	mustSaveOutputSchema(t, d, server.ID, "old_tool", jsonx.RawMessage(`{"type":"string"}`))
+	// Age the row to 10 minutes ago.
+	ageOutputSchema(t, d, server.ID, "old_tool", time.Now().Add(-10*time.Minute))
+
+	// maxAge = 5 minutes → row is 10 min old → filtered out.
+	schemas, err := d.GetAllOutputSchemas(context.Background(), server.ID, 5*time.Minute)
+	if err != nil {
+		t.Fatalf("GetAllOutputSchemas(maxAge=5m) error = %v, want nil", err)
+	}
+	if len(schemas) != 0 {
+		t.Errorf("GetAllOutputSchemas(maxAge=5m) len = %d, want 0 (stale row filtered)", len(schemas))
+	}
+
+	// maxAge = 0 → all rows returned regardless of age.
+	schemas, err = d.GetAllOutputSchemas(context.Background(), server.ID, 0)
+	if err != nil {
+		t.Fatalf("GetAllOutputSchemas(maxAge=0) error = %v, want nil", err)
+	}
+	if len(schemas) != 1 {
+		t.Errorf("GetAllOutputSchemas(maxAge=0) len = %d, want 1 (zero TTL returns all)", len(schemas))
+	}
+}
+
+func TestGetAllOutputSchemas_ZeroMaxAgeReturnsAll(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	server := mustCreateMCPServer(t, d, defaultMCPParams("schema-zero-ttl"))
+
+	mustSaveOutputSchema(t, d, server.ID, "tool_a", jsonx.RawMessage(`{"type":"string"}`))
+	mustSaveOutputSchema(t, d, server.ID, "tool_b", jsonx.RawMessage(`{"type":"number"}`))
+	// Age both rows to well beyond any reasonable maxAge.
+	ageOutputSchema(t, d, server.ID, "tool_a", time.Now().Add(-24*time.Hour))
+	ageOutputSchema(t, d, server.ID, "tool_b", time.Now().Add(-48*time.Hour))
+
+	schemas, err := d.GetAllOutputSchemas(context.Background(), server.ID, 0)
+	if err != nil {
+		t.Fatalf("GetAllOutputSchemas(maxAge=0) error = %v, want nil", err)
+	}
+	if len(schemas) != 2 {
+		t.Errorf("GetAllOutputSchemas(maxAge=0) len = %d, want 2 (zero TTL returns all)", len(schemas))
+	}
+}
+
+// ---- IsOutputSchemaStale -----------------------------------------------------
+
+func TestIsOutputSchemaStale_MissingIsStale(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	server := mustCreateMCPServer(t, d, defaultMCPParams("schema-missing-stale"))
+
+	stale, err := d.IsOutputSchemaStale(context.Background(), server.ID, "nonexistent_tool", time.Hour)
+	if err != nil {
+		t.Fatalf("IsOutputSchemaStale() error = %v, want nil", err)
+	}
+	if !stale {
+		t.Error("IsOutputSchemaStale() = false, want true for missing row")
+	}
+}
+
+func TestIsOutputSchemaStale_FreshIsNotStale(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	server := mustCreateMCPServer(t, d, defaultMCPParams("schema-fresh"))
+
+	mustSaveOutputSchema(t, d, server.ID, "fresh_tool", jsonx.RawMessage(`{"type":"string"}`))
+
+	stale, err := d.IsOutputSchemaStale(context.Background(), server.ID, "fresh_tool", time.Hour)
+	if err != nil {
+		t.Fatalf("IsOutputSchemaStale() error = %v, want nil", err)
+	}
+	if stale {
+		t.Error("IsOutputSchemaStale() = true, want false for freshly inserted row")
+	}
+}
+
+func TestIsOutputSchemaStale_ExpiredIsStale(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	server := mustCreateMCPServer(t, d, defaultMCPParams("schema-expired"))
+
+	mustSaveOutputSchema(t, d, server.ID, "old_tool", jsonx.RawMessage(`{"type":"boolean"}`))
+	ageOutputSchema(t, d, server.ID, "old_tool", time.Now().Add(-10*time.Minute))
+
+	stale, err := d.IsOutputSchemaStale(context.Background(), server.ID, "old_tool", 5*time.Minute)
+	if err != nil {
+		t.Fatalf("IsOutputSchemaStale() error = %v, want nil", err)
+	}
+	if !stale {
+		t.Error("IsOutputSchemaStale() = false, want true for row aged beyond maxAge")
+	}
+}
+
+func TestIsOutputSchemaStale_ZeroMaxAgeNeverStale(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	server := mustCreateMCPServer(t, d, defaultMCPParams("schema-zero-ttl-stale"))
+
+	mustSaveOutputSchema(t, d, server.ID, "any_tool", jsonx.RawMessage(`{"type":"string"}`))
+	ageOutputSchema(t, d, server.ID, "any_tool", time.Now().Add(-365*24*time.Hour))
+
+	stale, err := d.IsOutputSchemaStale(context.Background(), server.ID, "any_tool", 0)
+	if err != nil {
+		t.Fatalf("IsOutputSchemaStale(maxAge=0) error = %v, want nil", err)
+	}
+	if stale {
+		t.Error("IsOutputSchemaStale(maxAge=0) = true, want false (zero TTL disables staleness check)")
+	}
+}
+
+// ---- Cascade on server delete ------------------------------------------------
+
+func TestOutputSchemas_CascadeOnServerDelete(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	server := mustCreateMCPServer(t, d, defaultMCPParams("schema-cascade"))
+
+	mustSaveOutputSchema(t, d, server.ID, "tool_one", jsonx.RawMessage(`{"type":"string"}`))
+	mustSaveOutputSchema(t, d, server.ID, "tool_two", jsonx.RawMessage(`{"type":"number"}`))
+
+	// Verify the rows exist before deletion.
+	var before int
+	if err := d.sql.QueryRowContext(
+		context.Background(),
+		"SELECT COUNT(*) FROM output_schemas WHERE server_id = ?", server.ID,
+	).Scan(&before); err != nil {
+		t.Fatalf("pre-delete count query: %v", err)
+	}
+	if before != 2 {
+		t.Fatalf("pre-delete output_schemas count = %d, want 2", before)
+	}
+
+	// Delete the server row directly (hard delete) to trigger ON DELETE CASCADE.
+	// DeleteMCPServer performs a soft-delete (sets deleted_at) and does not remove
+	// the row, so it would not fire the FK cascade. A hard DELETE is required.
+	if _, err := d.sql.ExecContext(
+		context.Background(),
+		"DELETE FROM mcp_servers WHERE id = ?", server.ID,
+	); err != nil {
+		t.Fatalf("hard DELETE mcp_servers: %v", err)
+	}
+
+	var after int
+	if err := d.sql.QueryRowContext(
+		context.Background(),
+		"SELECT COUNT(*) FROM output_schemas WHERE server_id = ?", server.ID,
+	).Scan(&after); err != nil {
+		t.Fatalf("post-delete count query: %v", err)
+	}
+	if after != 0 {
+		t.Errorf("post-delete output_schemas count = %d, want 0 (ON DELETE CASCADE)", after)
+	}
+}

--- a/internal/mcp/codemode_exec.go
+++ b/internal/mcp/codemode_exec.go
@@ -58,6 +58,11 @@ type ExecuteParams struct {
 	// this execute_code invocation. It is threaded through to every tool call
 	// log so that all tool calls from one execution can be grouped together.
 	ExecutionID string
+	// OnToolResult is an optional hook called after each successful tool call
+	// with the unwrapped result. It is invoked in a separate goroutine and must
+	// not block. serverAlias and toolName identify the tool; result is the
+	// unwrapped JSON payload.
+	OnToolResult func(serverAlias, toolName string, result jsonx.RawMessage)
 }
 
 // ExecuteResult holds the output of a Code Mode script execution.
@@ -224,7 +229,14 @@ func (e *Executor) Execute(ctx context.Context, params ExecuteParams) (res *Exec
 			this.Promise().Reject(qctx.ThrowError(callErr))
 			return
 		}
-		this.Promise().Resolve(qctx.ParseJSON(string(callResult)))
+		unwrapped := unwrapToolResult(callResult)
+		const maxCaptureSize = 1 << 20 // 1 MB — skip inference for huge responses to bound memory.
+		if params.OnToolResult != nil && len(unwrapped) <= maxCaptureSize {
+			captured := make(jsonx.RawMessage, len(unwrapped))
+			copy(captured, unwrapped)
+			go params.OnToolResult(entry.alias, entry.tool, captured)
+		}
+		this.Promise().Resolve(qctx.ParseJSON(string(unwrapped)))
 	})
 
 	preamble := buildProxyPreamble(params.ServerTools)

--- a/internal/mcp/codemode_exec_test.go
+++ b/internal/mcp/codemode_exec_test.go
@@ -992,6 +992,44 @@ func TestExecute_ToolCallsNonNil(t *testing.T) {
 	}
 }
 
+// ---- ToolResult unwrapping ---------------------------------------------------
+
+// TestExecute_ToolResultUnwrapped verifies that a ToolResult wrapper returned
+// by a mock tool caller is transparently unwrapped before the script sees it.
+// The script accesses r.key directly rather than r.content[0].text.
+func TestExecute_ToolResultUnwrapped(t *testing.T) {
+	t.Parallel()
+
+	exec := newTestExecutor(t)
+
+	caller := mockToolCaller(map[string]json.RawMessage{
+		"srv/tool": json.RawMessage(`{"content":[{"type":"text","text":"{\"key\":\"value\"}"}]}`),
+	})
+
+	res, err := exec.Execute(context.Background(), mcp.ExecuteParams{
+		Code: `
+			async function main() {
+				const r = await tools.srv.tool({});
+				return JSON.stringify(r.key);
+			}
+			await main();
+		`,
+		ServerTools: map[string][]mcp.Tool{
+			"srv": {{Name: "tool"}},
+		},
+		CallTool: caller,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if res.Error != "" {
+		t.Fatalf("Execute() result.Error = %q", res.Error)
+	}
+	if string(res.Result) != `"value"` {
+		t.Errorf("Result = %s, want %q (unwrapped inner field)", res.Result, `"value"`)
+	}
+}
+
 // ---- Benchmark ---------------------------------------------------------------
 
 func BenchmarkExecute_NoTools(b *testing.B) {

--- a/internal/mcp/codemode_schema.go
+++ b/internal/mcp/codemode_schema.go
@@ -1,0 +1,173 @@
+package mcp
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/voidmind-io/voidllm/internal/jsonx"
+)
+
+const (
+	maxSchemaDepth      = 3
+	maxSchemaProperties = 64
+	// maxInputDepth is the maximum bracket nesting depth (counting '[' and '{')
+	// tolerated by the pre-unmarshal depth scan in InferSchema. Inputs that
+	// exceed this limit are rejected before sonic allocates any memory for
+	// them, bounding CPU and heap usage on adversarial payloads.
+	maxInputDepth = 64
+	// maxPropTypeLen is the maximum length of a rendered TypeScript type string
+	// for a single object property. Values that exceed this are replaced with
+	// "any" to prevent description bloat from crafted deeply-nested schemas.
+	maxPropTypeLen = 500
+)
+
+// InferSchema walks a JSON value and produces a JSON-Schema-like map.
+// Max depth 3 — deeper objects become {"type": "object"}.
+// Objects with more than 64 properties collapse to {"type": "object"}.
+// Returns nil if raw is not valid JSON or if the raw bytes exceed
+// maxInputDepth bracket nesting (checked before unmarshalling to bound CPU
+// and memory usage on adversarial inputs).
+func InferSchema(raw jsonx.RawMessage) jsonx.RawMessage {
+	if exceedsMaxDepth(raw, maxInputDepth) {
+		return nil
+	}
+	var v any
+	if err := jsonx.Unmarshal(raw, &v); err != nil {
+		return nil
+	}
+	schema := inferValue(v, 0)
+	out, _ := jsonx.Marshal(schema)
+	return out
+}
+
+// exceedsMaxDepth reports whether raw contains a bracket nesting run longer
+// than limit. It counts '[' and '{' without parsing string contents, so a
+// string value like "[[[" inflates the count. This conservative over-count is
+// intentional: the purpose is DoS prevention, not exactness.
+func exceedsMaxDepth(raw []byte, limit int) bool {
+	depth := 0
+	for _, b := range raw {
+		switch b {
+		case '[', '{':
+			depth++
+			if depth > limit {
+				return true
+			}
+		case ']', '}':
+			if depth > 0 {
+				depth--
+			}
+		}
+	}
+	return false
+}
+
+func inferValue(v any, depth int) map[string]any {
+	if depth > maxSchemaDepth {
+		return map[string]any{"type": "object"}
+	}
+	switch val := v.(type) {
+	case nil:
+		return map[string]any{"type": "string"} // safe fallback
+	case bool:
+		return map[string]any{"type": "boolean"}
+	case float64:
+		return map[string]any{"type": "number"}
+	case string:
+		return map[string]any{"type": "string"}
+	case []any:
+		if len(val) == 0 {
+			return map[string]any{"type": "array", "items": map[string]any{}}
+		}
+		return map[string]any{"type": "array", "items": inferValue(val[0], depth+1)}
+	case map[string]any:
+		if len(val) == 0 {
+			return map[string]any{"type": "object"}
+		}
+		if len(val) > maxSchemaProperties {
+			return map[string]any{"type": "object"}
+		}
+		props := make(map[string]any, len(val))
+		for k, child := range val {
+			props[k] = inferValue(child, depth+1)
+		}
+		return map[string]any{"type": "object", "properties": props}
+	default:
+		return map[string]any{"type": "any"}
+	}
+}
+
+// schemaToTypeScript converts an inferred JSON-Schema-like object to a
+// TypeScript type string.
+func schemaToTypeScript(schema jsonx.RawMessage) string {
+	var s map[string]any
+	if err := jsonx.Unmarshal(schema, &s); err != nil {
+		return "any"
+	}
+	return schemaTypeToTS(s)
+}
+
+// schemaTypeToTS recursively maps a parsed JSON Schema map to a TypeScript
+// type string. In the object branch, property names that are not valid JS
+// identifiers (as determined by isValidJSIdentifier) are silently dropped to
+// prevent a compromised upstream MCP server from injecting prompt-injection
+// payloads into the LLM-visible tool description via crafted property names.
+// If all properties are dropped the result falls back to Record<string, any>.
+// Property type strings longer than maxPropTypeLen characters are rendered as
+// "any" to prevent description bloat from pathologically wide schemas.
+func schemaTypeToTS(s map[string]any) string {
+	typ, _ := s["type"].(string)
+	switch typ {
+	case "string":
+		return "string"
+	case "number":
+		return "number"
+	case "boolean":
+		return "boolean"
+	case "array":
+		items, ok := s["items"].(map[string]any)
+		if !ok {
+			return "any[]"
+		}
+		return "Array<" + schemaTypeToTS(items) + ">"
+	case "object":
+		props, ok := s["properties"].(map[string]any)
+		if !ok || len(props) == 0 {
+			return "Record<string, any>"
+		}
+		// Collect only valid JS identifier keys to prevent injection via
+		// crafted property names. Sort for deterministic output.
+		keys := make([]string, 0, len(props))
+		for k := range props {
+			if isValidJSIdentifier(k) {
+				keys = append(keys, k)
+			}
+		}
+		if len(keys) == 0 {
+			return "Record<string, any>"
+		}
+		sort.Strings(keys)
+
+		var sb strings.Builder
+		sb.WriteString("{ ")
+		for i, k := range keys {
+			if i > 0 {
+				sb.WriteString("; ")
+			}
+			propSchema, ok := props[k].(map[string]any)
+			if !ok {
+				sb.WriteString(k + ": any")
+				continue
+			}
+			propType := schemaTypeToTS(propSchema)
+			if len(propType) > maxPropTypeLen {
+				propType = "any"
+			}
+			sb.WriteString(k + ": " + propType)
+		}
+		sb.WriteString(" }")
+		return sb.String()
+	default:
+		return "any"
+	}
+}

--- a/internal/mcp/codemode_schema.go
+++ b/internal/mcp/codemode_schema.go
@@ -19,6 +19,12 @@ const (
 	// for a single object property. Values that exceed this are replaced with
 	// "any" to prevent description bloat from crafted deeply-nested schemas.
 	maxPropTypeLen = 500
+	// maxTSRenderDepth caps recursion in schemaTypeToTS as defense-in-depth against
+	// malformed schemas read from the output_schemas table. InferSchema already
+	// caps inputs at maxSchemaDepth=3, but rendering reads from DB rows which could
+	// in principle be malformed. 10 is conservative — a 10-deep nested type
+	// already exceeds maxPropTypeLen and gets collapsed to "any" upstream.
+	maxTSRenderDepth = 10
 )
 
 // InferSchema walks a JSON value and produces a JSON-Schema-like map.
@@ -116,6 +122,13 @@ func schemaToTypeScript(schema jsonx.RawMessage) string {
 // Property type strings longer than maxPropTypeLen characters are rendered as
 // "any" to prevent description bloat from pathologically wide schemas.
 func schemaTypeToTS(s map[string]any) string {
+	return schemaTypeToTSInner(s, 0)
+}
+
+func schemaTypeToTSInner(s map[string]any, depth int) string {
+	if depth > maxTSRenderDepth {
+		return "any"
+	}
 	typ, _ := s["type"].(string)
 	switch typ {
 	case "string":
@@ -129,7 +142,7 @@ func schemaTypeToTS(s map[string]any) string {
 		if !ok {
 			return "any[]"
 		}
-		return "Array<" + schemaTypeToTS(items) + ">"
+		return "Array<" + schemaTypeToTSInner(items, depth+1) + ">"
 	case "object":
 		props, ok := s["properties"].(map[string]any)
 		if !ok || len(props) == 0 {
@@ -159,7 +172,7 @@ func schemaTypeToTS(s map[string]any) string {
 				sb.WriteString(k + ": any")
 				continue
 			}
-			propType := schemaTypeToTS(propSchema)
+			propType := schemaTypeToTSInner(propSchema, depth+1)
 			if len(propType) > maxPropTypeLen {
 				propType = "any"
 			}

--- a/internal/mcp/codemode_schema_test.go
+++ b/internal/mcp/codemode_schema_test.go
@@ -1,0 +1,406 @@
+package mcp_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/voidmind-io/voidllm/internal/jsonx"
+	"github.com/voidmind-io/voidllm/internal/mcp"
+)
+
+// TestInferSchema verifies that InferSchema returns a correct JSON-Schema-like
+// map for a wide range of input values and edge cases.
+func TestInferSchema(t *testing.T) {
+	t.Parallel()
+
+	// build65Keys constructs a JSON object literal with n integer-keyed properties.
+	build65Keys := func() jsonx.RawMessage {
+		var sb strings.Builder
+		sb.WriteString("{")
+		for i := range 65 {
+			if i > 0 {
+				sb.WriteString(",")
+			}
+			sb.WriteString(`"k` + strings.Repeat("x", i) + `":"v"`)
+		}
+		sb.WriteString("}")
+		return jsonx.RawMessage(sb.String())
+	}
+
+	tests := []struct {
+		name    string
+		input   jsonx.RawMessage
+		wantNil bool
+		want    map[string]any
+	}{
+		{
+			name:  "string primitive",
+			input: jsonx.RawMessage(`"hello"`),
+			want:  map[string]any{"type": "string"},
+		},
+		{
+			name:  "integer number primitive",
+			input: jsonx.RawMessage(`42`),
+			want:  map[string]any{"type": "number"},
+		},
+		{
+			name:  "float number primitive",
+			input: jsonx.RawMessage(`3.14`),
+			want:  map[string]any{"type": "number"},
+		},
+		{
+			name:  "boolean true primitive",
+			input: jsonx.RawMessage(`true`),
+			want:  map[string]any{"type": "boolean"},
+		},
+		{
+			name:  "boolean false primitive",
+			input: jsonx.RawMessage(`false`),
+			want:  map[string]any{"type": "boolean"},
+		},
+		{
+			name:  "null falls back to string",
+			input: jsonx.RawMessage(`null`),
+			want:  map[string]any{"type": "string"},
+		},
+		{
+			name:    "InvalidJSON returns nil",
+			input:   jsonx.RawMessage(`not json at all`),
+			wantNil: true,
+		},
+		{
+			name:  "EmptyObject",
+			input: jsonx.RawMessage(`{}`),
+			want:  map[string]any{"type": "object"},
+		},
+		{
+			name:  "EmptyArray",
+			input: jsonx.RawMessage(`[]`),
+			want:  map[string]any{"type": "array", "items": map[string]any{}},
+		},
+		{
+			name:  "ArrayOfStrings",
+			input: jsonx.RawMessage(`["a", "b"]`),
+			want:  map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+		},
+		{
+			name:  "ArrayOfNumbers",
+			input: jsonx.RawMessage(`[1, 2, 3]`),
+			want:  map[string]any{"type": "array", "items": map[string]any{"type": "number"}},
+		},
+		{
+			name:  "ArrayOfBooleans",
+			input: jsonx.RawMessage(`[true, false]`),
+			want:  map[string]any{"type": "array", "items": map[string]any{"type": "boolean"}},
+		},
+		{
+			name:  "ObjectWithMixedProperties",
+			input: jsonx.RawMessage(`{"name": "alice", "age": 30, "active": true}`),
+			want: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"name":   map[string]any{"type": "string"},
+					"age":    map[string]any{"type": "number"},
+					"active": map[string]any{"type": "boolean"},
+				},
+			},
+		},
+		{
+			name:  "NestedObject",
+			input: jsonx.RawMessage(`{"user": {"id": 1, "name": "a"}}`),
+			want: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"user": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"id":   map[string]any{"type": "number"},
+							"name": map[string]any{"type": "string"},
+						},
+					},
+				},
+			},
+		},
+		{
+			// maxSchemaDepth = 3. An object 4 levels deep means the innermost
+			// object is encountered at depth 4 (> 3) and is truncated.
+			// Structure: {"a": {"b": {"c": {"d": "leaf"}}}}
+			//   depth 0: outer object     → has properties
+			//   depth 1: "a" object       → has properties
+			//   depth 2: "b" object       → has properties
+			//   depth 3: "c" object       → has properties (depth == maxSchemaDepth, not > it)
+			//   depth 4: "d" leaf value   → this call has depth > maxSchemaDepth → truncated
+			// Wait — the depth check is `depth > maxSchemaDepth` before the switch.
+			// At depth 3 (the "c" object), we enter the map[string]any case and recurse
+			// into its child at depth 4. depth 4 > 3 → truncated to {type: "object"}.
+			name:  "DepthLimit",
+			input: jsonx.RawMessage(`{"a": {"b": {"c": {"d": "leaf"}}}}`),
+			want: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"a": map[string]any{
+						"type": "object",
+						"properties": map[string]any{
+							"b": map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"c": map[string]any{
+										"type": "object",
+										"properties": map[string]any{
+											"d": map[string]any{"type": "object"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			// 65 keys exceeds maxSchemaProperties = 64 → collapses to {type: "object"}
+			name:  "TooManyProperties",
+			input: build65Keys(),
+			want:  map[string]any{"type": "object"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mcp.InferSchema(tc.input)
+
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("InferSchema(%q) = %s, want nil", tc.input, got)
+				}
+				return
+			}
+
+			var gotMap map[string]any
+			if err := jsonx.Unmarshal(got, &gotMap); err != nil {
+				t.Fatalf("InferSchema(%q): unmarshal result %q: %v", tc.input, got, err)
+			}
+
+			if !reflect.DeepEqual(gotMap, tc.want) {
+				t.Errorf("InferSchema(%q)\n  got  = %v\n  want = %v", tc.input, gotMap, tc.want)
+			}
+		})
+	}
+}
+
+// buildDeepArraySchema returns a JSON schema for an array nested n levels deep,
+// with "string" at the innermost items. At n=71 the rendered TypeScript type
+// "Array<Array<...<string>...>>" is 503 characters, exceeding maxPropTypeLen=500.
+func buildDeepArraySchema(n int) jsonx.RawMessage {
+	// Build from the inside out: start with {"type":"string"}, then wrap n times.
+	inner := `{"type":"string"}`
+	for range n {
+		inner = `{"type":"array","items":` + inner + `}`
+	}
+	return jsonx.RawMessage(inner)
+}
+
+// TestSchemaToTypeScript verifies the TypeScript type-string generation for a
+// range of JSON-Schema-like inputs.
+func TestSchemaToTypeScript(t *testing.T) {
+	t.Parallel()
+
+	// oversizedPropSchema builds an object schema whose single valid property
+	// renders to a TypeScript type longer than maxPropTypeLen (500) characters.
+	// At 71 nesting levels: len("Array<")*71 + len("string") + 71 = 6*71+6+71 = 503 > 500.
+	oversizedPropSchema := func() jsonx.RawMessage {
+		itemsSchema := buildDeepArraySchema(71)
+		return jsonx.RawMessage(`{"type":"object","properties":{"bigprop":` + string(itemsSchema) + `}}`)
+	}()
+
+	tests := []struct {
+		name  string
+		input jsonx.RawMessage
+		want  string
+	}{
+		{
+			name:  "string type",
+			input: jsonx.RawMessage(`{"type":"string"}`),
+			want:  "string",
+		},
+		{
+			name:  "number type",
+			input: jsonx.RawMessage(`{"type":"number"}`),
+			want:  "number",
+		},
+		{
+			name:  "boolean type",
+			input: jsonx.RawMessage(`{"type":"boolean"}`),
+			want:  "boolean",
+		},
+		{
+			name:  "array of strings",
+			input: jsonx.RawMessage(`{"type":"array","items":{"type":"string"}}`),
+			want:  "Array<string>",
+		},
+		{
+			name:  "array without items",
+			input: jsonx.RawMessage(`{"type":"array"}`),
+			want:  "any[]",
+		},
+		{
+			name:  "object with properties sorted alphabetically",
+			input: jsonx.RawMessage(`{"type":"object","properties":{"id":{"type":"number"},"name":{"type":"string"}}}`),
+			want:  "{ id: number; name: string }",
+		},
+		{
+			name:  "object without properties",
+			input: jsonx.RawMessage(`{"type":"object"}`),
+			want:  "Record<string, any>",
+		},
+		{
+			name:  "array of objects",
+			input: jsonx.RawMessage(`{"type":"array","items":{"type":"object","properties":{"id":{"type":"number"}}}}`),
+			want:  "Array<{ id: number }>",
+		},
+		{
+			name:  "unknown type",
+			input: jsonx.RawMessage(`{"type":"date"}`),
+			want:  "any",
+		},
+		{
+			name:  "invalid JSON",
+			input: jsonx.RawMessage(`not valid json`),
+			want:  "any",
+		},
+		// --- Security regression cases ---
+		//
+		// These cases exercise the injection-prevention guards in schemaTypeToTS.
+		// If a future refactor removes isValidJSIdentifier filtering or the
+		// maxPropTypeLen cap, these tests will fail.
+		{
+			// An injection-payload key ("*/\nIGNORE") must be dropped; the valid
+			// key survives and the output is a clean TypeScript literal with no
+			// injected content.
+			name: "ObjectWithInvalidPropertyName_DropsKey",
+			input: jsonx.RawMessage(`{"type":"object","properties":{` +
+				`"valid_key":{"type":"string"},` +
+				`"*/\nIGNORE":{"type":"number"}` +
+				`}}`),
+			want: "{ valid_key: string }",
+		},
+		{
+			// Both keys fail isValidJSIdentifier ("*/" contains '*' and '/';
+			// "has space" contains a space). After filtering, no valid keys
+			// remain — the output must be the safe fallback Record<string, any>.
+			name: "ObjectWithAllInvalidPropertyNames_Record",
+			input: jsonx.RawMessage(`{"type":"object","properties":{` +
+				`"*/":{"type":"number"},` +
+				`"has space":{"type":"string"}` +
+				`}}`),
+			want: "Record<string, any>",
+		},
+		{
+			// A hyphen is not a valid JS identifier character. "kebab-case" must
+			// be dropped; "valid" survives.
+			name: "ObjectWithHyphenatedProperty_DropsKey",
+			input: jsonx.RawMessage(`{"type":"object","properties":{` +
+				`"valid":{"type":"string"},` +
+				`"kebab-case":{"type":"number"}` +
+				`}}`),
+			want: "{ valid: string }",
+		},
+		{
+			// A newline embedded in a property name must be dropped; "ok" survives.
+			name: "ObjectWithNewlineInPropertyName_DropsKey",
+			input: jsonx.RawMessage("{\"type\":\"object\",\"properties\":{" +
+				"\"ok\":{\"type\":\"string\"}," +
+				"\"bad\\nkey\":{\"type\":\"boolean\"}" +
+				"}}"),
+			want: "{ ok: string }",
+		},
+		{
+			// A property whose rendered TypeScript type exceeds maxPropTypeLen
+			// (500 chars) must be replaced with ": any". We verify the output
+			// contains "bigprop: any" rather than the full unbounded type string.
+			// This ensures the length cap is enforced and prevents description bloat
+			// from crafted deeply-nested schemas injected by a compromised MCP server.
+			name:  "ObjectWithPropertyValueExceedsLengthCap_RendersAny",
+			input: oversizedPropSchema,
+			want:  "{ bigprop: any }",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mcp.SchemaToTypeScript(tc.input)
+			if got != tc.want {
+				t.Errorf("SchemaToTypeScript(%q)\n  got  = %q\n  want = %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestInferSchema_RejectsPathologicalDepth verifies the pre-unmarshal bracket
+// depth guard in InferSchema. Inputs with bracket nesting > maxInputDepth (64)
+// are rejected before sonic allocates memory, bounding CPU and heap usage on
+// adversarial payloads. A positive control at 60 levels confirms the guard does
+// not over-fire on legitimate (if deep) inputs.
+func TestInferSchema_RejectsPathologicalDepth(t *testing.T) {
+	t.Parallel()
+
+	t.Run("depth_70_rejected", func(t *testing.T) {
+		t.Parallel()
+
+		// 70 nested arrays exceeds maxInputDepth = 64.
+		input := jsonx.RawMessage(strings.Repeat("[", 70) + strings.Repeat("]", 70))
+		got := mcp.InferSchema(input)
+		if got != nil {
+			t.Errorf("InferSchema(depth=70): expected nil (guard fired), got %q", got)
+		}
+	})
+
+	t.Run("depth_60_allowed", func(t *testing.T) {
+		t.Parallel()
+
+		// 60 nested arrays is below maxInputDepth = 64. InferSchema proceeds past
+		// the depth guard. inferValue truncates at maxSchemaDepth=3, so the result
+		// is non-nil (some schema is produced).
+		input := jsonx.RawMessage(strings.Repeat("[", 60) + strings.Repeat("]", 60))
+		got := mcp.InferSchema(input)
+		if got == nil {
+			t.Error("InferSchema(depth=60): expected non-nil result (guard should not fire), got nil")
+		}
+	})
+}
+
+// TestInferSchema_DepthScanIgnoresStringContents documents a known, deliberate
+// trade-off in the exceedsMaxDepth byte-scan: bracket characters inside JSON
+// string values are counted as nesting depth, which can cause the guard to fire
+// on inputs whose actual structural depth is shallow.
+//
+// This conservative over-count is intentional for DoS prevention. The scan
+// avoids the cost of a full parse and ensures worst-case work is bounded by a
+// simple linear scan. A "fix" that skips string contents would require parsing
+// quotes and escape sequences, reintroducing the attack surface this guard was
+// designed to close.
+//
+// This test locks the existing behavior: if someone changes exceedsMaxDepth to
+// parse strings and thereby allow the input below through, this test will catch
+// the regression.
+func TestInferSchema_DepthScanIgnoresStringContents(t *testing.T) {
+	t.Parallel()
+
+	// The outer JSON object has structural depth 1 (one '{' ... '}').
+	// However, the string value contains 100 '[' characters, pushing the
+	// naive bracket counter above maxInputDepth=64. InferSchema must return nil.
+	brackets := strings.Repeat("[", 100)
+	input := jsonx.RawMessage(`{"note":"` + brackets + `"}`)
+
+	got := mcp.InferSchema(input)
+	if got != nil {
+		// If this fires, exceedsMaxDepth now parses strings — the DoS guard has
+		// been weakened. Restore the simple byte scan.
+		t.Errorf("InferSchema(string with 100 brackets): expected nil (conservative over-count), got %q", got)
+	}
+}

--- a/internal/mcp/codemode_schema_test.go
+++ b/internal/mcp/codemode_schema_test.go
@@ -1,6 +1,7 @@
 package mcp_test
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -191,16 +192,23 @@ func TestInferSchema(t *testing.T) {
 	}
 }
 
-// buildDeepArraySchema returns a JSON schema for an array nested n levels deep,
-// with "string" at the innermost items. At n=71 the rendered TypeScript type
-// "Array<Array<...<string>...>>" is 503 characters, exceeding maxPropTypeLen=500.
-func buildDeepArraySchema(n int) jsonx.RawMessage {
-	// Build from the inside out: start with {"type":"string"}, then wrap n times.
-	inner := `{"type":"string"}`
-	for range n {
-		inner = `{"type":"array","items":` + inner + `}`
+// buildWideObjectSchema returns a JSON schema for an object with n string
+// properties named "p01", "p02", ..., "pNN". The rendered TypeScript type is
+// approximately 13*n characters (each "pNN: string; " is 13 chars). At n=40
+// the result is ~522 chars, exceeding maxPropTypeLen=500.
+// Unlike deeply-nested schemas this stays at a single level of nesting, so
+// it exercises maxPropTypeLen independently of maxTSRenderDepth.
+func buildWideObjectSchema(n int) jsonx.RawMessage {
+	var sb strings.Builder
+	sb.WriteString(`{"type":"object","properties":{`)
+	for i := range n {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(fmt.Sprintf(`"p%02d":{"type":"string"}`, i+1))
 	}
-	return jsonx.RawMessage(inner)
+	sb.WriteString("}}")
+	return jsonx.RawMessage(sb.String())
 }
 
 // TestSchemaToTypeScript verifies the TypeScript type-string generation for a
@@ -210,10 +218,13 @@ func TestSchemaToTypeScript(t *testing.T) {
 
 	// oversizedPropSchema builds an object schema whose single valid property
 	// renders to a TypeScript type longer than maxPropTypeLen (500) characters.
-	// At 71 nesting levels: len("Array<")*71 + len("string") + 71 = 6*71+6+71 = 503 > 500.
+	// The inner schema is a wide object with 40 string properties. Each property
+	// renders as "pNN: string; " (~13 chars), so 40 properties ≈ 522 chars > 500.
+	// This stays within 2 nesting levels so it fires maxPropTypeLen before
+	// maxTSRenderDepth, exercising the length cap independently of the depth guard.
 	oversizedPropSchema := func() jsonx.RawMessage {
-		itemsSchema := buildDeepArraySchema(71)
-		return jsonx.RawMessage(`{"type":"object","properties":{"bigprop":` + string(itemsSchema) + `}}`)
+		innerSchema := buildWideObjectSchema(40)
+		return jsonx.RawMessage(`{"type":"object","properties":{"bigprop":` + string(innerSchema) + `}}`)
 	}()
 
 	tests := []struct {
@@ -372,6 +383,54 @@ func TestInferSchema_RejectsPathologicalDepth(t *testing.T) {
 			t.Error("InferSchema(depth=60): expected non-nil result (guard should not fire), got nil")
 		}
 	})
+}
+
+// TestSchemaTypeToTS_DeepNestingCappedAtAny verifies that the maxTSRenderDepth
+// guard in schemaTypeToTSInner fires on a 12-deep nested object schema and
+// returns "any" somewhere in the rendered string, rather than recursing
+// unboundedly.
+//
+// The schema is constructed directly as a map (not via InferSchema, which caps
+// at maxSchemaDepth=3) so we can reach the TS rendering guard at depth 10+.
+func TestSchemaTypeToTS_DeepNestingCappedAtAny(t *testing.T) {
+	t.Parallel()
+
+	// deeplyNestedSchema builds a JSON schema for a nested object chain of the
+	// given depth. At depth 0 the leaf is {"type":"string"}. At depth n the
+	// result is {"type":"object","properties":{"x": deeplyNestedSchema(n-1)}}.
+	var deeplyNestedSchema func(depth int) map[string]any
+	deeplyNestedSchema = func(depth int) map[string]any {
+		if depth == 0 {
+			return map[string]any{"type": "string"}
+		}
+		return map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"x": deeplyNestedSchema(depth - 1),
+			},
+		}
+	}
+
+	// Build a 12-deep schema and marshal it to JSON for SchemaToTypeScript.
+	schema := deeplyNestedSchema(12)
+	raw, err := jsonx.Marshal(schema)
+	if err != nil {
+		t.Fatalf("marshal deep schema: %v", err)
+	}
+
+	result := mcp.SchemaToTypeScript(jsonx.RawMessage(raw))
+
+	// The depth guard must have fired — "any" must appear in the output.
+	if !strings.Contains(result, "any") {
+		t.Errorf("depth guard did not fire: result contains no \"any\"\ngot: %s", result)
+	}
+
+	// The recursion must have been capped — a 12-deep chain of "x:" keys is not
+	// present in the output.
+	xCount := strings.Count(result, "x:")
+	if xCount >= 12 {
+		t.Errorf("recursion was not capped: result contains %d occurrences of \"x:\", want < 12\ngot: %s", xCount, result)
+	}
 }
 
 // TestInferSchema_DepthScanIgnoresStringContents documents a known, deliberate

--- a/internal/mcp/codemode_types.go
+++ b/internal/mcp/codemode_types.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"sort"
 	"strings"
+
+	"github.com/voidmind-io/voidllm/internal/jsonx"
 )
 
 // GenerateToolTypeDefs produces TypeScript-style namespace declarations for all
@@ -17,8 +19,14 @@ import (
 //	  function search_documentation(args: { query: string; limit?: number }): Promise<any>;
 //	}
 //
+// outputSchemas maps server alias → tool name → inferred output schema
+// (as returned by InferSchema). When a schema is present for a tool, the
+// return type is emitted as a concrete TypeScript type instead of Promise<any>.
+// A nil outputSchemas map is valid and produces the same output as before —
+// all tool signatures emit Promise<any>.
+//
 // If serverTools is empty, GenerateToolTypeDefs returns an empty string.
-func GenerateToolTypeDefs(serverTools map[string][]Tool) string {
+func GenerateToolTypeDefs(serverTools map[string][]Tool, outputSchemas map[string]map[string]jsonx.RawMessage) string {
 	if len(serverTools) == 0 {
 		return ""
 	}
@@ -69,8 +77,13 @@ func GenerateToolTypeDefs(serverTools map[string][]Tool) string {
 			return sorted[a].Name < sorted[b].Name
 		})
 
+		aliasSchemas := outputSchemas[alias] // nil when outputSchemas is nil or alias absent
 		for _, tool := range sorted {
-			writeToolDecl(&sb, tool)
+			var outSchema jsonx.RawMessage
+			if aliasSchemas != nil {
+				outSchema = aliasSchemas[tool.Name]
+			}
+			writeToolDecl(&sb, tool, outSchema)
 		}
 
 		sb.WriteString("}")
@@ -79,7 +92,10 @@ func GenerateToolTypeDefs(serverTools map[string][]Tool) string {
 }
 
 // writeToolDecl writes a single TypeScript function declaration into sb.
-func writeToolDecl(sb *strings.Builder, tool Tool) {
+// outSchema is the inferred output schema for the tool; when non-nil the
+// return type is a concrete TypeScript type with a comment noting it is
+// inferred. When nil, Promise<any> is emitted.
+func writeToolDecl(sb *strings.Builder, tool Tool, outSchema jsonx.RawMessage) {
 	// Skip tools whose names are not valid identifiers — they could inject
 	// arbitrary content into the TypeScript declaration block.
 	if !isValidJSIdentifier(tool.Name) {
@@ -133,7 +149,13 @@ func writeToolDecl(sb *strings.Builder, tool Tool) {
 		sb.WriteString("  ")
 	}
 
-	sb.WriteString("}): Promise<any>;\n")
+	if outSchema != nil {
+		sb.WriteString("}): Promise<")
+		sb.WriteString(schemaToTypeScript(outSchema))
+		sb.WriteString(">; // inferred - could depend on previous query\n")
+	} else {
+		sb.WriteString("}): Promise<any>;\n")
+	}
 }
 
 // isValidJSIdentifier reports whether s is a valid bare JavaScript identifier

--- a/internal/mcp/codemode_types_test.go
+++ b/internal/mcp/codemode_types_test.go
@@ -15,7 +15,7 @@ import (
 func TestGenerateToolTypeDefs_Empty(t *testing.T) {
 	t.Parallel()
 
-	got := mcp.GenerateToolTypeDefs(map[string][]mcp.Tool{})
+	got := mcp.GenerateToolTypeDefs(map[string][]mcp.Tool{}, nil)
 	if got != "" {
 		t.Errorf("GenerateToolTypeDefs(empty) = %q, want empty string", got)
 	}
@@ -24,7 +24,7 @@ func TestGenerateToolTypeDefs_Empty(t *testing.T) {
 func TestGenerateToolTypeDefs_NilMap(t *testing.T) {
 	t.Parallel()
 
-	got := mcp.GenerateToolTypeDefs(nil)
+	got := mcp.GenerateToolTypeDefs(nil, nil)
 	if got != "" {
 		t.Errorf("GenerateToolTypeDefs(nil) = %q, want empty string", got)
 	}
@@ -118,7 +118,7 @@ func TestGenerateToolTypeDefs_SingleServerSingleTool(t *testing.T) {
 
 			got := mcp.GenerateToolTypeDefs(map[string][]mcp.Tool{
 				"aws": {tc.tool},
-			})
+			}, nil)
 			for _, want := range tc.wantContain {
 				if !strings.Contains(got, want) {
 					t.Errorf("output does not contain %q\nfull output:\n%s", want, got)
@@ -145,7 +145,7 @@ func TestGenerateToolTypeDefs_RequiredVsOptional(t *testing.T) {
 
 	got := mcp.GenerateToolTypeDefs(map[string][]mcp.Tool{
 		"srv": {tool},
-	})
+	}, nil)
 
 	// required_field has no ?; optional_field has ?
 	if !strings.Contains(got, "required_field: string") {
@@ -175,7 +175,7 @@ func TestGenerateToolTypeDefs_ArrayAndObjectParams(t *testing.T) {
 
 	got := mcp.GenerateToolTypeDefs(map[string][]mcp.Tool{
 		"srv": {tool},
-	})
+	}, nil)
 
 	if !strings.Contains(got, "tags?: any[]") {
 		t.Errorf("array param should map to 'any[]', got:\n%s", got)
@@ -200,7 +200,7 @@ func TestGenerateToolTypeDefs_UnknownTypeMapToAny(t *testing.T) {
 
 	got := mcp.GenerateToolTypeDefs(map[string][]mcp.Tool{
 		"srv": {tool},
-	})
+	}, nil)
 
 	if !strings.Contains(got, "val?: any") {
 		t.Errorf("property with no type should map to 'any', got:\n%s", got)
@@ -218,7 +218,7 @@ func TestGenerateToolTypeDefs_EmptyDescription(t *testing.T) {
 
 	got := mcp.GenerateToolTypeDefs(map[string][]mcp.Tool{
 		"srv": {tool},
-	})
+	}, nil)
 
 	// No JSDoc comment should be emitted.
 	if strings.Contains(got, "/**") {
@@ -241,7 +241,7 @@ func TestGenerateToolTypeDefs_LongDescriptionTruncated(t *testing.T) {
 
 	got := mcp.GenerateToolTypeDefs(map[string][]mcp.Tool{
 		"srv": {tool},
-	})
+	}, nil)
 
 	if !strings.Contains(got, "First sentence.") {
 		t.Errorf("first sentence should appear in output, got:\n%s", got)
@@ -262,7 +262,7 @@ func TestGenerateToolTypeDefs_LongDescriptionNewlineTruncated(t *testing.T) {
 
 	got := mcp.GenerateToolTypeDefs(map[string][]mcp.Tool{
 		"srv": {tool},
-	})
+	}, nil)
 
 	if !strings.Contains(got, "First line") {
 		t.Errorf("first line should appear in output, got:\n%s", got)
@@ -281,7 +281,7 @@ func TestGenerateToolTypeDefs_MultipleServersSortedAlphabetically(t *testing.T) 
 		"mango": {{Name: "tool_m", InputSchema: mcp.InputSchema{Type: "object"}}},
 	}
 
-	got := mcp.GenerateToolTypeDefs(tools)
+	got := mcp.GenerateToolTypeDefs(tools, nil)
 
 	posAlpha := strings.Index(got, "tools.alpha")
 	posMango := strings.Index(got, "tools.mango")
@@ -307,7 +307,7 @@ func TestGenerateToolTypeDefs_ToolNamesWithHyphensAndDots(t *testing.T) {
 
 	got := mcp.GenerateToolTypeDefs(map[string][]mcp.Tool{
 		"my-api.v1": {tool},
-	})
+	}, nil)
 
 	// Aliases with special chars use bracket notation comment + sanitized namespace.
 	if !strings.Contains(got, `tools["my-api.v1"]`) {
@@ -337,7 +337,7 @@ func TestGenerateToolTypeDefs_NoPropertiesProducesEmptyArgs(t *testing.T) {
 
 	got := mcp.GenerateToolTypeDefs(map[string][]mcp.Tool{
 		"srv": {tool},
-	})
+	}, nil)
 
 	// args block should be inline with no newlines between braces.
 	if !strings.Contains(got, "function no_args(args: {})") {
@@ -354,7 +354,7 @@ func TestGenerateToolTypeDefs_ServerWithNoToolsOmitted(t *testing.T) {
 		"empty_server": {},
 	}
 
-	got := mcp.GenerateToolTypeDefs(tools)
+	got := mcp.GenerateToolTypeDefs(tools, nil)
 
 	if strings.Contains(got, "tools.empty_server") {
 		t.Errorf("server with no tools should be omitted, got:\n%s", got)
@@ -375,7 +375,7 @@ func TestGenerateToolTypeDefs_ToolsSortedWithinNamespace(t *testing.T) {
 		},
 	}
 
-	got := mcp.GenerateToolTypeDefs(tools)
+	got := mcp.GenerateToolTypeDefs(tools, nil)
 
 	posFirst := strings.Index(got, "aaa_first")
 	posMiddle := strings.Index(got, "mmm_middle")
@@ -400,8 +400,8 @@ func TestGenerateToolTypeDefs_DeterministicOutput(t *testing.T) {
 		"alpha": {{Name: "tool_a", InputSchema: mcp.InputSchema{Type: "object"}}},
 	}
 
-	first := mcp.GenerateToolTypeDefs(tools)
-	second := mcp.GenerateToolTypeDefs(tools)
+	first := mcp.GenerateToolTypeDefs(tools, nil)
+	second := mcp.GenerateToolTypeDefs(tools, nil)
 
 	if first != second {
 		t.Errorf("non-deterministic output:\nfirst:\n%s\nsecond:\n%s", first, second)
@@ -427,7 +427,7 @@ func TestGenerateToolTypeDefs_OutputStructure(t *testing.T) {
 
 	got := mcp.GenerateToolTypeDefs(map[string][]mcp.Tool{
 		"users": {tool},
-	})
+	}, nil)
 
 	wantParts := []string{
 		"declare namespace tools.users {",

--- a/internal/mcp/codemode_unwrap.go
+++ b/internal/mcp/codemode_unwrap.go
@@ -1,0 +1,70 @@
+package mcp
+
+import "github.com/voidmind-io/voidllm/internal/jsonx"
+
+// unwrapToolResult strips the MCP ToolResult wrapper when the response matches
+// the expected shape. Returns raw unchanged when the response does not match
+// the ToolResult wrapper shape, providing a defensive fallback for arbitrary payloads.
+func unwrapToolResult(raw jsonx.RawMessage) jsonx.RawMessage {
+	// Phase 1: inspect top-level keys to confirm the MCP ToolResult shape.
+	var topLevel map[string]jsonx.RawMessage
+	if err := jsonx.Unmarshal(raw, &topLevel); err != nil {
+		return raw
+	}
+
+	if _, hasContent := topLevel["content"]; !hasContent {
+		return raw
+	}
+
+	// Only unwrap when every top-level key is one of the known ToolResult fields.
+	// Any extra key means this is payload data, not a wrapper.
+	knownKeys := 0
+	for k := range topLevel {
+		switch k {
+		case "content", "isError", "structuredContent", "_meta":
+			knownKeys++
+		}
+	}
+	if knownKeys != len(topLevel) {
+		return raw
+	}
+
+	// Phase 2: parse the content array.
+	var tr struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := jsonx.Unmarshal(raw, &tr); err != nil || len(tr.Content) == 0 {
+		return raw
+	}
+
+	// Phase 3: extract the payload.
+	if len(tr.Content) == 1 && tr.Content[0].Type == "text" {
+		text := tr.Content[0].Text
+		if jsonx.Valid([]byte(text)) {
+			return jsonx.RawMessage(text)
+		}
+		quoted, err := jsonx.Marshal(text)
+		if err != nil {
+			return raw
+		}
+		return jsonx.RawMessage(quoted)
+	}
+
+	texts := make([]string, 0, len(tr.Content))
+	for _, c := range tr.Content {
+		if c.Type == "text" {
+			texts = append(texts, c.Text)
+		}
+	}
+	if len(texts) == 0 {
+		return raw
+	}
+	out, err := jsonx.Marshal(texts)
+	if err != nil {
+		return raw
+	}
+	return jsonx.RawMessage(out)
+}

--- a/internal/mcp/codemode_unwrap.go
+++ b/internal/mcp/codemode_unwrap.go
@@ -5,6 +5,9 @@ import "github.com/voidmind-io/voidllm/internal/jsonx"
 // unwrapToolResult strips the MCP ToolResult wrapper when the response matches
 // the expected shape. Returns raw unchanged when the response does not match
 // the ToolResult wrapper shape, providing a defensive fallback for arbitrary payloads.
+// Note: isError=true responses are also unwrapped — Code Mode scripts handle
+// errors via JS try/catch on the call's promise rejection rather than via the
+// wrapper's error flag.
 func unwrapToolResult(raw jsonx.RawMessage) jsonx.RawMessage {
 	// Phase 1: inspect top-level keys to confirm the MCP ToolResult shape.
 	var topLevel map[string]jsonx.RawMessage

--- a/internal/mcp/codemode_unwrap_test.go
+++ b/internal/mcp/codemode_unwrap_test.go
@@ -1,0 +1,140 @@
+package mcp_test
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/voidmind-io/voidllm/internal/jsonx"
+	"github.com/voidmind-io/voidllm/internal/mcp"
+)
+
+func TestUnwrapToolResult(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		input       jsonx.RawMessage
+		wantRaw     bool // true = expect byte-identical passthrough of input
+		wantPayload jsonx.RawMessage
+	}{
+		{
+			name:        "SingleTextBlockWithJSON",
+			input:       jsonx.RawMessage(`{"content":[{"type":"text","text":"{\"key\":\"value\"}"}]}`),
+			wantRaw:     false,
+			wantPayload: jsonx.RawMessage(`{"key":"value"}`),
+		},
+		{
+			name:        "SingleTextBlockWithPlainText",
+			input:       jsonx.RawMessage(`{"content":[{"type":"text","text":"hello world"}]}`),
+			wantRaw:     false,
+			wantPayload: jsonx.RawMessage(`"hello world"`),
+		},
+		{
+			name:        "SingleTextBlockEmptyString",
+			input:       jsonx.RawMessage(`{"content":[{"type":"text","text":""}]}`),
+			wantRaw:     false,
+			wantPayload: jsonx.RawMessage(`""`),
+		},
+		{
+			name:        "MultipleTextBlocks",
+			input:       jsonx.RawMessage(`{"content":[{"type":"text","text":"first"},{"type":"text","text":"second"}]}`),
+			wantRaw:     false,
+			wantPayload: jsonx.RawMessage(`["first","second"]`),
+		},
+		{
+			name:        "MultipleMixedBlocks_TextAndNonText",
+			input:       jsonx.RawMessage(`{"content":[{"type":"text","text":"a"},{"type":"image","text":""},{"type":"text","text":"b"}]}`),
+			wantRaw:     false,
+			wantPayload: jsonx.RawMessage(`["a","b"]`),
+		},
+		{
+			name:    "MultipleNonTextBlocks_PassThrough",
+			input:   jsonx.RawMessage(`{"content":[{"type":"image","text":""},{"type":"image","text":""}]}`),
+			wantRaw: true,
+		},
+		{
+			name:    "SingleNonTextBlock_PassThrough",
+			input:   jsonx.RawMessage(`{"content":[{"type":"image","text":""}]}`),
+			wantRaw: true,
+		},
+		{
+			name:    "NotAToolResult_NoContentKey",
+			input:   jsonx.RawMessage(`{"score":99}`),
+			wantRaw: true,
+		},
+		{
+			name:    "UnknownTopLevelKey_PassThrough",
+			input:   jsonx.RawMessage(`{"content":[{"type":"text","text":"x"}],"userFoo":"bar"}`),
+			wantRaw: true,
+		},
+		{
+			name:        "AllowedTopLevelKeys_StillUnwraps",
+			input:       jsonx.RawMessage(`{"content":[{"type":"text","text":"x"}],"isError":false,"_meta":{},"structuredContent":null}`),
+			wantRaw:     false,
+			wantPayload: jsonx.RawMessage(`"x"`),
+		},
+		{
+			name:    "EmptyContentArray_PassThrough",
+			input:   jsonx.RawMessage(`{"content":[]}`),
+			wantRaw: true,
+		},
+		{
+			name:    "InvalidJSON_PassThrough",
+			input:   jsonx.RawMessage(`not json at all`),
+			wantRaw: true,
+		},
+		{
+			name:    "ContentKeyWrongType_PassThrough",
+			input:   jsonx.RawMessage(`{"content":"not an array"}`),
+			wantRaw: true,
+		},
+		{
+			name:        "NestedJSONInText_Array",
+			input:       jsonx.RawMessage(`{"content":[{"type":"text","text":"[1,2,3]"}]}`),
+			wantRaw:     false,
+			wantPayload: jsonx.RawMessage(`[1,2,3]`),
+		},
+		{
+			name:    "UppercaseContentKey_PassThrough",
+			input:   jsonx.RawMessage(`{"Content":[{"type":"text","text":"x"}]}`),
+			wantRaw: true,
+		},
+		{
+			// inner content is valid JSON — returns unquoted; contrast with SingleTextBlockWithPlainText
+			name:        "SingleTextBlockWithJSONNumber",
+			input:       jsonx.RawMessage(`{"content":[{"type":"text","text":"42"}]}`),
+			wantRaw:     false,
+			wantPayload: jsonx.RawMessage(`42`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mcp.UnwrapToolResult(tc.input)
+
+			if tc.wantRaw {
+				if !bytes.Equal(got, tc.input) {
+					t.Errorf("case %q: expected raw passthrough\n  input: %s\n  got:   %s",
+						tc.name, tc.input, got)
+				}
+				return
+			}
+
+			// Compare as parsed JSON to tolerate key-ordering differences.
+			var gotParsed, wantParsed interface{}
+			if err := jsonx.Unmarshal(got, &gotParsed); err != nil {
+				t.Fatalf("case %q: got is not valid JSON: %v\n  got: %s", tc.name, err, got)
+			}
+			if err := jsonx.Unmarshal(tc.wantPayload, &wantParsed); err != nil {
+				t.Fatalf("case %q: wantPayload is not valid JSON: %v\n  wantPayload: %s", tc.name, err, tc.wantPayload)
+			}
+			if !reflect.DeepEqual(gotParsed, wantParsed) {
+				t.Errorf("case %q: payload mismatch\n  input: %s\n  got:   %s\n  want:  %s",
+					tc.name, tc.input, got, tc.wantPayload)
+			}
+		})
+	}
+}

--- a/internal/mcp/export_test.go
+++ b/internal/mcp/export_test.go
@@ -3,3 +3,11 @@ package mcp
 // ParseSSEEndpoint exposes the internal parseSSEEndpoint function for
 // white-box testing from the mcp_test package.
 var ParseSSEEndpoint = parseSSEEndpoint
+
+// UnwrapToolResult exposes the internal unwrapToolResult function for
+// white-box testing from the mcp_test package.
+var UnwrapToolResult = unwrapToolResult
+
+// SchemaToTypeScript exposes the internal schemaToTypeScript function for
+// white-box testing from the mcp_test package.
+var SchemaToTypeScript = schemaToTypeScript

--- a/internal/mcp/voidllm.go
+++ b/internal/mcp/voidllm.go
@@ -18,6 +18,58 @@ const (
 	keyInfoContextKey mcpContextKey = iota
 )
 
+// codeModeDescription is the static, non-dynamic portion of the execute_code
+// tool description. It contains the STRONG PREFERENCE, WORKFLOW, RULES,
+// PATTERNS, and NOTE sections. The toolsListHook in internal/app/code_mode.go
+// appends "## Available Tools" followed by live TypeScript type definitions.
+// Having a single source prevents the static and dynamic descriptions from
+// drifting apart.
+const codeModeDescription = "Execute JavaScript that chains multiple MCP tool calls in a single turn. " +
+	"Use this instead of calling tools individually - pass output from one tool as input to the next.\n\n" +
+	"STRONG PREFERENCE: Whenever a task needs more than one downstream MCP tool call, use execute_code. " +
+	"Sequential calls on your own side cost one LLM round-trip each; chained calls inside execute_code cost one round-trip total. " +
+	"Two or more downstream MCP calls for the same task = use execute_code. One downstream call = call it directly. " +
+	"(search_tools and list_servers are Code Mode control tools and do not count toward this rule.) " +
+	"If the next call depends on the previous result, chain it here. If N calls are independent, Promise.allSettled them here.\n\n" +
+	"WORKFLOW: Always call search_tools() first, then execute_code.\n\n" +
+	"Step 1 - search_tools(\"your goal\") returns TypeScript signatures like:\n" +
+	"  tools.sqlite.read_query(args: { query: string }): Promise<Array<{ id: number; name: string }>>\n" +
+	"  tools.sqlite.write_query(args: { query: string }): Promise<string>\n\n" +
+	"Step 2 - execute_code uses those signatures:\n" +
+	"```js\n" +
+	"await tools.sqlite.write_query({ query: \"INSERT INTO users (name) VALUES ('Alice')\" });\n" +
+	"const rows = await tools.sqlite.read_query({ query: \"SELECT * FROM users\" });\n" +
+	"return rows; // direct value, no wrapper\n" +
+	"```\n\n" +
+	"RULES:\n" +
+	"- All calls return Promises (use await)\n" +
+	"- Results are unwrapped values (objects, arrays, strings) - not MCP protocol wrappers\n" +
+	"- Use tools.serverAlias.toolName(args) syntax\n" +
+	"- Use console.log() for debugging\n" +
+	"- Assign to return for output: return { key: value }\n\n" +
+	"PATTERNS:\n" +
+	"- Parallel fan-out (N calls, one turn):\n" +
+	"  ```js\n" +
+	"  const results = await Promise.allSettled(items.map(i => tools.x.do(i)));\n" +
+	"  const failed = results.flatMap((r, idx) => r.status === \"rejected\" ? [{ i: idx, err: String(r.reason) }] : []);\n" +
+	"  ```\n" +
+	"- Continue on partial failure (sequential):\n" +
+	"  ```js\n" +
+	"  for (const i of items) { try { await tools.x.do(i); } catch (e) { console.log(\"skip\", i, e); } }\n" +
+	"  ```\n" +
+	"- Unhandled rejection aborts the run. The response still returns error + logs + tool_calls up to the failure, so you can retry next turn.\n\n" +
+	"NOTE: Return types shown as Promise<any> mean the tool has not been called yet. " +
+	"After the first call, the return type is inferred automatically and will show the actual structure on the next search_tools(). " +
+	"When you see Promise<any>, use console.log() on the result to inspect its shape."
+
+// CodeModeDescription returns the static part of the execute_code tool
+// description (STRONG PREFERENCE, WORKFLOW, RULES, PATTERNS, NOTE). The
+// dynamic toolsListHook in internal/app/code_mode.go appends
+// "## Available Tools" followed by live TypeScript type definitions.
+func CodeModeDescription() string {
+	return codeModeDescription
+}
+
 // KeyIdentity holds the caller identity extracted from the authenticated request.
 // It is stored in the context by the MCP transport handler and read by tool
 // handlers via VoidLLMDeps.GetKeyInfo.
@@ -112,10 +164,11 @@ type VoidLLMDeps struct {
 	ListAccessibleMCPServers func(ctx context.Context, codeModeOnly bool) ([]map[string]any, error)
 
 	// SearchMCPTools searches tool schemas across accessible servers by
-	// keyword. query is matched case-insensitively against tool names and
-	// descriptions. serverAliases optionally restricts the search scope
-	// (nil = all accessible). Returns nil when Code Mode is disabled.
-	SearchMCPTools func(ctx context.Context, query string, serverAliases []string) ([]map[string]any, error)
+	// keyword and returns a rendered TypeScript text block. query is matched
+	// case-insensitively against tool names and descriptions. serverAliases
+	// optionally restricts the search scope (nil = all accessible). Returns
+	// an empty string when Code Mode is disabled.
+	SearchMCPTools func(ctx context.Context, query string, serverAliases []string) (string, error)
 }
 
 // RegisterVoidLLMTools registers the VoidLLM management tools on the given MCP
@@ -227,7 +280,7 @@ func RegisterCodeModeTools(s *Server, deps VoidLLMDeps) {
 
 	s.RegisterTool(Tool{
 		Name:        "list_servers",
-		Description: "List MCP servers available for Code Mode execution. Shows server names, aliases, and tool counts.",
+		Description: "List MCP servers available for Code Mode execution. Shows server names, aliases, and tool counts. For tool signatures and parameter shapes, use search_tools instead.",
 		InputSchema: InputSchema{
 			Type: "object",
 		},
@@ -235,7 +288,7 @@ func RegisterCodeModeTools(s *Server, deps VoidLLMDeps) {
 
 	s.RegisterTool(Tool{
 		Name:        "search_tools",
-		Description: "Search for MCP tools across accessible servers by keyword. Returns matching tool names, descriptions, and input schemas for writing Code Mode scripts.",
+		Description: "Discover tool signatures before using execute_code. Always call this first to learn parameter names, types, and return values. Returns matching tools with full TypeScript definitions including inferred return types from previous calls. Search by keyword across tool names and descriptions, or by server name via the optional \"server\" parameter. If no results are returned, no MCP servers are accessible to this caller yet — ask an admin to register or grant access. After search_tools() returns signatures, use execute_code to call them — especially if the task needs more than one tool call. Calling tools individually after searching wastes round-trips; chain them inside execute_code instead.",
 		InputSchema: InputSchema{
 			Type: "object",
 			Properties: map[string]Property{
@@ -252,11 +305,14 @@ func RegisterCodeModeTools(s *Server, deps VoidLLMDeps) {
 		},
 	}, makeSearchTools(deps))
 
+	// execute_code — registered with the static codeModeDescription, but at
+	// runtime the app-package toolsListHook rewrites this description on every
+	// tools/list call, appending the live "## Available Tools" TypeScript block
+	// via mcp.CodeModeDescription() + generated defs. Edits to codeModeDescription
+	// flow through automatically because the hook calls CodeModeDescription().
 	s.RegisterTool(Tool{
-		Name: "execute_code",
-		Description: "Execute JavaScript code in a sandboxed WASM runtime with MCP tools available as async functions. " +
-			"Tools are accessible via tools.serverAlias.toolName(args). Use await for tool calls. " +
-			"Return a value to send it back as the result.",
+		Name:        "execute_code",
+		Description: codeModeDescription,
 		InputSchema: InputSchema{
 			Type: "object",
 			Properties: map[string]Property{
@@ -463,13 +519,11 @@ func makeSearchTools(deps VoidLLMDeps) ToolHandler {
 			serverAliases = []string{input.Server}
 		}
 
-		tools, err := deps.SearchMCPTools(ctx, input.Query, serverAliases)
+		rendered, err := deps.SearchMCPTools(ctx, input.Query, serverAliases)
 		if err != nil {
 			return nil, fmt.Errorf("search mcp tools: %w", err)
 		}
-
-		out, _ := jsonx.MarshalIndent(tools, "", "  ")
-		return TextResult(string(out)), nil
+		return TextResult(rendered), nil
 	}
 }
 

--- a/internal/mcp/voidllm_test.go
+++ b/internal/mcp/voidllm_test.go
@@ -1111,15 +1111,15 @@ func TestVoidLLM_SearchTools_Success(t *testing.T) {
 	var capturedQuery string
 	var capturedAliases []string
 
-	tools := []map[string]any{
-		{"name": "get_weather", "description": "Get current weather", "server": "weather"},
-	}
-
 	deps := defaultDeps()
-	deps.SearchMCPTools = func(_ context.Context, query string, serverAliases []string) ([]map[string]any, error) {
+	deps.SearchMCPTools = func(_ context.Context, query string, serverAliases []string) (string, error) {
 		capturedQuery = query
 		capturedAliases = serverAliases
-		return tools, nil
+		return `Found 1 tool(s) matching "weather":
+
+declare namespace tools.weather {
+  function get_weather(args: { city: string; }): Promise<any>;
+}`, nil
 	}
 	deps.ExecuteCode = func(_ context.Context, _ string, _ []string) (*mcp.ExecuteResult, error) {
 		return &mcp.ExecuteResult{Result: json.RawMessage(`"ok"`)}, nil
@@ -1150,9 +1150,9 @@ func TestVoidLLM_SearchTools_WithServerFilter(t *testing.T) {
 	var capturedAliases []string
 
 	deps := defaultDeps()
-	deps.SearchMCPTools = func(_ context.Context, _ string, serverAliases []string) ([]map[string]any, error) {
+	deps.SearchMCPTools = func(_ context.Context, _ string, serverAliases []string) (string, error) {
 		capturedAliases = serverAliases
-		return []map[string]any{}, nil
+		return "", nil
 	}
 	deps.ExecuteCode = func(_ context.Context, _ string, _ []string) (*mcp.ExecuteResult, error) {
 		return &mcp.ExecuteResult{Result: json.RawMessage(`"ok"`)}, nil
@@ -1173,8 +1173,8 @@ func TestVoidLLM_SearchTools_MissingQuery(t *testing.T) {
 	t.Parallel()
 
 	deps := defaultDeps()
-	deps.SearchMCPTools = func(_ context.Context, _ string, _ []string) ([]map[string]any, error) {
-		return nil, nil
+	deps.SearchMCPTools = func(_ context.Context, _ string, _ []string) (string, error) {
+		return "", nil
 	}
 	deps.ExecuteCode = func(_ context.Context, _ string, _ []string) (*mcp.ExecuteResult, error) {
 		return &mcp.ExecuteResult{Result: json.RawMessage(`"ok"`)}, nil
@@ -1195,8 +1195,8 @@ func TestVoidLLM_SearchTools_DepError(t *testing.T) {
 	t.Parallel()
 
 	deps := defaultDeps()
-	deps.SearchMCPTools = func(_ context.Context, _ string, _ []string) ([]map[string]any, error) {
-		return nil, errors.New("search index unavailable")
+	deps.SearchMCPTools = func(_ context.Context, _ string, _ []string) (string, error) {
+		return "", errors.New("search index unavailable")
 	}
 	deps.ExecuteCode = func(_ context.Context, _ string, _ []string) (*mcp.ExecuteResult, error) {
 		return &mcp.ExecuteResult{Result: json.RawMessage(`"ok"`)}, nil
@@ -1230,6 +1230,53 @@ func TestVoidLLM_SearchTools_DepError(t *testing.T) {
 	}
 	if strings.Contains(tr.Content[0].Text, "search index") {
 		t.Errorf("raw dep error must not be leaked: %q", tr.Content[0].Text)
+	}
+}
+
+func TestVoidLLM_SearchTools_SurfacesTypeScript(t *testing.T) {
+	t.Parallel()
+
+	const tsBlock = `Found 1 tool(s) matching "infer":
+
+declare namespace tools.my_server {
+  function get_result(args: { id: number; }): Promise<{ id: number; name: string }>; // inferred - could depend on previous query
+}`
+
+	deps := defaultDeps()
+	deps.SearchMCPTools = func(_ context.Context, _ string, _ []string) (string, error) {
+		return tsBlock, nil
+	}
+	deps.ExecuteCode = func(_ context.Context, _ string, _ []string) (*mcp.ExecuteResult, error) {
+		return &mcp.ExecuteResult{Result: json.RawMessage(`"ok"`)}, nil
+	}
+
+	s := buildCodeModeServer(deps)
+	tr := callTool(t, s, context.Background(), "search_tools", map[string]any{
+		"query": "infer",
+	})
+
+	if tr.IsError {
+		t.Fatalf("unexpected error: %s", tr.Content[0].Text)
+	}
+	if len(tr.Content) == 0 {
+		t.Fatal("empty content")
+	}
+
+	text := tr.Content[0].Text
+
+	// The handler must pass the TypeScript string through verbatim.
+	if text != tsBlock {
+		t.Errorf("handler output differs from stub return:\ngot:  %q\nwant: %q", text, tsBlock)
+	}
+
+	// Output must not be JSON-encoded (no leading '[' or '{').
+	if strings.HasPrefix(text, "[") || strings.HasPrefix(text, "{") {
+		t.Errorf("output must not be JSON-encoded, got: %s", text)
+	}
+
+	// Inferred-types marker must be preserved.
+	if !strings.Contains(text, "// inferred - could depend on previous query") {
+		t.Errorf("inferred-types marker missing from handler output\ngot: %s", text)
 	}
 }
 
@@ -1390,8 +1437,8 @@ func TestRegisterVoidLLMTools_CodeModeToolsListed(t *testing.T) {
 	deps.ListAccessibleMCPServers = func(_ context.Context, _ bool) ([]map[string]any, error) {
 		return nil, nil
 	}
-	deps.SearchMCPTools = func(_ context.Context, _ string, _ []string) ([]map[string]any, error) {
-		return nil, nil
+	deps.SearchMCPTools = func(_ context.Context, _ string, _ []string) (string, error) {
+		return "", nil
 	}
 
 	s := buildCodeModeServer(deps)
@@ -1414,4 +1461,133 @@ func TestRegisterVoidLLMTools_CodeModeToolsListed(t *testing.T) {
 			t.Errorf("Code Mode tool %q not found in tools/list", want)
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Code Mode description regression tests (L-013)
+// ---------------------------------------------------------------------------
+
+// assertContains fails the test if desc does not contain needle.
+func assertContains(t *testing.T, desc, needle string) {
+	t.Helper()
+	if !strings.Contains(desc, needle) {
+		t.Errorf("description missing %q, got:\n%s", needle, desc)
+	}
+}
+
+// assertNotContains fails the test if desc contains needle.
+func assertNotContains(t *testing.T, desc, needle string) {
+	t.Helper()
+	if strings.Contains(desc, needle) {
+		t.Errorf("description should not contain %q, got:\n%s", needle, desc)
+	}
+}
+
+// findTool returns the Tool with the given name from tools, or the zero value
+// if not found.
+func findTool(tools []mcp.Tool, name string) (mcp.Tool, bool) {
+	for _, t := range tools {
+		if t.Name == name {
+			return t, true
+		}
+	}
+	return mcp.Tool{}, false
+}
+
+// TestCodeModeToolDescriptions_Static locks in the STRONG PREFERENCE, WORKFLOW,
+// PATTERNS, NOTE, and cross-reference language in each Code Mode tool description.
+// Any future refactor that strips this guidance must fail this test.
+func TestCodeModeToolDescriptions_Static(t *testing.T) {
+	t.Parallel()
+
+	// Use CodeModeDescription() directly for the execute_code body — it is the
+	// authoritative source and what RegisterCodeModeTools wires in.
+	execDesc := mcp.CodeModeDescription()
+
+	// Also verify the descriptions come through the registered tool objects so
+	// the wiring is covered.
+	deps := defaultDeps()
+	deps.ExecuteCode = func(_ context.Context, _ string, _ []string) (*mcp.ExecuteResult, error) {
+		return &mcp.ExecuteResult{Result: json.RawMessage(`"ok"`)}, nil
+	}
+	deps.ListAccessibleMCPServers = func(_ context.Context, _ bool) ([]map[string]any, error) {
+		return nil, nil
+	}
+	deps.SearchMCPTools = func(_ context.Context, _ string, _ []string) (string, error) {
+		return "", nil
+	}
+	s := buildCodeModeServer(deps)
+	registeredTools := s.Tools()
+
+	t.Run("execute_code_static_description", func(t *testing.T) {
+		t.Parallel()
+
+		// --- required substrings ---
+		assertContains(t, execDesc, "STRONG PREFERENCE")
+		assertContains(t, execDesc, "Promise.allSettled")
+		assertContains(t, execDesc, "search_tools()")
+		assertContains(t, execDesc, "try {")
+		assertContains(t, execDesc, "Promise<any>")
+
+		// --- forbidden substrings (VoidMCP artefacts must be scrubbed) ---
+		assertNotContains(t, execDesc, "add_mcp")
+		assertNotContains(t, execDesc, "remove_mcp")
+		assertNotContains(t, execDesc, "list_mcps")
+		assertNotContains(t, execDesc, "via CLI")
+	})
+
+	t.Run("execute_code_registered_description_matches", func(t *testing.T) {
+		t.Parallel()
+
+		tool, ok := findTool(registeredTools, "execute_code")
+		if !ok {
+			t.Fatal("execute_code not found in registered tools")
+		}
+		// The registered description is the static constant — it must start with
+		// the same text that CodeModeDescription() returns (the hook may later
+		// append more, but at registration time they must be identical).
+		if tool.Description != execDesc {
+			t.Errorf("registered execute_code description does not match CodeModeDescription();\ngot:  %q\nwant: %q",
+				tool.Description, execDesc)
+		}
+	})
+
+	t.Run("search_tools_description", func(t *testing.T) {
+		t.Parallel()
+
+		tool, ok := findTool(registeredTools, "search_tools")
+		if !ok {
+			t.Fatal("search_tools not found in registered tools")
+		}
+		desc := tool.Description
+
+		// --- required substrings ---
+		assertContains(t, desc, "execute_code")
+		assertContains(t, desc, "chain them")
+		assertContains(t, desc, "ask an admin")
+
+		// --- forbidden substrings ---
+		assertNotContains(t, desc, "add_mcp")
+		assertNotContains(t, desc, "via CLI")
+	})
+
+	t.Run("list_servers_description", func(t *testing.T) {
+		t.Parallel()
+
+		tool, ok := findTool(registeredTools, "list_servers")
+		if !ok {
+			t.Fatal("list_servers not found in registered tools")
+		}
+		desc := tool.Description
+
+		// list_servers must cross-reference search_tools.
+		assertContains(t, desc, "search_tools")
+
+		// Lock in that it stays minimal — a bloated description is a regression.
+		const maxLen = 300
+		if len(desc) >= maxLen {
+			t.Errorf("list_servers description is %d chars (>= %d); it should stay minimal:\n%s",
+				len(desc), maxLen, desc)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Three related Code Mode improvements ported from VoidMCP. One feature branch because each depends on the previous.

### Response unwrapping
Strips the MCP ``ToolResult`` wrapper before handing results to the JS sandbox. Scripts access ``result.field`` directly instead of ``JSON.parse(result.content[0].text).field``. Defensive passthrough when the payload doesn't match a wrapper shape.

### Output schema inference
First successful tool call walks the response (bounded depth and size), produces a JSON-Schema-like map, stores it in a new ``output_schemas`` table. Subsequent ``search_tools`` responses render the inferred shape as real TypeScript (e.g. ``Promise<Array<{ id: number; name: string }>>``) instead of ``Promise<any>``. Configurable via ``code_mode.schema_ttl`` (default 7 days, 0 disables re-inference).

### Description polish
``execute_code`` and ``search_tools`` descriptions rewritten to explicitly steer the LLM toward chained execution, with inline pattern examples (``Promise.allSettled``, ``try/catch``) and a clear search-first workflow. Static descriptions and the dynamic ``toolsListHook`` both derive from a single source so they can't drift.

### search_tools TypeScript output
``search_tools`` now returns a TypeScript text block (matching VoidMCP's equivalent) instead of flat JSON metadata. This is what makes inferred types actually reachable mid-session.

## Migration

``0012_output_schemas.up.sql`` — new table, universal SQL (SQLite + Postgres), reversible.

## Test plan

- [x] ``go vet ./...`` clean
- [x] ``go test ./... -race -count=1`` all packages green
- [x] Unit tests for inference matrix, TypeScript generation matrix, store CRUD + TTL math, unwrap edge cases
- [x] Integration tests for end-to-end schema capture and rendering
- [x] Code review (two rounds, final approved)
- [x] Review findings addressed
- [ ] Manual smoke: register MCP server, execute tool, confirm ``search_tools`` surfaces inferred types