### PR TITLE
feat: brute-force protection for the login endpoint

### DIFF
--- a/internal/api/admin/auth.go
+++ b/internal/api/admin/auth.go
@@ -99,6 +99,24 @@ func (h *Handler) Login(c fiber.Ctx) error {
 		return apierror.BadRequest(c, "password is required")
 	}
 
+	// Brute-force protection: per-IP rate limit and per-account lockout.
+	// Called after field validation so that missing-field 400s are not throttled.
+	if h.LoginThrottle != nil {
+		if err := h.LoginThrottle.Allow(c.IP(), req.Email); err != nil {
+			h.Log.LogAttrs(c.Context(), slog.LevelWarn, "login throttled",
+				slog.String("ip", c.IP()),
+				slog.String("email", req.Email),
+			)
+			// Burn bcrypt time before returning 429 so that a throttled response
+			// takes ~the same wall time as a normal failed-password response.
+			// Without this, an attacker can distinguish "account locked" (fast)
+			// from "wrong password" (slow ~100ms) via timing. The error is
+			// intentionally discarded — the burn's only purpose is elapsed time.
+			_ = bcrypt.CompareHashAndPassword(dummyHash, []byte(req.Password))
+			return apierror.Send(c, fiber.StatusTooManyRequests, "too_many_requests", "too many login attempts, try again later")
+		}
+	}
+
 	ctx := c.Context()
 
 	userID, hash, err := h.DB.GetUserPasswordHash(ctx, req.Email)
@@ -106,6 +124,9 @@ func (h *Handler) Login(c fiber.Ctx) error {
 		// Burn bcrypt time to prevent timing-based email enumeration.
 		_ = bcrypt.CompareHashAndPassword(dummyHash, []byte(req.Password))
 		if errors.Is(err, db.ErrNotFound) || errors.Is(err, db.ErrNoPassword) {
+			if h.LoginThrottle != nil {
+				h.LoginThrottle.RecordFailure(req.Email)
+			}
 			h.auditLoginFailed(c, req.Email, fiber.StatusUnauthorized)
 			return apierror.Send(c, fiber.StatusUnauthorized, "unauthorized", "invalid email or password")
 		}
@@ -114,6 +135,9 @@ func (h *Handler) Login(c fiber.Ctx) error {
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(req.Password)); err != nil {
+		if h.LoginThrottle != nil {
+			h.LoginThrottle.RecordFailure(req.Email)
+		}
 		h.auditLoginFailed(c, req.Email, fiber.StatusUnauthorized)
 		return apierror.Send(c, fiber.StatusUnauthorized, "unauthorized", "invalid email or password")
 	}
@@ -174,6 +198,10 @@ func (h *Handler) Login(c fiber.Ctx) error {
 	if err != nil {
 		h.Log.ErrorContext(ctx, "login: get user", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "authentication failed")
+	}
+
+	if h.LoginThrottle != nil {
+		h.LoginThrottle.RecordSuccess(req.Email)
 	}
 
 	if h.AuditLogger != nil {

--- a/internal/api/admin/auth_throttle_test.go
+++ b/internal/api/admin/auth_throttle_test.go
@@ -1,0 +1,298 @@
+package admin_test
+
+import (
+	"fmt"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"context"
+	"github.com/gofiber/fiber/v3"
+	"github.com/voidmind-io/voidllm/internal/api/admin"
+	"github.com/voidmind-io/voidllm/internal/auth"
+	"github.com/voidmind-io/voidllm/internal/cache"
+	"github.com/voidmind-io/voidllm/internal/config"
+	"github.com/voidmind-io/voidllm/internal/db"
+	"github.com/voidmind-io/voidllm/internal/license"
+	"log/slog"
+	"time"
+)
+
+// setupTestAppWithThrottle is like setupTestApp but attaches a real LoginThrottle
+// to the handler so that brute-force protection is active.
+func setupTestAppWithThrottle(t *testing.T, dsn string) (*fiber.App, *db.DB, *cache.Cache[string, auth.KeyInfo]) {
+	t.Helper()
+
+	ctx := context.Background()
+	database, err := db.Open(ctx, config.DatabaseConfig{
+		Driver:          "sqlite",
+		DSN:             dsn,
+		MaxOpenConns:    1,
+		MaxIdleConns:    1,
+		ConnMaxLifetime: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("open test DB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	if err := db.RunMigrations(ctx, database.SQL(), db.SQLiteDialect{}, slog.Default()); err != nil {
+		t.Fatalf("run migrations: %v", err)
+	}
+
+	keyCache := cache.New[string, auth.KeyInfo]()
+
+	handler := &admin.Handler{
+		DB:            database,
+		HMACSecret:    testHMACSecret,
+		KeyCache:      keyCache,
+		License:       license.NewHolder(license.Verify("", true)),
+		Log:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+		LoginThrottle: auth.NewLoginThrottle(),
+	}
+
+	app := fiber.New()
+	admin.RegisterRoutes(app, handler, keyCache, testHMACSecret, nil)
+
+	return app, database, keyCache
+}
+
+// doLoginRequest sends a single POST /api/v1/auth/login request with the given
+// credentials and returns the HTTP status code.
+func doLoginRequest(t *testing.T, app *fiber.App, email, password string) int {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/v1/auth/login",
+		bodyJSON(t, map[string]any{"email": email, "password": password}))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// TestLoginThrottle_LockoutAfterFiveFailures verifies that five consecutive
+// wrong-password attempts for a known user trigger account lockout so that the
+// sixth attempt returns 429, regardless of whether the password is correct.
+func TestLoginThrottle_LockoutAfterFiveFailures(t *testing.T) {
+	t.Parallel()
+
+	const (
+		email    = "throttle-lock@example.com"
+		password = "correcthorse"
+	)
+
+	dsn := "file:TestLoginThrottle_Lockout?mode=memory&cache=private"
+	app, database, _ := setupTestAppWithThrottle(t, dsn)
+
+	org := mustCreateOrg(t, database, "Throttle Org", "throttle-lock-org")
+	user := mustCreateUserWithPassword(t, database, email, "Throttle User", password)
+	mustCreateOrgMembership(t, database, org.ID, user.ID, auth.RoleOrgAdmin)
+
+	// Five wrong-password attempts — each must return 401 (not yet throttled).
+	for i := 1; i <= 5; i++ {
+		status := doLoginRequest(t, app, email, "wrongpassword")
+		if status != fiber.StatusUnauthorized {
+			t.Fatalf("attempt %d: status = %d, want 401 (not yet throttled)", i, status)
+		}
+	}
+
+	// Sixth attempt — must be throttled regardless of which password is used.
+	req := httptest.NewRequest("POST", "/api/v1/auth/login",
+		bodyJSON(t, map[string]any{"email": email, "password": "wrongpassword"}))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusTooManyRequests {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("sixth attempt: status = %d, want 429; body: %s", resp.StatusCode, raw)
+	}
+
+	// Verify the response body uses a generic message — it must not reveal whether
+	// the account is locked or the IP is rate-limited.
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+	msg := errMsg(got)
+	if msg == "" {
+		t.Error("429 response has no error.message field")
+	}
+	// The message must not mention "lock", "block", or reveal account state.
+	for _, forbidden := range []string{"lock", "block", "account", "email"} {
+		if containsFold(msg, forbidden) {
+			t.Errorf("429 message %q must not mention %q (information leak)", msg, forbidden)
+		}
+	}
+}
+
+// TestLoginThrottle_CorrectPasswordAlsoThrottled verifies that after lockout is
+// active, even the correct password returns 429 (throttle check happens before
+// credential verification).
+func TestLoginThrottle_CorrectPasswordAlsoThrottled(t *testing.T) {
+	t.Parallel()
+
+	const (
+		email    = "throttle-correct@example.com"
+		password = "correcthorse2"
+	)
+
+	dsn := "file:TestLoginThrottle_CorrectPwd?mode=memory&cache=private"
+	app, database, _ := setupTestAppWithThrottle(t, dsn)
+
+	org := mustCreateOrg(t, database, "Throttle Org 2", "throttle-correct-org")
+	user := mustCreateUserWithPassword(t, database, email, "Throttle User 2", password)
+	mustCreateOrgMembership(t, database, org.ID, user.ID, auth.RoleOrgAdmin)
+
+	// Trigger lockout with five wrong-password attempts.
+	for i := 0; i < 5; i++ {
+		doLoginRequest(t, app, email, "wrong")
+	}
+
+	// Now use the CORRECT password — must still receive 429.
+	status := doLoginRequest(t, app, email, password)
+	if status != fiber.StatusTooManyRequests {
+		t.Errorf("correct-password attempt after lockout: status = %d, want 429", status)
+	}
+}
+
+// TestLoginThrottle_SuccessResetsCounter verifies that a successful login resets
+// the failure counter so that four subsequent failures do not re-trigger lockout.
+func TestLoginThrottle_SuccessResetsCounter(t *testing.T) {
+	t.Parallel()
+
+	const (
+		email    = "throttle-reset@example.com"
+		password = "correcthorse3"
+	)
+
+	dsn := "file:TestLoginThrottle_Reset?mode=memory&cache=private"
+	app, database, _ := setupTestAppWithThrottle(t, dsn)
+
+	org := mustCreateOrg(t, database, "Throttle Org 3", "throttle-reset-org")
+	user := mustCreateUserWithPassword(t, database, email, "Throttle User 3", password)
+	mustCreateOrgMembership(t, database, org.ID, user.ID, auth.RoleOrgAdmin)
+
+	// Four wrong attempts — one below the lockout threshold.
+	for i := 0; i < 4; i++ {
+		status := doLoginRequest(t, app, email, "wrong")
+		if status != fiber.StatusUnauthorized {
+			t.Fatalf("wrong attempt %d: status = %d, want 401", i+1, status)
+		}
+	}
+
+	// One correct login — must succeed and reset the failure counter.
+	status := doLoginRequest(t, app, email, password)
+	if status != fiber.StatusOK {
+		t.Fatalf("correct login: status = %d, want 200", status)
+	}
+
+	// Four more wrong attempts after the reset — must still return 401, not 429.
+	for i := 0; i < 4; i++ {
+		status := doLoginRequest(t, app, email, "wrong")
+		if status != fiber.StatusUnauthorized {
+			t.Fatalf("post-reset wrong attempt %d: status = %d, want 401 (counter should be reset)", i+1, status)
+		}
+	}
+}
+
+// TestLoginThrottle_NilThrottleExistingTestsUnchanged verifies that the default
+// setupTestApp (no throttle attached) still passes the original login cases.
+// This ensures nil-throttle is a clean no-op and does not alter existing tests.
+func TestLoginThrottle_NilThrottleExistingTestsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		email      string
+		password   string
+		setup      func(t *testing.T, database *db.DB, org *db.Org)
+		wantStatus int
+	}{
+		{
+			name:     "correct credentials returns 200 without throttle",
+			email:    "nil-throttle-ok@example.com",
+			password: "pass1",
+			setup: func(t *testing.T, database *db.DB, org *db.Org) {
+				t.Helper()
+				user := mustCreateUserWithPassword(t, database, "nil-throttle-ok@example.com", "User", "pass1")
+				mustCreateOrgMembership(t, database, org.ID, user.ID, auth.RoleOrgAdmin)
+			},
+			wantStatus: fiber.StatusOK,
+		},
+		{
+			name:     "wrong password returns 401 without throttle",
+			email:    "nil-throttle-wp@example.com",
+			password: "wrongpass",
+			setup: func(t *testing.T, database *db.DB, org *db.Org) {
+				t.Helper()
+				user := mustCreateUserWithPassword(t, database, "nil-throttle-wp@example.com", "User WP", "correctpass")
+				mustCreateOrgMembership(t, database, org.ID, user.ID, auth.RoleOrgAdmin)
+			},
+			wantStatus: fiber.StatusUnauthorized,
+		},
+		{
+			name:       "unknown email returns 401 without throttle",
+			email:      "nobody-nil@example.com",
+			password:   "anything",
+			setup:      func(t *testing.T, database *db.DB, org *db.Org) {},
+			wantStatus: fiber.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dsn := fmt.Sprintf("file:TestLoginThrottle_Nil_%s?mode=memory&cache=private",
+				slugFor(tc.name))
+			// Use the standard setup WITHOUT a throttle — tests nil-throttle no-op.
+			app, database, _ := setupTestApp(t, dsn)
+			org := mustCreateOrg(t, database, "Nil Throttle Org", "nil-throttle-org-"+slugFor(tc.name))
+			tc.setup(t, database, org)
+
+			status := doLoginRequest(t, app, tc.email, tc.password)
+			if status != tc.wantStatus {
+				t.Errorf("status = %d, want %d", status, tc.wantStatus)
+			}
+		})
+	}
+}
+
+// containsFold reports whether s contains substr, case-insensitively.
+func containsFold(s, substr string) bool {
+	return len(s) >= len(substr) &&
+		func() bool {
+			sl := len(substr)
+			for i := 0; i <= len(s)-sl; i++ {
+				if equalFold(s[i:i+sl], substr) {
+					return true
+				}
+			}
+			return false
+		}()
+}
+
+// equalFold is a simple ASCII-only case-insensitive equality check sufficient
+// for the small set of forbidden words used in tests.
+func equalFold(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		ca, cb := a[i], b[i]
+		if ca >= 'A' && ca <= 'Z' {
+			ca += 'a' - 'A'
+		}
+		if cb >= 'A' && cb <= 'Z' {
+			cb += 'a' - 'A'
+		}
+		if ca != cb {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/api/admin/handler.go
+++ b/internal/api/admin/handler.go
@@ -95,6 +95,9 @@ type Handler struct {
 	// app.cleanup can drain and close the pool on graceful shutdown.
 	// Nil when Code Mode is disabled.
 	CodePool *mcp.RuntimePool
+	// LoginThrottle enforces per-IP and per-account brute-force protection on
+	// the login endpoint. Nil disables throttling (test environments only).
+	LoginThrottle *auth.LoginThrottle
 	// UpdateChecker provides cached update status read from the settings table.
 	// Nil in dev builds (Version == "dev") — GetUpdateStatus returns a static
 	// response in that case.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -77,6 +77,7 @@ type Application struct {
 
 	rateLimiter      ratelimit.Checker
 	tokenCounter     *ratelimit.TokenCounter
+	loginThrottle    *auth.LoginThrottle
 	usageLogger      *usage.Logger
 	mcpLogger        *usage.MCPLogger
 	auditLogger      *audit.Logger
@@ -669,6 +670,8 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 	proxyHandler.MaxStreamDuration = cfg.Server.Proxy.MaxStreamDuration
 	proxyHandler.FallbackMaxDepth = cfg.Settings.FallbackMaxDepth
 
+	loginThrottle := auth.NewLoginThrottle()
+
 	adminHandler := &admin.Handler{
 		DB:                database,
 		HMACSecret:        hmacSecret,
@@ -686,6 +689,7 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 		Log:               log,
 		SSOProvider:       ssoProvider,
 		SSOConfig:         cfg.Settings.SSO,
+		LoginThrottle:     loginThrottle,
 	}
 	// Wire the in-process reload callback so SetLicense can re-gate the
 	// model registry immediately after storing a new license, even on
@@ -1062,6 +1066,7 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 		mcpTransportCache: mcpTransportCache,
 		rateLimiter:       rateLimiter,
 		tokenCounter:      tokenCounter,
+		loginThrottle:     loginThrottle,
 		usageLogger:       usageLogger,
 		mcpLogger:         mcpLogger,
 		auditLogger:       auditLogger,
@@ -1114,6 +1119,7 @@ func (a *Application) Start() error {
 		}),
 		startTicker(5*time.Minute, func() {
 			a.tokenCounter.EvictStale()
+			a.loginThrottle.EvictStale()
 		}),
 		startTicker(30*time.Second, func() {
 			metrics.CacheSize.WithLabelValues("keys").Set(float64(a.keyCache.Len()))

--- a/internal/auth/login_throttle.go
+++ b/internal/auth/login_throttle.go
@@ -1,0 +1,220 @@
+package auth
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ErrTooManyAttempts is returned by LoginThrottle.Allow when a request is
+// blocked by either the per-IP rate limit or the per-account lockout.
+var ErrTooManyAttempts = errors.New("too many login attempts")
+
+// Package-level constants govern the throttle behaviour. They are intentionally
+// not configurable so that operators cannot accidentally weaken brute-force
+// protection.
+const (
+	// loginMaxAttemptsPerIPPerMinute is the maximum number of login attempts
+	// allowed from a single client IP within a one-minute fixed window.
+	loginMaxAttemptsPerIPPerMinute = 10
+
+	// loginLockoutThreshold is the number of consecutive failed attempts for a
+	// single email address that triggers a lockout.
+	loginLockoutThreshold = 5
+
+	// loginLockoutDuration is how long an email address remains locked out after
+	// reaching loginLockoutThreshold consecutive failures.
+	loginLockoutDuration = 15 * time.Minute
+
+	// loginAccountIdleEviction is the minimum time since the last recorded
+	// failure before an account entry without an active lockout is removed by
+	// EvictStale. Must be >= loginLockoutDuration so that entries whose lockout
+	// window has not yet expired are never evicted prematurely.
+	loginAccountIdleEviction = 30 * time.Minute
+)
+
+// ipEntry tracks login attempts from a single client IP within a fixed
+// one-minute window.
+type ipEntry struct {
+	mu          sync.Mutex
+	count       int
+	windowStart time.Time
+}
+
+// accountEntry tracks consecutive failures for a single email address and the
+// time at which a lockout (if any) expires.
+type accountEntry struct {
+	mu          sync.Mutex
+	failures    int
+	lockedUntil time.Time
+	lastFailure time.Time // zero if no failure has ever been recorded
+}
+
+// LoginThrottle protects the login endpoint against brute-force attacks using
+// two in-memory mechanisms: a per-IP attempt limit and a per-account lockout
+// after consecutive failures. Safe for concurrent use.
+type LoginThrottle struct {
+	ipCounters sync.Map // normalised IP string → *ipEntry
+	accounts   sync.Map // normalised email string → *accountEntry
+	// now returns the current time. Defaults to time.Now; overridden in tests.
+	now func() time.Time
+}
+
+// NewLoginThrottle constructs a LoginThrottle ready for use.
+func NewLoginThrottle() *LoginThrottle {
+	return &LoginThrottle{now: time.Now}
+}
+
+// Allow checks whether a login attempt from ip for email should be permitted.
+// It must be called before credential verification. Every call — whether the
+// credentials turn out to be valid or not — counts toward the per-IP limit.
+//
+// Returns ErrTooManyAttempts if the IP has exceeded its per-minute budget or if
+// the account is currently locked out. The returned error never reveals whether
+// the IP limit or the account lockout triggered the rejection.
+func (t *LoginThrottle) Allow(ip, email string) error {
+	now := t.now()
+	email = normaliseEmail(email)
+
+	// Per-IP check: increment attempt counter for this IP in the current window.
+	// Aborted attempts (bad JSON body, missing fields) are counted by the caller
+	// if Allow is invoked; callers may choose not to invoke Allow for those cases
+	// to keep the early-return path cheap, but the Login handler calls Allow
+	// after validating required fields.
+	ipE := t.loadOrCreateIP(ip)
+	ipE.mu.Lock()
+	windowStart := now.Truncate(time.Minute)
+	if ipE.windowStart != windowStart {
+		// New minute window — reset.
+		ipE.windowStart = windowStart
+		ipE.count = 0
+	}
+	ipE.count++
+	ipOver := ipE.count > loginMaxAttemptsPerIPPerMinute
+	ipE.mu.Unlock()
+
+	if ipOver {
+		return ErrTooManyAttempts
+	}
+
+	// Per-account check: is the account currently locked out?
+	if email == "" {
+		return nil
+	}
+	accE := t.loadOrCreateAccount(email)
+	accE.mu.Lock()
+	locked := !accE.lockedUntil.IsZero() && now.Before(accE.lockedUntil)
+	// Lazy eviction: clear expired lockout so memory is reclaimed over time.
+	if !accE.lockedUntil.IsZero() && !locked {
+		accE.lockedUntil = time.Time{}
+		accE.failures = 0
+	}
+	accE.mu.Unlock()
+
+	if locked {
+		return ErrTooManyAttempts
+	}
+	return nil
+}
+
+// RecordFailure increments the consecutive-failure counter for email. If the
+// counter reaches loginLockoutThreshold the account is locked out for
+// loginLockoutDuration. Unknown email addresses are tracked the same way as
+// known ones to prevent probing via observable timing differences.
+func (t *LoginThrottle) RecordFailure(email string) {
+	email = normaliseEmail(email)
+	if email == "" {
+		return
+	}
+	accE := t.loadOrCreateAccount(email)
+	accE.mu.Lock()
+	defer accE.mu.Unlock()
+
+	now := t.now()
+	accE.failures++
+	accE.lastFailure = now
+	if accE.failures >= loginLockoutThreshold {
+		accE.lockedUntil = now.Add(loginLockoutDuration)
+	}
+}
+
+// RecordSuccess resets the consecutive-failure counter for email after a
+// successful authentication. This ensures that a legitimately authenticated
+// user is not locked out by prior failed attempts.
+func (t *LoginThrottle) RecordSuccess(email string) {
+	email = normaliseEmail(email)
+	if email == "" {
+		return
+	}
+	accE := t.loadOrCreateAccount(email)
+	accE.mu.Lock()
+	defer accE.mu.Unlock()
+
+	accE.failures = 0
+	accE.lockedUntil = time.Time{}
+}
+
+// EvictStale removes IP window entries whose minute window has expired and
+// account entries that are neither locked nor have any recorded failures. It
+// should be called periodically (e.g. every 5 minutes via the application
+// ticker) to bound memory usage. Entries that are currently being mutated by
+// concurrent Allow / RecordFailure calls are not removed.
+func (t *LoginThrottle) EvictStale() {
+	now := t.now()
+	currentWindow := now.Truncate(time.Minute)
+
+	t.ipCounters.Range(func(key, value any) bool {
+		e := value.(*ipEntry)
+		e.mu.Lock()
+		stale := e.windowStart.Before(currentWindow)
+		e.mu.Unlock()
+		if stale {
+			t.ipCounters.Delete(key)
+		}
+		return true
+	})
+
+	t.accounts.Range(func(key, value any) bool {
+		e := value.(*accountEntry)
+		e.mu.Lock()
+		noLock := e.lockedUntil.IsZero() || now.After(e.lockedUntil)
+		noFails := e.failures == 0
+		// Also evict entries that have partial failures but no active lockout and
+		// whose last failure is older than loginAccountIdleEviction. Without this,
+		// accounts with 1–4 failures from random probes accumulate indefinitely.
+		idle := !e.lastFailure.IsZero() && now.Sub(e.lastFailure) > loginAccountIdleEviction
+		e.mu.Unlock()
+		if noLock && (noFails || idle) {
+			t.accounts.Delete(key)
+		}
+		return true
+	})
+}
+
+// loadOrCreateIP retrieves the ipEntry for ip, creating one if absent.
+func (t *LoginThrottle) loadOrCreateIP(ip string) *ipEntry {
+	if v, ok := t.ipCounters.Load(ip); ok {
+		return v.(*ipEntry)
+	}
+	e := &ipEntry{}
+	actual, _ := t.ipCounters.LoadOrStore(ip, e)
+	return actual.(*ipEntry)
+}
+
+// loadOrCreateAccount retrieves the accountEntry for email, creating one if absent.
+func (t *LoginThrottle) loadOrCreateAccount(email string) *accountEntry {
+	if v, ok := t.accounts.Load(email); ok {
+		return v.(*accountEntry)
+	}
+	e := &accountEntry{}
+	actual, _ := t.accounts.LoadOrStore(email, e)
+	return actual.(*accountEntry)
+}
+
+// normaliseEmail returns the email in lowercase with surrounding whitespace
+// removed. This ensures that "User@Example.com" and "user@example.com" map to
+// the same throttle bucket.
+func normaliseEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}

--- a/internal/auth/login_throttle_test.go
+++ b/internal/auth/login_throttle_test.go
@@ -1,0 +1,315 @@
+package auth
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// newThrottleWithClock returns a LoginThrottle whose clock is controlled by the
+// supplied pointer. Tests advance *cur to simulate the passage of time without
+// real sleeps.
+func newThrottleWithClock(cur *time.Time) *LoginThrottle {
+	return &LoginThrottle{
+		now: func() time.Time { return *cur },
+	}
+}
+
+// mustAllow calls t.Allow and fails the test if it returns an error.
+func mustAllow(t *testing.T, th *LoginThrottle, ip, email string) {
+	t.Helper()
+	if err := th.Allow(ip, email); err != nil {
+		t.Fatalf("Allow(%q, %q) unexpected error: %v", ip, email, err)
+	}
+}
+
+// TestIPLimit verifies that the 10th attempt from a single IP succeeds and the
+// 11th returns ErrTooManyAttempts. A different IP is unaffected.
+func TestIPLimit(t *testing.T) {
+	t.Parallel()
+
+	cur := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	th := newThrottleWithClock(&cur)
+
+	// Attempts 1–10: all must succeed.
+	for i := 0; i < loginMaxAttemptsPerIPPerMinute; i++ {
+		if err := th.Allow("1.2.3.4", "user@example.com"); err != nil {
+			t.Fatalf("attempt %d: unexpected error: %v", i+1, err)
+		}
+	}
+
+	// Attempt 11: must be blocked.
+	err := th.Allow("1.2.3.4", "user@example.com")
+	if !errors.Is(err, ErrTooManyAttempts) {
+		t.Errorf("attempt 11: got %v, want ErrTooManyAttempts", err)
+	}
+
+	// A different IP must still be allowed.
+	if err := th.Allow("9.9.9.9", "user@example.com"); err != nil {
+		t.Errorf("different IP unexpectedly blocked: %v", err)
+	}
+}
+
+// TestIPWindowRollover verifies that advancing the clock into a new minute
+// resets the per-IP counter and allows requests again.
+func TestIPWindowRollover(t *testing.T) {
+	t.Parallel()
+
+	cur := time.Date(2024, 1, 1, 12, 0, 30, 0, time.UTC) // 12:00:30
+	th := newThrottleWithClock(&cur)
+
+	// Exhaust the limit within the current minute window.
+	for i := 0; i < loginMaxAttemptsPerIPPerMinute; i++ {
+		mustAllow(t, th, "2.2.2.2", "a@example.com")
+	}
+	if err := th.Allow("2.2.2.2", "a@example.com"); !errors.Is(err, ErrTooManyAttempts) {
+		t.Fatalf("expected block before rollover, got: %v", err)
+	}
+
+	// Advance clock into the next minute.
+	cur = cur.Add(31 * time.Second) // now 12:01:01
+
+	// The counter should have reset — first attempt in new window must succeed.
+	if err := th.Allow("2.2.2.2", "a@example.com"); err != nil {
+		t.Errorf("after window rollover: unexpected error: %v", err)
+	}
+}
+
+// TestAccountLockout verifies that 5 consecutive RecordFailure calls lock the
+// account and Allow returns ErrTooManyAttempts for that email.
+// A different email must remain unaffected.
+func TestAccountLockout(t *testing.T) {
+	t.Parallel()
+
+	cur := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	th := newThrottleWithClock(&cur)
+
+	// Four failures must not yet lock the account.
+	for i := 0; i < loginLockoutThreshold-1; i++ {
+		th.RecordFailure("locked@example.com")
+		if err := th.Allow("3.3.3.3", "locked@example.com"); err != nil {
+			t.Fatalf("after %d failures: unexpected block: %v", i+1, err)
+		}
+	}
+
+	// Fifth failure triggers lockout.
+	th.RecordFailure("locked@example.com")
+	err := th.Allow("3.3.3.3", "locked@example.com")
+	if !errors.Is(err, ErrTooManyAttempts) {
+		t.Errorf("after %d failures: got %v, want ErrTooManyAttempts", loginLockoutThreshold, err)
+	}
+
+	// A different email must still pass.
+	if err := th.Allow("3.3.3.3", "other@example.com"); err != nil {
+		t.Errorf("other email unexpectedly blocked: %v", err)
+	}
+}
+
+// TestLockoutExpiry verifies that advancing the clock past loginLockoutDuration
+// allows the account again and resets its failure counter via lazy eviction.
+func TestLockoutExpiry(t *testing.T) {
+	t.Parallel()
+
+	cur := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	th := newThrottleWithClock(&cur)
+
+	// Trigger lockout.
+	for i := 0; i < loginLockoutThreshold; i++ {
+		th.RecordFailure("expiry@example.com")
+	}
+	if err := th.Allow("4.4.4.4", "expiry@example.com"); !errors.Is(err, ErrTooManyAttempts) {
+		t.Fatalf("expected lockout immediately after threshold, got: %v", err)
+	}
+
+	// Advance clock to just before expiry — still blocked.
+	cur = cur.Add(loginLockoutDuration - time.Second)
+	if err := th.Allow("4.4.4.4", "expiry@example.com"); !errors.Is(err, ErrTooManyAttempts) {
+		t.Fatalf("expected lockout 1s before expiry, got: %v", err)
+	}
+
+	// Advance clock past expiry — must be allowed again.
+	cur = cur.Add(2 * time.Second) // 1 second after lockout expires
+	if err := th.Allow("4.4.4.4", "expiry@example.com"); err != nil {
+		t.Errorf("after lockout expiry: unexpected error: %v", err)
+	}
+
+	// Failure counter must have been reset by lazy eviction inside Allow.
+	// Confirm by inducing only (threshold-1) new failures — must not re-lock.
+	for i := 0; i < loginLockoutThreshold-1; i++ {
+		th.RecordFailure("expiry@example.com")
+	}
+	if err := th.Allow("4.4.4.4", "expiry@example.com"); err != nil {
+		t.Errorf("after expiry + %d new failures: unexpected block: %v", loginLockoutThreshold-1, err)
+	}
+}
+
+// TestRecordSuccessResetsFails verifies that a successful login clears the
+// failure counter so that subsequent failures start fresh.
+func TestRecordSuccessResetsFails(t *testing.T) {
+	t.Parallel()
+
+	cur := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	th := newThrottleWithClock(&cur)
+
+	// Four failures — one short of lockout threshold (5).
+	for i := 0; i < loginLockoutThreshold-1; i++ {
+		th.RecordFailure("reset@example.com")
+	}
+
+	// Successful login resets the counter to zero.
+	th.RecordSuccess("reset@example.com")
+
+	// Four more failures after the reset — counter is at 4, below threshold.
+	for i := 0; i < loginLockoutThreshold-1; i++ {
+		th.RecordFailure("reset@example.com")
+	}
+	if err := th.Allow("5.5.5.5", "reset@example.com"); err != nil {
+		t.Errorf("after success + %d new failures: unexpected block: %v", loginLockoutThreshold-1, err)
+	}
+
+	// The 5th failure post-reset reaches the threshold and triggers lockout.
+	th.RecordFailure("reset@example.com")
+	if err := th.Allow("5.5.5.5", "reset@example.com"); !errors.Is(err, ErrTooManyAttempts) {
+		t.Errorf("after threshold failures post-reset: expected ErrTooManyAttempts, got: %v", err)
+	}
+}
+
+// TestEmailNormalisation verifies that "User@Example.COM " and
+// "user@example.com" resolve to the same throttle bucket.
+func TestEmailNormalisation(t *testing.T) {
+	t.Parallel()
+
+	cur := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	th := newThrottleWithClock(&cur)
+
+	// Record failures using the mixed-case + padded form.
+	for i := 0; i < loginLockoutThreshold; i++ {
+		th.RecordFailure("User@Example.COM ")
+	}
+
+	// Allow must see the lockout when queried with the canonical form.
+	err := th.Allow("6.6.6.6", "user@example.com")
+	if !errors.Is(err, ErrTooManyAttempts) {
+		t.Errorf("canonical form not blocked after failures recorded via mixed-case: %v", err)
+	}
+
+	// Also confirm the reverse: failures recorded via canonical form block the
+	// padded / mixed-case variant.
+	cur2 := time.Date(2024, 1, 1, 13, 0, 0, 0, time.UTC)
+	th2 := newThrottleWithClock(&cur2)
+	for i := 0; i < loginLockoutThreshold; i++ {
+		th2.RecordFailure("user@example.com")
+	}
+	err2 := th2.Allow("6.6.6.6", "User@Example.COM ")
+	if !errors.Is(err2, ErrTooManyAttempts) {
+		t.Errorf("padded/mixed form not blocked after failures recorded via canonical: %v", err2)
+	}
+}
+
+// TestEvictStale verifies that EvictStale removes expired IP windows and idle
+// account entries from the internal sync.Maps.
+// This test is in the same package to access ipCounters and accounts directly.
+func TestEvictStale(t *testing.T) {
+	t.Parallel()
+
+	cur := time.Date(2024, 1, 1, 12, 0, 30, 0, time.UTC)
+	th := newThrottleWithClock(&cur)
+
+	// Create an IP entry by making a request.
+	mustAllow(t, th, "7.7.7.7", "evict@example.com")
+	// Create an account entry by recording a failure then clearing it.
+	th.RecordFailure("evict@example.com")
+	th.RecordSuccess("evict@example.com") // failures=0, lockedUntil=zero
+
+	// Verify both entries exist before eviction.
+	if _, ok := th.ipCounters.Load("7.7.7.7"); !ok {
+		t.Fatal("IP entry not present before EvictStale")
+	}
+	if _, ok := th.accounts.Load("evict@example.com"); !ok {
+		t.Fatal("account entry not present before EvictStale")
+	}
+
+	// Advance clock into a new minute so the IP window is stale.
+	cur = cur.Add(31 * time.Second) // 12:01:01 — window 12:00 is now stale
+
+	th.EvictStale()
+
+	// IP entry must be gone.
+	if _, ok := th.ipCounters.Load("7.7.7.7"); ok {
+		t.Error("stale IP entry still present after EvictStale")
+	}
+	// Account entry with zero failures and no lockout must be gone.
+	if _, ok := th.accounts.Load("evict@example.com"); ok {
+		t.Error("idle account entry still present after EvictStale")
+	}
+
+	// Active lockout entries must NOT be evicted.
+	for i := 0; i < loginLockoutThreshold; i++ {
+		th.RecordFailure("active@example.com")
+	}
+	th.EvictStale()
+	if _, ok := th.accounts.Load("active@example.com"); !ok {
+		t.Error("active locked account was incorrectly evicted by EvictStale")
+	}
+
+	// Partial failures (1–4) with an old lastFailure must be evicted.
+	th.RecordFailure("partial@example.com") // failures=1, no lockout
+	// Advance clock beyond loginAccountIdleEviction.
+	cur = cur.Add(loginAccountIdleEviction + time.Second)
+	th.EvictStale()
+	if _, ok := th.accounts.Load("partial@example.com"); ok {
+		t.Error("partial-failure account with stale lastFailure was not evicted by EvictStale")
+	}
+
+	// Partial failures with a recent lastFailure must NOT be evicted.
+	th.RecordFailure("recent@example.com") // failures=1, lastFailure=now (cur after advance)
+	// EvictStale immediately — lastFailure is fresh, so must stay.
+	th.EvictStale()
+	if _, ok := th.accounts.Load("recent@example.com"); !ok {
+		t.Error("recent partial-failure account was incorrectly evicted by EvictStale")
+	}
+}
+
+// TestConcurrencySmoke fires many concurrent Allow calls from multiple
+// goroutines and verifies there are no data races (run with -race).
+func TestConcurrencySmoke(t *testing.T) {
+	t.Parallel()
+
+	cur := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	th := newThrottleWithClock(&cur)
+
+	const goroutines = 50
+	const callsEach = 40
+
+	var wg sync.WaitGroup
+	var allowed, blocked atomic.Int64
+
+	for g := 0; g < goroutines; g++ {
+		g := g
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ip := "10.0.0." + string(rune('A'+g%26))
+			for i := 0; i < callsEach; i++ {
+				if err := th.Allow(ip, "smoke@example.com"); err == nil {
+					allowed.Add(1)
+				} else {
+					blocked.Add(1)
+				}
+				th.RecordFailure("smoke@example.com")
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Sanity check: some requests must have been allowed, some blocked.
+	if allowed.Load() == 0 {
+		t.Error("no requests were allowed — throttle may be broken")
+	}
+	if blocked.Load() == 0 {
+		t.Error("no requests were blocked — throttle may not be working")
+	}
+}


### PR DESCRIPTION
## Problem

`POST /api/v1/auth/login` had no rate limiting and no account lockout. bcrypt slows a single attempt, but a wordlist attack against a known account was practical.

## Fix

New `LoginThrottle` (in-memory, `internal/auth/login_throttle.go`) with two mechanisms:

- **Per-IP limit:** 10 attempts per minute per client IP (every attempt counts, success or failure).
- **Per-account lockout:** 15 minutes after 5 consecutive failures for the same (normalised) email. A successful login resets the counter.

Integration in the login handler:
- `Allow()` is checked **before** the bcrypt comparison.
- On lockout, the handler still runs a bcrypt dummy comparison before returning **429**, so response timing does not reveal whether an account is locked.
- The 429 message is generic (`too many login attempts, try again later`) - it does not disclose whether the IP limit or the account lockout fired, nor whether the account exists.
- The existing dummy-hash timing protection against user enumeration is preserved.

## Memory bounds

Eviction is hooked into the existing 5-minute ticker (no new goroutine). It drops expired IP windows and idle account entries (no active lockout, last failure older than 30 minutes), so spraying random emails cannot grow the maps unbounded.

## Known tradeoffs (accepted for this iteration)

- **Account-lockout DoS:** an attacker can lock a known account for 15 min with 5 failed attempts - the standard tradeoff of account lockout. State is per-process, so a restart clears it.
- **TOCTOU under concurrency:** a few attempts may exceed the threshold under heavy parallel load; bounded in practice by the per-IP limit and bcrypt cost.
- **Reverse-proxy deployments:** `c.IP()` uses the TCP peer IP (no `X-Forwarded-For` trust configured), so behind a proxy without `trusted_proxies` set, all clients share one IP bucket. This is a pre-existing, deployment-wide concern (also affects audit logs) and should be documented in the deployment guide.
- **In-memory / single-instance:** consistent with the documented single-instance constraint; distributed throttling will come with Redis.

## Tests

- 8 unit tests (IP limit, window rollover, lockout set/expiry, success reset, email normalisation, idle eviction, concurrency smoke) using an injected clock.
- 4 handler integration tests (lockout after 5 failures, correct password still throttled while locked, success resets, nil-throttle no-op).
- `go test -race ./internal/auth/ ./internal/api/...` clean.