### PR TITLE
fix: redact secrets from audit log descriptions

### DIFF
--- a/internal/audit/build_description_test.go
+++ b/internal/audit/build_description_test.go
@@ -1,0 +1,331 @@
+package audit
+
+// White-box unit tests for buildDescription and its helpers. These live in
+// package audit (not audit_test) so that the unexported buildDescription,
+// redactMap, and redactSlice functions are directly accessible.
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuildDescription covers the full contract of buildDescription:
+// sensitive-field redaction, zero-value dropping, recursive descent, and
+// fallback behaviour for invalid input.
+func TestBuildDescription(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+		// checks is a list of assertions expressed as functions so each test case
+		// can assert the combination of contains/not-contains that matters to it.
+		checks []func(t *testing.T, got string)
+	}{
+		// ------------------------------------------------------------------
+		// Top-level sensitive field: password
+		// ------------------------------------------------------------------
+		{
+			name: "top-level password is redacted",
+			body: `{"email":"a@b.c","password":"secret123"}`,
+			checks: []func(t *testing.T, got string){
+				containsStr(`"email":"a@b.c"`),
+				containsStr(`"[REDACTED]"`),
+				containsStr(`"password"`),
+				notContainsStr("secret123"),
+			},
+		},
+		// ------------------------------------------------------------------
+		// All sensitive field names — one subtest per field
+		// ------------------------------------------------------------------
+		{
+			name: "api_key is redacted",
+			body: `{"api_key":"sk-live-abc123","name":"my-model"}`,
+			checks: []func(t *testing.T, got string){
+				containsStr(`"api_key"`),
+				containsStr(`"[REDACTED]"`),
+				notContainsStr("sk-live-abc123"),
+				containsStr(`"name":"my-model"`),
+			},
+		},
+		{
+			name: "auth_token is redacted",
+			body: `{"auth_token":"tok-xyz","url":"https://example.com"}`,
+			checks: []func(t *testing.T, got string){
+				containsStr(`"auth_token"`),
+				containsStr(`"[REDACTED]"`),
+				notContainsStr("tok-xyz"),
+			},
+		},
+		{
+			name: "oauth_client_secret is redacted",
+			body: `{"oauth_client_secret":"oauth-secret-99","client_id":"client-1"}`,
+			checks: []func(t *testing.T, got string){
+				containsStr(`"oauth_client_secret"`),
+				containsStr(`"[REDACTED]"`),
+				notContainsStr("oauth-secret-99"),
+				containsStr(`"client_id":"client-1"`),
+			},
+		},
+		{
+			name: "client_secret is redacted",
+			body: `{"client_secret":"cs-top-secret","issuer":"https://idp.example"}`,
+			checks: []func(t *testing.T, got string){
+				containsStr(`"client_secret"`),
+				containsStr(`"[REDACTED]"`),
+				notContainsStr("cs-top-secret"),
+			},
+		},
+		{
+			name: "key is redacted",
+			body: `{"key":"vl-license-jwt-xxx","seat_count":5}`,
+			checks: []func(t *testing.T, got string){
+				containsStr(`"key"`),
+				containsStr(`"[REDACTED]"`),
+				notContainsStr("vl-license-jwt-xxx"),
+				containsStr(`"seat_count"`),
+			},
+		},
+		// ------------------------------------------------------------------
+		// Nested object: sensitive field inside nested config object
+		// ------------------------------------------------------------------
+		{
+			name: "api_key nested inside config object is redacted",
+			body: `{"config":{"api_key":"sk-live-123","name":"x"}}`,
+			checks: []func(t *testing.T, got string){
+				containsStr(`"api_key"`),
+				containsStr(`"[REDACTED]"`),
+				notContainsStr("sk-live-123"),
+				containsStr(`"name":"x"`),
+			},
+		},
+		// ------------------------------------------------------------------
+		// Array of objects: sensitive field inside each array element
+		// ------------------------------------------------------------------
+		{
+			name: "auth_token inside array of objects is redacted for all elements",
+			body: `{"servers":[{"auth_token":"tok-1","host":"h1"},{"auth_token":"tok-2","host":"h2"}]}`,
+			checks: []func(t *testing.T, got string){
+				containsStr(`"[REDACTED]"`),
+				notContainsStr("tok-1"),
+				notContainsStr("tok-2"),
+				containsStr(`"host":"h1"`),
+				containsStr(`"host":"h2"`),
+			},
+		},
+		// ------------------------------------------------------------------
+		// Negative test: "token"-containing field names that are NOT sensitive
+		// ------------------------------------------------------------------
+		{
+			name: "max_tokens and token_count are not redacted (no substring match)",
+			body: `{"max_tokens":100,"token_count":5,"prompt":"hello"}`,
+			checks: []func(t *testing.T, got string){
+				notContainsStr(`"[REDACTED]"`),
+				containsStr(`"max_tokens"`),
+				containsStr(`"token_count"`),
+				// "prompt" is a non-zero string so it is included too
+				containsStr(`"prompt":"hello"`),
+			},
+		},
+		// ------------------------------------------------------------------
+		// Drop behaviour: zero/empty/null/false values for non-sensitive fields
+		// ------------------------------------------------------------------
+		{
+			name: "zero-value non-sensitive fields are dropped",
+			body: `{"name":"","count":0,"flag":false,"x":null,"kept":"value"}`,
+			checks: []func(t *testing.T, got string){
+				notContainsStr(`"name"`),
+				notContainsStr(`"count"`),
+				notContainsStr(`"flag"`),
+				notContainsStr(`"x"`),
+				containsStr(`"kept":"value"`),
+			},
+		},
+		// ------------------------------------------------------------------
+		// Sensitive field with empty value: document the actual behaviour.
+		// The implementation always emits sensitive fields as "[REDACTED]"
+		// regardless of their value, including the empty string.
+		// ------------------------------------------------------------------
+		{
+			name: "password with empty string value is emitted as [REDACTED]",
+			body: `{"password":""}`,
+			checks: []func(t *testing.T, got string){
+				containsStr(`"password"`),
+				containsStr(`"[REDACTED]"`),
+			},
+		},
+		// ------------------------------------------------------------------
+		// Invalid JSON: returns empty string (existing fallback behaviour)
+		// ------------------------------------------------------------------
+		{
+			name: "invalid JSON returns empty string",
+			body: `{not valid json`,
+			checks: []func(t *testing.T, got string){
+				func(t *testing.T, got string) {
+					t.Helper()
+					if got != "" {
+						t.Errorf("buildDescription(%q) = %q, want empty string for invalid JSON", `{not valid json`, got)
+					}
+				},
+			},
+		},
+		// ------------------------------------------------------------------
+		// Empty body: returns empty string
+		// ------------------------------------------------------------------
+		{
+			name: "empty body returns empty string",
+			body: ``,
+			checks: []func(t *testing.T, got string){
+				func(t *testing.T, got string) {
+					t.Helper()
+					if got != "" {
+						t.Errorf("buildDescription(empty) = %q, want empty string", got)
+					}
+				},
+			},
+		},
+		// ------------------------------------------------------------------
+		// Body that is all-zero after dropping: returns empty string
+		// ------------------------------------------------------------------
+		{
+			name: "body with only zero-value fields returns empty string",
+			body: `{"name":"","count":0,"active":false,"data":null}`,
+			checks: []func(t *testing.T, got string){
+				func(t *testing.T, got string) {
+					t.Helper()
+					if got != "" {
+						t.Errorf("buildDescription(all-zero) = %q, want empty string", got)
+					}
+				},
+			},
+		},
+		// ------------------------------------------------------------------
+		// Multiple sensitive fields at once: every one is redacted
+		// ------------------------------------------------------------------
+		{
+			name: "multiple sensitive fields in same body are all redacted",
+			body: `{"password":"p","api_key":"k","name":"bob"}`,
+			checks: []func(t *testing.T, got string){
+				notContainsStr(`"p"`),
+				notContainsStr(`"k"`),
+				containsStr(`"password"`),
+				containsStr(`"api_key"`),
+				containsStr(`"name":"bob"`),
+			},
+		},
+		// ------------------------------------------------------------------
+		// Deeply nested: sensitive field two levels deep
+		// ------------------------------------------------------------------
+		{
+			name: "client_secret two levels deep is redacted",
+			body: `{"sso":{"provider":"google","credentials":{"client_secret":"deep-secret","client_id":"cid-1"}}}`,
+			checks: []func(t *testing.T, got string){
+				containsStr(`"client_secret"`),
+				containsStr(`"[REDACTED]"`),
+				notContainsStr("deep-secret"),
+				containsStr(`"client_id":"cid-1"`),
+			},
+		},
+		// ------------------------------------------------------------------
+		// Array of scalars: scalars pass through unchanged
+		// ------------------------------------------------------------------
+		{
+			name: "array of scalars passes through without redaction",
+			body: `{"tags":["alpha","beta"],"active":true}`,
+			checks: []func(t *testing.T, got string){
+				containsStr(`"tags"`),
+				containsStr("alpha"),
+				containsStr("beta"),
+				notContainsStr(`"[REDACTED]"`),
+			},
+		},
+		// ------------------------------------------------------------------
+		// Fix 1 – Case-insensitive redaction
+		// ------------------------------------------------------------------
+		{
+			name: "mixed-case Password field is redacted (case-insensitive)",
+			body: `{"email":"a@b.c","Password":"secret"}`,
+			checks: []func(t *testing.T, got string){
+				containsStr(`"email":"a@b.c"`),
+				containsStr(`"[REDACTED]"`),
+				notContainsStr("secret"),
+			},
+		},
+		{
+			name: "all-caps API_KEY field is redacted (case-insensitive)",
+			body: `{"API_KEY":"sk-upper-case","name":"m"}`,
+			checks: []func(t *testing.T, got string){
+				containsStr(`"[REDACTED]"`),
+				notContainsStr("sk-upper-case"),
+				containsStr(`"name":"m"`),
+			},
+		},
+		{
+			name: "mixed-case Client_Secret field is redacted (case-insensitive)",
+			body: `{"Client_Secret":"cs-mixed","issuer":"https://idp.example"}`,
+			checks: []func(t *testing.T, got string){
+				containsStr(`"[REDACTED]"`),
+				notContainsStr("cs-mixed"),
+			},
+		},
+		// ------------------------------------------------------------------
+		// Fix 2 – "token" field added to sensitiveFields
+		// ------------------------------------------------------------------
+		{
+			name: "token field is redacted",
+			body: `{"token":"invite-tok-abc","email":"a@b.c"}`,
+			checks: []func(t *testing.T, got string){
+				containsStr(`"token"`),
+				containsStr(`"[REDACTED]"`),
+				notContainsStr("invite-tok-abc"),
+				containsStr(`"email":"a@b.c"`),
+			},
+		},
+		// ------------------------------------------------------------------
+		// Edge-case: sensitive field whose value is itself an object.
+		// The sensitiveFields check must fire BEFORE recursion so the nested
+		// content is never included in the output.
+		// ------------------------------------------------------------------
+		{
+			name: "sensitive field with object value is redacted without recursing",
+			body: `{"password":{"hash":"abc123","algo":"bcrypt"}}`,
+			checks: []func(t *testing.T, got string){
+				containsStr(`"password"`),
+				containsStr(`"[REDACTED]"`),
+				notContainsStr("abc123"),
+				notContainsStr("bcrypt"),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := buildDescription([]byte(tc.body))
+			for _, check := range tc.checks {
+				check(t, got)
+			}
+		})
+	}
+}
+
+// containsStr returns a check function asserting that got contains sub.
+func containsStr(sub string) func(t *testing.T, got string) {
+	return func(t *testing.T, got string) {
+		t.Helper()
+		if !strings.Contains(got, sub) {
+			t.Errorf("buildDescription output %q does not contain %q", got, sub)
+		}
+	}
+}
+
+// notContainsStr returns a check function asserting that got does NOT contain sub.
+func notContainsStr(sub string) func(t *testing.T, got string) {
+	return func(t *testing.T, got string) {
+		t.Helper()
+		if strings.Contains(got, sub) {
+			t.Errorf("buildDescription output %q must not contain %q", got, sub)
+		}
+	}
+}

--- a/internal/audit/middleware.go
+++ b/internal/audit/middleware.go
@@ -10,6 +10,37 @@ import (
 	"github.com/voidmind-io/voidllm/internal/jsonx"
 )
 
+// sensitiveFields lists JSON field names whose values must never be persisted
+// in audit log descriptions. All keys are lowercase; redactMap normalises
+// incoming field names with strings.ToLower before the lookup so that
+// mixed-case variants such as "Password" or "API_KEY" are caught correctly.
+// Matching is exact (not substring) to avoid false positives such as
+// "max_tokens". When a field in this set is present in the request body, its
+// value is replaced with the string "[REDACTED]" rather than being dropped
+// entirely — so the audit trail shows that the field was sent (e.g. "password
+// was changed") without exposing the value.
+//
+// Sources:
+//   - "password":            createUserRequest, updateUserRequest (users.go)
+//   - "api_key":             createModelRequest, updateModelRequest (models.go);
+//     createDeploymentRequest, updateDeploymentRequest (deployments.go);
+//     testConnectionRequest (models.go)
+//   - "auth_token":          createMCPServerRequest, updateMCPServerRequest (mcp_servers.go)
+//   - "oauth_client_secret": createMCPServerRequest, updateMCPServerRequest (mcp_servers.go)
+//   - "client_secret":       ssoConfigRequest (org_sso.go)
+//   - "key":                 setLicenseRequest (license.go)
+//   - "token":               defense-in-depth for invite tokens and similar
+//     single-field token payloads
+var sensitiveFields = map[string]struct{}{
+	"password":            {},
+	"api_key":             {},
+	"auth_token":          {},
+	"oauth_client_secret": {},
+	"client_secret":       {},
+	"key":                 {},
+	"token":               {},
+}
+
 // normalizeResourceType maps plural URL path segments to their canonical
 // resource type names used in audit events.
 var normalizeResourceType = map[string]string{
@@ -209,27 +240,30 @@ func parseRoute(c fiber.Ctx) (action, resourceType, resourceID string) {
 	return action, resourceType, resourceID
 }
 
+// redactedValue is the JSON literal substituted for any sensitive field value.
+const redactedValue = `"[REDACTED]"`
+
 // buildDescription creates a compact JSON representation of the request body
 // fields that were sent. This shows exactly what the caller changed without
 // requiring a pre-change DB read. Fields with zero values are omitted.
+// Sensitive field values (see sensitiveFields) are replaced with "[REDACTED]"
+// rather than being dropped — the audit trail records that the field was
+// present without exposing the secret. Redaction is applied recursively into
+// nested objects and into objects contained in arrays.
 // The result is stored as the audit event description.
 func buildDescription(body []byte) string {
 	if len(body) == 0 {
 		return ""
 	}
-	var raw map[string]jsonx.RawMessage
+	// any is intentional here: jsonx.Unmarshal of an arbitrary JSON document
+	// into interface{} is the standard approach for schema-agnostic traversal.
+	// The alternative — operating purely on RawMessage bytes — would require a
+	// custom JSON tokeniser and is not meaningfully safer.
+	var raw map[string]any
 	if jsonx.Unmarshal(body, &raw) != nil {
 		return ""
 	}
-	// Re-marshal only non-null, non-empty fields into compact JSON.
-	clean := make(map[string]jsonx.RawMessage, len(raw))
-	for k, v := range raw {
-		s := string(v)
-		if s == "null" || s == `""` || s == "0" || s == "false" {
-			continue
-		}
-		clean[k] = v
-	}
+	clean := redactMap(raw)
 	if len(clean) == 0 {
 		return ""
 	}
@@ -238,4 +272,75 @@ func buildDescription(body []byte) string {
 		return ""
 	}
 	return string(out)
+}
+
+// redactMap processes a JSON object map: it drops zero-value fields for
+// non-sensitive keys, replaces sensitive key values with redactedValue, and
+// recurses into nested objects and arrays of objects.
+//
+// The return type is map[string]any. any is required here because the values
+// may be strings, numbers, booleans, nested maps, or slices — all originating
+// from jsonx.Unmarshal into interface{}.
+func redactMap(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		if _, sensitive := sensitiveFields[strings.ToLower(k)]; sensitive {
+			// Always include sensitive fields, but replace their value so the
+			// audit trail shows the field was present (e.g. "password changed").
+			out[k] = jsonx.RawMessage(redactedValue)
+			continue
+		}
+		// Drop zero/empty values for non-sensitive fields (existing behaviour).
+		if isZeroValue(v) {
+			continue
+		}
+		// Recurse into nested objects.
+		if nested, ok := v.(map[string]any); ok {
+			if rec := redactMap(nested); len(rec) > 0 {
+				out[k] = rec
+			}
+			continue
+		}
+		// Recurse into arrays: process object elements, pass scalars through.
+		if arr, ok := v.([]any); ok {
+			out[k] = redactSlice(arr)
+			continue
+		}
+		out[k] = v
+	}
+	return out
+}
+
+// redactSlice processes a JSON array: object elements are passed through
+// redactMap; scalar elements are included as-is.
+//
+// []any is the natural type produced by jsonx.Unmarshal for JSON arrays.
+func redactSlice(arr []any) []any {
+	out := make([]any, 0, len(arr))
+	for _, elem := range arr {
+		if nested, ok := elem.(map[string]any); ok {
+			out = append(out, redactMap(nested))
+		} else {
+			out = append(out, elem)
+		}
+	}
+	return out
+}
+
+// isZeroValue reports whether v represents a JSON zero/empty value that should
+// be omitted from the audit description. It mirrors the original string-based
+// checks: null, empty string, numeric zero, and boolean false.
+func isZeroValue(v any) bool {
+	if v == nil {
+		return true
+	}
+	switch val := v.(type) {
+	case string:
+		return val == ""
+	case float64:
+		return val == 0
+	case bool:
+		return !val
+	}
+	return false
 }

--- a/internal/audit/redaction_middleware_test.go
+++ b/internal/audit/redaction_middleware_test.go
@@ -1,0 +1,221 @@
+package audit_test
+
+// End-to-end redaction tests for the audit middleware. These tests send a real
+// HTTP request through a Fiber app wired to the audit middleware, let the event
+// flush to an in-memory SQLite database, and then read the persisted description
+// back to assert that no secret value is present.
+
+import (
+	"context"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+)
+
+// TestMiddleware_Redaction_PasswordNotPersistedInDescription verifies that a
+// POST body containing a "password" field results in an audit log row whose
+// description column contains neither the plaintext password nor any variation
+// of it. The field key itself must appear (as "[REDACTED]") so the audit trail
+// records that a password was supplied.
+func TestMiddleware_Redaction_PasswordNotPersistedInDescription(t *testing.T) {
+	t.Parallel()
+
+	logger, database := setupMiddlewareLogger(t, "TestMiddleware_Redaction_Password")
+	app := buildApp(t, logger, []middlewareRoute{
+		{method: "POST", path: "/users", handler: handlerWithStatus(201)},
+	})
+
+	body := `{"email":"alice@example.com","password":"super-secret-pass-99"}`
+	req := httptest.NewRequest("POST", "/api/v1/users",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	if resp.StatusCode != 201 {
+		t.Fatalf("handler status = %d, want 201", resp.StatusCode)
+	}
+
+	logger.Stop()
+
+	if got := countAuditLogs(t, database); got != 1 {
+		t.Fatalf("audit_logs row count = %d, want 1", got)
+	}
+
+	var description string
+	row := database.SQL().QueryRowContext(context.Background(),
+		"SELECT description FROM audit_logs LIMIT 1")
+	if err := row.Scan(&description); err != nil {
+		t.Fatalf("scan description: %v", err)
+	}
+
+	if strings.Contains(description, "super-secret-pass-99") {
+		t.Errorf("description %q must not contain the plaintext password", description)
+	}
+	if !strings.Contains(description, `"password"`) {
+		t.Errorf("description %q must contain the field key \"password\" (as [REDACTED]) "+
+			"so the audit trail shows the field was supplied", description)
+	}
+	if !strings.Contains(description, "[REDACTED]") {
+		t.Errorf("description %q must contain \"[REDACTED]\" for the password value", description)
+	}
+	if !strings.Contains(description, `"email"`) {
+		t.Errorf("description %q must contain non-sensitive field \"email\"", description)
+	}
+}
+
+// TestMiddleware_Redaction_APIKeyNotPersistedInDescription verifies that
+// api_key values are redacted in the persisted audit description.
+func TestMiddleware_Redaction_APIKeyNotPersistedInDescription(t *testing.T) {
+	t.Parallel()
+
+	logger, database := setupMiddlewareLogger(t, "TestMiddleware_Redaction_APIKey")
+	app := buildApp(t, logger, []middlewareRoute{
+		{method: "POST", path: "/models", handler: handlerWithStatus(201)},
+	})
+
+	body := `{"name":"gpt-4-proxy","api_key":"sk-live-very-secret-key"}`
+	req := httptest.NewRequest("POST", "/api/v1/models",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	logger.Stop()
+
+	if got := countAuditLogs(t, database); got != 1 {
+		t.Fatalf("audit_logs row count = %d, want 1", got)
+	}
+
+	var description string
+	row := database.SQL().QueryRowContext(context.Background(),
+		"SELECT description FROM audit_logs LIMIT 1")
+	if err := row.Scan(&description); err != nil {
+		t.Fatalf("scan description: %v", err)
+	}
+
+	if strings.Contains(description, "sk-live-very-secret-key") {
+		t.Errorf("description %q must not contain the plaintext api_key", description)
+	}
+	if !strings.Contains(description, "[REDACTED]") {
+		t.Errorf("description %q must contain \"[REDACTED]\" for the api_key value", description)
+	}
+	if !strings.Contains(description, `"name":"gpt-4-proxy"`) {
+		t.Errorf("description %q must contain the non-sensitive \"name\" field", description)
+	}
+}
+
+// TestMiddleware_Redaction_NonSensitiveBodyPreserved verifies that a body
+// containing no sensitive fields is preserved verbatim in the description
+// (modulo zero-value dropping), and no "[REDACTED]" marker appears.
+func TestMiddleware_Redaction_NonSensitiveBodyPreserved(t *testing.T) {
+	t.Parallel()
+
+	logger, database := setupMiddlewareLogger(t, "TestMiddleware_Redaction_NonSensitive")
+	app := buildApp(t, logger, []middlewareRoute{
+		{method: "PATCH", path: "/orgs/:org_id", handler: handlerWithStatus(200)},
+	})
+
+	body := `{"display_name":"Acme Corp","max_tokens":4096}`
+	req := httptest.NewRequest("PATCH", "/api/v1/orgs/org-abc",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	logger.Stop()
+
+	if got := countAuditLogs(t, database); got != 1 {
+		t.Fatalf("audit_logs row count = %d, want 1", got)
+	}
+
+	var description string
+	row := database.SQL().QueryRowContext(context.Background(),
+		"SELECT description FROM audit_logs LIMIT 1")
+	if err := row.Scan(&description); err != nil {
+		t.Fatalf("scan description: %v", err)
+	}
+
+	if strings.Contains(description, "[REDACTED]") {
+		t.Errorf("description %q must not contain \"[REDACTED]\" for non-sensitive fields", description)
+	}
+	if !strings.Contains(description, `"display_name":"Acme Corp"`) {
+		t.Errorf("description %q must contain the \"display_name\" field value", description)
+	}
+}
+
+// TestMiddleware_Redaction_MultipleSecretsInOneRequest verifies that when a
+// request body carries several sensitive fields simultaneously, every one of
+// them is redacted and no plaintext secret leaks into the persisted description.
+func TestMiddleware_Redaction_MultipleSecretsInOneRequest(t *testing.T) {
+	t.Parallel()
+
+	logger, database := setupMiddlewareLogger(t, "TestMiddleware_Redaction_MultipleSecrets")
+	app := buildApp(t, logger, []middlewareRoute{
+		{method: "PUT", path: "/orgs/:org_id/sso", handler: handlerWithStatus(200)},
+	})
+
+	body := `{"client_secret":"cs-plaintext","api_key":"ak-plaintext","issuer":"https://idp.example"}`
+	req := httptest.NewRequest("PUT", "/api/v1/orgs/org-sso/sso",
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: 5 * time.Second})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+
+	logger.Stop()
+
+	if got := countAuditLogs(t, database); got != 1 {
+		t.Fatalf("audit_logs row count = %d, want 1", got)
+	}
+
+	var description string
+	row := database.SQL().QueryRowContext(context.Background(),
+		"SELECT description FROM audit_logs LIMIT 1")
+	if err := row.Scan(&description); err != nil {
+		t.Fatalf("scan description: %v", err)
+	}
+
+	for _, secret := range []string{"cs-plaintext", "ak-plaintext"} {
+		if strings.Contains(description, secret) {
+			t.Errorf("description %q must not contain secret %q", description, secret)
+		}
+	}
+	if !strings.Contains(description, "[REDACTED]") {
+		t.Errorf("description %q must contain \"[REDACTED]\"", description)
+	}
+	if !strings.Contains(description, `"issuer"`) {
+		t.Errorf("description %q must contain non-sensitive \"issuer\" field", description)
+	}
+}

--- a/internal/db/migrations/0013_redact_audit_log_secrets.down.sql
+++ b/internal/db/migrations/0013_redact_audit_log_secrets.down.sql
@@ -1,0 +1,18 @@
+-- Migration: 0013_redact_audit_log_secrets.down.sql
+-- Description: This migration is intentionally a no-op.
+--
+-- The up migration overwrote plaintext secrets in audit_logs.description with
+-- an empty string. The original secret values are not stored anywhere and
+-- cannot be recovered. Rolling back this migration is therefore not possible
+-- without data loss — and restoring plaintext secrets into the database would
+-- be a security regression in any case.
+--
+-- If you need to roll back the schema version recorded in schema_migrations,
+-- you can delete the row manually:
+--
+--   DELETE FROM schema_migrations
+--   WHERE filename = '0013_redact_audit_log_secrets.up.sql';
+--
+-- This will cause the up migration to be re-applied on next startup, which is
+-- safe because the UPDATE is idempotent (rows already cleared to '' are
+-- excluded by the WHERE description != '' guard).

--- a/internal/db/migrations/0013_redact_audit_log_secrets.up.sql
+++ b/internal/db/migrations/0013_redact_audit_log_secrets.up.sql
@@ -1,0 +1,42 @@
+-- Migration: 0013_redact_audit_log_secrets.up.sql
+-- Description: One-time cleanup of audit_logs rows that were written before the
+-- redaction fix landed. Prior to the fix, the audit middleware serialised the
+-- raw Admin API request body as the description, which could contain plaintext
+-- secrets for any field that is now listed in sensitiveFields:
+--
+--   password, api_key, auth_token, oauth_client_secret, client_secret, key
+--
+-- The description column is NOT NULL (empty string = no description), so
+-- affected rows are cleared to '' rather than NULL.
+--
+-- IMPORTANT: Any secrets that may have been stored in audit_logs.description
+-- should be considered compromised. Rotate all credentials that were configured
+-- via the Admin API before this fix was applied (API keys, MCP auth tokens,
+-- SSO client secrets, model API keys, user passwords, license keys).
+--
+-- Pattern strategy: each LIKE pattern matches the JSON key as it would appear
+-- in a serialised object ('"key_name"'). A JSON key is always preceded by either
+-- '{' (opening brace) or ',' (field separator), and followed by '":'. Matching
+-- '"key_name":' is sufficient and portable across both SQLite and PostgreSQL.
+--
+-- Case-sensitivity note: SQLite LIKE is case-insensitive for ASCII letters by
+-- default; PostgreSQL LIKE is case-sensitive. The patterns below use lowercase
+-- only, which covers the standard API usage where field names are always
+-- lowercase. Mixed-case or uppercase variants of these field names are not
+-- matched by this migration. If variant casing is a concern, run a manual
+-- query using ILIKE (PostgreSQL) or LOWER(description) LIKE (SQLite) after
+-- this migration completes.
+
+UPDATE audit_logs
+SET    description = ''
+WHERE  description != ''
+  AND (
+        description LIKE '%"password":%'
+     OR description LIKE '%"api_key":%'
+     OR description LIKE '%"auth_token":%'
+     OR description LIKE '%"oauth_client_secret":%'
+     OR description LIKE '%"client_secret":%'
+     OR description LIKE '%"key":%'
+     OR description LIKE '%"token":%'
+     OR description LIKE '%"license":%'
+  );


### PR DESCRIPTION
## Problem

The audit middleware wrote admin API request bodies into `audit_logs.description`, which leaked secrets in cleartext: user passwords, upstream provider API keys, MCP `auth_token` / `oauth_client_secret`, SSO `client_secret`, and license keys. Any `org_admin` with audit-log read access could read them.

## Fix

- `buildDescription` now replaces the values of sensitive fields with `[REDACTED]` instead of persisting them, recursively through nested objects and arrays of objects.
- Field matching is **case-insensitive** (`strings.ToLower`), because Go unmarshals JSON into the request structs case-insensitively - so `{"Password": "..."}` would otherwise be processed by the handler but slip past redaction.
- Sensitive keys: `password`, `api_key`, `auth_token`, `oauth_client_secret`, `client_secret`, `key`, `token`.
- Non-sensitive fields keep the existing drop-empty/null/zero behaviour.

## Existing data

Migration `0013_redact_audit_log_secrets` clears `description` on existing rows whose value contains a known sensitive key (conservative LIKE match, SQLite + PostgreSQL portable, idempotent). The down migration is an intentional no-op - the original values are gone and must not be restored. **Operators should rotate any secrets that were entered via the admin API before this fix.**

## Tests

- Unit tests for `buildDescription`: top-level + nested + array redaction, case-insensitive variants (`Password`, `API_KEY`, `Client_Secret`), sensitive-field-with-object-value, exact-match negatives (`max_tokens` not touched), unchanged drop behaviour.
- End-to-end middleware tests against real in-memory SQLite verifying no plaintext lands in the persisted `description`.
- `go test -race ./internal/audit/ ./internal/db/ ./internal/api/...` clean.

Note: the login endpoint never went through this path (it builds its own description from the email only) - verified, no password leak there.