### PR TITLE
chore: release 0.0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to VoidLLM are documented in this file.
 
+## [0.0.19] - 2026-05-14
+
+### Fixes
+- Admin TLS configuration (`server.admin.tls`) is now actually applied in dual-port mode. Previously `tls.enabled: true` was a silent no-op - the schema and validation existed but no listener consumed the cert/key. In single-port mode (admin sharing the proxy port) configuring TLS now emits a WARN since external termination is expected there. Thanks to @martinsotirov for the fix (#92)
+
+---
+
 ## [0.0.18] - 2026-05-13
 
 ### Fixes

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 COPY --from=ui-builder /app/ui/dist ./ui/dist
-ARG VERSION=0.0.18
+ARG VERSION=0.0.19
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -ldflags="-s -w -X 'github.com/voidmind-io/voidllm/internal/api/health.Version=${VERSION}'" \
     -o /voidllm ./cmd/voidllm

--- a/chart/voidllm/Chart.yaml
+++ b/chart/voidllm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: voidllm
 description: Privacy-first LLM proxy and AI gateway with load balancing, RBAC, MCP gateway, and built-in admin UI. Self-hosted, single binary, sub-500us overhead.
 type: application
-version: 0.0.18
-appVersion: "0.0.18"
+version: 0.0.19
+appVersion: "0.0.19"
 home: https://voidllm.ai
 icon: https://voidllm.ai/logo.svg
 sources:

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -89,5 +89,5 @@ The Docker image sets `VOIDLLM_DATABASE_DSN=/data/voidllm.db` by default. Overri
 
 ```bash
 curl http://localhost:8080/healthz
-# {"status":"ok","uptime_seconds":42,"version":"0.0.18"}
+# {"status":"ok","uptime_seconds":42,"version":"0.0.19"}
 ```


### PR DESCRIPTION
Hotfix release for admin TLS being a silent no-op.

Includes #92 by @martinsotirov.

## Test plan
- [x] CI green on #92 before merge
- [x] CHANGELOG/Dockerfile/Chart.yaml/docker.md bumped to 0.0.19