### PR TITLE
Fix startup panic when Code Mode is disabled

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -749,6 +749,15 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 	// Create Code Mode service — wires the three Code Mode VoidLLMDeps functions
 	// and the OnToolsListHook as methods on a single struct so they share state
 	// without ad-hoc closure captures.
+	//
+	// SchemaTTL is only assigned a default when Code Mode is explicitly enabled,
+	// so it can still be nil here when Code Mode is disabled. Dereferencing it
+	// unconditionally would panic at startup; fall back to a zero TTL in that
+	// case (the service's Code Mode entrypoints are not reachable anyway).
+	var schemaTTL time.Duration
+	if cfg.Settings.MCP.CodeMode.SchemaTTL != nil {
+		schemaTTL = *cfg.Settings.MCP.CodeMode.SchemaTTL
+	}
 	cmService := &codeModeService{
 		executor:     adminHandler.CodeExecutor,
 		toolCache:    adminHandler.ToolCache,
@@ -756,7 +765,7 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 		db:           database,
 		log:          log,
 		maxToolCalls: cfg.Settings.MCP.CodeMode.MaxToolCalls,
-		schemaTTL:    *cfg.Settings.MCP.CodeMode.SchemaTTL,
+		schemaTTL:    schemaTTL,
 		serverCache:  mcpServerCache,
 		codePool:     adminHandler.CodePool,
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1584,6 +1584,36 @@ func TestSetDefaults_SchemaTTL_ExplicitZeroIsPreserved(t *testing.T) {
 	}
 }
 
+// TestSetDefaults_SchemaTTL_NilWhenCodeModeDisabled verifies that setDefaults
+// does NOT fill in a SchemaTTL default when Code Mode is not enabled. The
+// pointer stays nil, so any consumer that dereferences it (e.g. app.New) must
+// guard against nil; see the regression for the startup panic in
+// internal/app/app.go.
+func TestSetDefaults_SchemaTTL_NilWhenCodeModeDisabled(t *testing.T) {
+	t.Parallel()
+
+	yaml := `
+server:
+  proxy:
+    port: 8080
+database:
+  driver: sqlite
+  dsn: voidllm.db
+settings:
+  encryption_key: aaaaaaaaaaaaaaaa
+  usage:
+    buffer_size: 100
+`
+	path := writeTemp(t, "voidllm.yaml", yaml)
+	cfg, _, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+	if cfg.Settings.MCP.CodeMode.SchemaTTL != nil {
+		t.Errorf("SchemaTTL = %v, want nil when Code Mode is disabled", *cfg.Settings.MCP.CodeMode.SchemaTTL)
+	}
+}
+
 // ---- Load — full integration -----------------------------------------------
 
 func TestLoad_FullConfig(t *testing.T) {


### PR DESCRIPTION
## Problem

VoidLLM panics at startup with a nil pointer dereference whenever Code Mode is not explicitly enabled:

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/voidmind-io/voidllm/internal/app.New(...)
	/app/internal/app/app.go:759
main.main()
	/app/cmd/voidllm/main.go:85
```

Fixes #87.

## Cause

`app.New` builds `codeModeService` unconditionally and does `schemaTTL: *cfg.Settings.MCP.CodeMode.SchemaTTL`. But `setDefaults` only assigns `SchemaTTL` a default when `CodeMode.IsEnabled()` is true, so the pointer is nil in the (default) disabled case and the dereference panics.

## Fix

Dereference `SchemaTTL` only when it is non-nil, falling back to a zero `time.Duration` otherwise. The Code Mode entrypoints on the service are not registered/reachable when Code Mode is disabled, so the value is unused in that path.

## Test plan

- Added `TestSetDefaults_SchemaTTL_NilWhenCodeModeDisabled` in `internal/config` documenting that `SchemaTTL` stays nil when Code Mode is disabled (the precondition this fix tolerates).
- `go test ./internal/config/ ./internal/app/` passes; `go vet` clean. (`internal/app` requires `ui/dist` built per CONTRIBUTING; with that present the package builds and tests pass.)