### PR TITLE
chore: release 0.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to VoidLLM are documented in this file.
 
+## [0.0.18] - 2026-05-13
+
+### Fixes
+- Startup panic when Code Mode is disabled - default config caused a nil pointer dereference of `SchemaTTL` in `app.go`. Thanks to @kernelb00t for the report (#87) and @SAY-5 for the fix (#90)
+
+---
+
 ## [0.0.17] - 2026-04-30
 
 ### Features

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 COPY --from=ui-builder /app/ui/dist ./ui/dist
-ARG VERSION=0.0.17
+ARG VERSION=0.0.18
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -ldflags="-s -w -X 'github.com/voidmind-io/voidllm/internal/api/health.Version=${VERSION}'" \
     -o /voidllm ./cmd/voidllm

--- a/chart/voidllm/Chart.yaml
+++ b/chart/voidllm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: voidllm
 description: Privacy-first LLM proxy and AI gateway with load balancing, RBAC, MCP gateway, and built-in admin UI. Self-hosted, single binary, sub-500us overhead.
 type: application
-version: 0.0.17
-appVersion: "0.0.17"
+version: 0.0.18
+appVersion: "0.0.18"
 home: https://voidllm.ai
 icon: https://voidllm.ai/logo.svg
 sources:

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -89,5 +89,5 @@ The Docker image sets `VOIDLLM_DATABASE_DSN=/data/voidllm.db` by default. Overri
 
 ```bash
 curl http://localhost:8080/healthz
-# {"status":"ok","uptime_seconds":42,"version":"0.0.17"}
+# {"status":"ok","uptime_seconds":42,"version":"0.0.18"}
 ```


### PR DESCRIPTION
Hotfix release for the startup panic introduced in v0.0.17.

Fixes #87 — startup nil pointer dereference when Code Mode is disabled (default config).
Includes #90 by @SAY-5, reported by @kernelb00t.

## Test plan
- [x] CI green on #90 before merge
- [x] CHANGELOG/Dockerfile/Chart.yaml/docker.md consistently bumped to 0.0.18