### PR TITLE
fix: profile password change now works and is verified (#99)

### DIFF
--- a/internal/api/admin/auth.go
+++ b/internal/api/admin/auth.go
@@ -253,6 +253,146 @@ func (h *Handler) AvailableModels(c fiber.Ctx) error {
 	return c.JSON(availableModelsResponse{Models: models})
 }
 
+// changeOwnPasswordRequest is the JSON body for POST /api/v1/me/password.
+type changeOwnPasswordRequest struct {
+	CurrentPassword string `json:"current_password"`
+	NewPassword     string `json:"new_password"`
+}
+
+// ChangeOwnPassword handles POST /api/v1/me/password. It verifies the caller's
+// current password, then replaces it with the new one and invalidates all other
+// active sessions for the user. The current session remains valid.
+// Only local (non-SSO) accounts may use this endpoint.
+//
+// @Summary      Change own password
+// @Description  Verifies the current password and sets a new one. Revokes all other active sessions. Requires a user-scoped session key.
+// @Tags         auth
+// @Accept       json
+// @Produce      json
+// @Param        body  body      changeOwnPasswordRequest  true  "Password change request"
+// @Success      200   "OK"
+// @Failure      400   {object}  swaggerErrorResponse
+// @Failure      401   {object}  swaggerErrorResponse
+// @Failure      500   {object}  swaggerErrorResponse
+// @Security     BearerAuth
+// @Router       /me/password [post]
+func (h *Handler) ChangeOwnPassword(c fiber.Ctx) error {
+	keyInfo := auth.KeyInfoFromCtx(c)
+	if keyInfo == nil {
+		return apierror.Send(c, fiber.StatusUnauthorized, "unauthorized", "missing authentication")
+	}
+	if keyInfo.UserID == "" {
+		return apierror.Send(c, fiber.StatusBadRequest, "bad_request", "this endpoint requires a user-scoped key")
+	}
+
+	var req changeOwnPasswordRequest
+	if err := c.Bind().JSON(&req); err != nil {
+		return apierror.BadRequest(c, "invalid request body")
+	}
+	if req.CurrentPassword == "" {
+		return apierror.BadRequest(c, "current_password is required")
+	}
+	if len(req.NewPassword) < 8 {
+		return apierror.BadRequest(c, "new_password must be at least 8 characters")
+	}
+	if len(req.NewPassword) > 128 {
+		return apierror.BadRequest(c, "new_password must be at most 128 characters")
+	}
+
+	ctx := c.Context()
+
+	authProvider, currentHash, err := h.DB.GetUserPasswordHashByID(ctx, keyInfo.UserID)
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return apierror.Send(c, fiber.StatusUnauthorized, "unauthorized", "user not found")
+		}
+		if errors.Is(err, db.ErrNoPassword) {
+			// Burn bcrypt time to prevent timing-based account-type enumeration.
+			// The error from CompareHashAndPassword is intentionally ignored here.
+			_ = bcrypt.CompareHashAndPassword(dummyHash, []byte(req.CurrentPassword))
+			return apierror.BadRequest(c, "password change not available for this account")
+		}
+		h.Log.ErrorContext(ctx, "change own password: get password hash", slog.String("error", err.Error()))
+		return apierror.InternalError(c, "failed to verify current password")
+	}
+
+	// SSO accounts never have a local password even if auth_provider is set.
+	// The ErrNoPassword sentinel above covers the NULL hash case; this guard
+	// catches rows where auth_provider is set to a non-local value but the hash
+	// column is somehow populated — defensive, belt-and-suspenders.
+	if authProvider != "local" {
+		// Burn bcrypt time to prevent timing-based account-type enumeration.
+		// The error from CompareHashAndPassword is intentionally ignored here.
+		_ = bcrypt.CompareHashAndPassword(dummyHash, []byte(req.CurrentPassword))
+		return apierror.BadRequest(c, "password change not available for this account")
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(currentHash), []byte(req.CurrentPassword)); err != nil {
+		return apierror.Send(c, fiber.StatusBadRequest, "bad_request", "current password is incorrect")
+	}
+
+	newHash, err := bcrypt.GenerateFromPassword([]byte(req.NewPassword), bcrypt.DefaultCost)
+	if err != nil {
+		h.Log.ErrorContext(ctx, "change own password: bcrypt", slog.String("error", err.Error()))
+		return apierror.InternalError(c, "failed to hash new password")
+	}
+	newHashStr := string(newHash)
+
+	if _, err := h.DB.UpdateUser(ctx, keyInfo.UserID, db.UpdateUserParams{
+		PasswordHash: &newHashStr,
+	}); err != nil {
+		if errors.Is(err, db.ErrNotFound) {
+			return apierror.Send(c, fiber.StatusUnauthorized, "unauthorized", "user not found")
+		}
+		h.Log.ErrorContext(ctx, "change own password: update user", slog.String("error", err.Error()))
+		return apierror.InternalError(c, "failed to update password")
+	}
+
+	// Revoke all other session keys for this user from the database, keeping the
+	// current session alive. Using RevokeUserSessionsExcept rather than
+	// RevokeUserSessions prevents the current session row from being deleted,
+	// which would cause a silent logout on the next periodic cache refresh.
+	if err := h.DB.RevokeUserSessionsExcept(ctx, keyInfo.UserID, keyInfo.ID); err != nil {
+		// Non-fatal: the password has already been changed; log and continue.
+		h.Log.ErrorContext(ctx, "change own password: revoke sessions", slog.String("error", err.Error()))
+	}
+
+	// Evict all other session entries for this user from the in-memory key cache
+	// so that revoked sessions are rejected immediately without waiting for the
+	// next periodic cache refresh.
+	// Collect hashes first — Range holds a read lock, so Delete (write lock)
+	// must not be called inside the Range closure.
+	var toEvict []string
+	currentKeyID := keyInfo.ID
+	h.KeyCache.Range(func(keyHash string, ki auth.KeyInfo) bool {
+		if ki.UserID == keyInfo.UserID && ki.ID != currentKeyID {
+			toEvict = append(toEvict, keyHash)
+		}
+		return true
+	})
+	for _, keyHash := range toEvict {
+		h.KeyCache.Delete(keyHash)
+	}
+
+	if h.AuditLogger != nil {
+		h.AuditLogger.Log(audit.Event{
+			Timestamp:    time.Now().UTC(),
+			OrgID:        keyInfo.OrgID,
+			ActorID:      keyInfo.UserID,
+			ActorType:    "user",
+			ActorKeyID:   keyInfo.ID,
+			Action:       "password_change",
+			ResourceType: "user",
+			ResourceID:   keyInfo.UserID,
+			IPAddress:    c.IP(),
+			StatusCode:   fiber.StatusOK,
+			RequestID:    apierror.RequestIDFromCtx(c),
+		})
+	}
+
+	return c.SendStatus(fiber.StatusOK)
+}
+
 // Me returns the authenticated user's profile.
 //
 // @Summary      Get authenticated user profile

--- a/internal/api/admin/auth.go
+++ b/internal/api/admin/auth.go
@@ -295,8 +295,8 @@ func (h *Handler) ChangeOwnPassword(c fiber.Ctx) error {
 	if len(req.NewPassword) < 8 {
 		return apierror.BadRequest(c, "new_password must be at least 8 characters")
 	}
-	if len(req.NewPassword) > 128 {
-		return apierror.BadRequest(c, "new_password must be at most 128 characters")
+	if len(req.NewPassword) > 72 {
+		return apierror.BadRequest(c, "new_password must be at most 72 bytes")
 	}
 
 	ctx := c.Context()
@@ -333,28 +333,23 @@ func (h *Handler) ChangeOwnPassword(c fiber.Ctx) error {
 
 	newHash, err := bcrypt.GenerateFromPassword([]byte(req.NewPassword), bcrypt.DefaultCost)
 	if err != nil {
+		if errors.Is(err, bcrypt.ErrPasswordTooLong) {
+			return apierror.BadRequest(c, "new_password must be at most 72 bytes")
+		}
 		h.Log.ErrorContext(ctx, "change own password: bcrypt", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "failed to hash new password")
 	}
 	newHashStr := string(newHash)
 
-	if _, err := h.DB.UpdateUser(ctx, keyInfo.UserID, db.UpdateUserParams{
-		PasswordHash: &newHashStr,
-	}); err != nil {
+	// Update the password hash and revoke all other sessions atomically.
+	// If either operation fails the transaction rolls back, leaving the DB
+	// consistent: neither the password nor the session list is partially updated.
+	if err := h.DB.ChangePasswordAndRevokeOtherSessions(ctx, keyInfo.UserID, newHashStr, keyInfo.ID); err != nil {
 		if errors.Is(err, db.ErrNotFound) {
 			return apierror.Send(c, fiber.StatusUnauthorized, "unauthorized", "user not found")
 		}
-		h.Log.ErrorContext(ctx, "change own password: update user", slog.String("error", err.Error()))
+		h.Log.ErrorContext(ctx, "change own password: update password and revoke sessions", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "failed to update password")
-	}
-
-	// Revoke all other session keys for this user from the database, keeping the
-	// current session alive. Using RevokeUserSessionsExcept rather than
-	// RevokeUserSessions prevents the current session row from being deleted,
-	// which would cause a silent logout on the next periodic cache refresh.
-	if err := h.DB.RevokeUserSessionsExcept(ctx, keyInfo.UserID, keyInfo.ID); err != nil {
-		// Non-fatal: the password has already been changed; log and continue.
-		h.Log.ErrorContext(ctx, "change own password: revoke sessions", slog.String("error", err.Error()))
 	}
 
 	// Evict all other session entries for this user from the in-memory key cache

--- a/internal/api/admin/change_password_test.go
+++ b/internal/api/admin/change_password_test.go
@@ -1,0 +1,587 @@
+package admin_test
+
+import (
+	"context"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+
+	"github.com/voidmind-io/voidllm/internal/auth"
+	"github.com/voidmind-io/voidllm/internal/cache"
+	"github.com/voidmind-io/voidllm/internal/db"
+	"github.com/voidmind-io/voidllm/pkg/keygen"
+)
+
+// doLogin performs a POST /api/v1/auth/login and returns the session token.
+// It fatals immediately if login fails or the response contains no token.
+func doLogin(t *testing.T, app *fiber.App, email, password string) string {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/v1/auth/login",
+		bodyJSON(t, map[string]any{"email": email, "password": password}))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("doLogin app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("doLogin: status = %d, want 200; body: %s", resp.StatusCode, raw)
+	}
+
+	var body map[string]any
+	decodeBody(t, resp.Body, &body)
+	token, _ := body["token"].(string)
+	if token == "" {
+		t.Fatal("doLogin: response token is empty")
+	}
+	return token
+}
+
+// doLoginStatus performs a POST /api/v1/auth/login and returns only the HTTP
+// status code. Unlike doLogin it does not fatal on a non-200 response.
+func doLoginStatus(t *testing.T, app *fiber.App, email, password string) int {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/v1/auth/login",
+		bodyJSON(t, map[string]any{"email": email, "password": password}))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("doLoginStatus app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// doChangePassword calls POST /api/v1/me/password with the given token and
+// returns (statusCode, error-message-from-body).  An empty token omits the
+// Authorization header entirely. The error message is empty on 200.
+func doChangePassword(t *testing.T, app *fiber.App, token, currentPwd, newPwd string) (int, string) {
+	t.Helper()
+	req := httptest.NewRequest("POST", "/api/v1/me/password",
+		bodyJSON(t, map[string]any{
+			"current_password": currentPwd,
+			"new_password":     newPwd,
+		}))
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("doChangePassword app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == fiber.StatusOK {
+		return fiber.StatusOK, ""
+	}
+	var body map[string]any
+	decodeBody(t, resp.Body, &body)
+	return resp.StatusCode, errMsg(body)
+}
+
+// doGet performs an authenticated GET request and returns only the status code.
+func doGet(t *testing.T, app *fiber.App, path, token string) int {
+	t.Helper()
+	req := httptest.NewRequest("GET", path, nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("doGet %s app.Test: %v", path, err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// setupLocalUser creates an org + a local user with the given password inside an
+// already-opened test app, and returns the user.
+func setupLocalUser(t *testing.T, database *db.DB, orgSlug, email, displayName, password string) *db.User {
+	t.Helper()
+	org := mustCreateOrg(t, database, displayName+" Org", orgSlug)
+	user := mustCreateUserWithPassword(t, database, email, displayName, password)
+	mustCreateOrgMembership(t, database, org.ID, user.ID, auth.RoleOrgAdmin)
+	return user
+}
+
+// injectSession creates a second independent session in the DB and the cache for
+// the given user, without going through the Login handler (which would revoke
+// existing sessions). Returns the plaintext token.
+func injectSession(
+	t *testing.T,
+	database *db.DB,
+	keyCache *cache.Cache[string, auth.KeyInfo],
+	user *db.User,
+	name string,
+) string {
+	t.Helper()
+
+	raw, err := keygen.Generate(keygen.KeyTypeSession)
+	if err != nil {
+		t.Fatalf("injectSession keygen.Generate: %v", err)
+	}
+	hash := keygen.Hash(raw, testHMACSecret)
+
+	role, orgID, err := database.ResolveUserRole(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("injectSession ResolveUserRole: %v", err)
+	}
+
+	exp := time.Now().UTC().Add(24 * time.Hour)
+	expStr := exp.Format(time.RFC3339)
+
+	apiKey, err := database.CreateAPIKey(context.Background(), db.CreateAPIKeyParams{
+		KeyHash:   hash,
+		KeyHint:   keygen.Hint(raw),
+		KeyType:   keygen.KeyTypeSession,
+		Name:      name,
+		OrgID:     orgID,
+		UserID:    &user.ID,
+		ExpiresAt: &expStr,
+		CreatedBy: user.ID,
+	})
+	if err != nil {
+		t.Fatalf("injectSession CreateAPIKey: %v", err)
+	}
+
+	keyCache.Set(hash, auth.KeyInfo{
+		ID:        apiKey.ID,
+		KeyType:   keygen.KeyTypeSession,
+		Role:      role,
+		OrgID:     orgID,
+		UserID:    user.ID,
+		Name:      name,
+		ExpiresAt: &exp,
+	})
+
+	return raw
+}
+
+// ---- POST /api/v1/me/password ------------------------------------------------
+
+// TestChangeOwnPassword_HappyPath is the direct regression test for Issue #99.
+//
+// Before the fix the handler returned 200 without writing the new bcrypt hash to
+// the database.  The old password continued to work and the new password never
+// did.  This test proves the bug is fixed: after a successful 200 response the
+// new password must work for login and the old password must not.
+func TestChangeOwnPassword_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	const (
+		oldPwd = "hunter2batteries"
+		newPwd = "correct-horse-staple"
+	)
+
+	const email = "changepwd-happy@example.com"
+	app, database, _ := setupTestApp(t, "file:TestChangePwd_Happy?mode=memory&cache=private")
+	setupLocalUser(t, database, "happy-pwdtest-org", email, "Happy User", oldPwd)
+
+	// Obtain a session and change the password.
+	token := doLogin(t, app, email, oldPwd)
+	status, msg := doChangePassword(t, app, token, oldPwd, newPwd)
+	if status != fiber.StatusOK {
+		t.Fatalf("change password: status = %d, msg: %s (Issue #99 regression)", status, msg)
+	}
+
+	// New password must now work for login — this is the core of Issue #99.
+	// Before the fix this login would fail with 401 because the hash was never updated.
+	if got := doLoginStatus(t, app, email, newPwd); got != fiber.StatusOK {
+		t.Errorf("login with NEW password: status = %d, want 200 — password was NOT persisted (Issue #99 regression)", got)
+	}
+
+	// Old password must now be rejected.
+	if got := doLoginStatus(t, app, email, oldPwd); got == fiber.StatusOK {
+		t.Errorf("login with OLD password: status = 200, want non-200 — old password still accepted (Issue #99 regression)")
+	}
+}
+
+// TestChangeOwnPassword_WrongCurrentPassword verifies that a wrong current
+// password returns 400 and leaves the stored hash unchanged.
+func TestChangeOwnPassword_WrongCurrentPassword(t *testing.T) {
+	t.Parallel()
+
+	const (
+		realPwd = "myrealpassword"
+		newPwd  = "completelynewpwd"
+	)
+
+	const email = "changepwd-wrongcurrent@example.com"
+	app, database, _ := setupTestApp(t, "file:TestChangePwd_WrongCurrent?mode=memory&cache=private")
+	setupLocalUser(t, database, "wrong-current-org", email, "Wrong Current User", realPwd)
+
+	token := doLogin(t, app, email, realPwd)
+	status, msg := doChangePassword(t, app, token, "thisiswrong!", newPwd)
+
+	if status != fiber.StatusBadRequest {
+		t.Errorf("status = %d, want 400", status)
+	}
+	if msg != "current password is incorrect" {
+		t.Errorf("error.message = %q, want %q", msg, "current password is incorrect")
+	}
+
+	// Old password must still work — the hash was not changed.
+	if got := doLoginStatus(t, app, email, realPwd); got != fiber.StatusOK {
+		t.Errorf("login with real password after rejected change: status = %d, want 200", got)
+	}
+}
+
+// TestChangeOwnPassword_ValidationErrors covers the input validation cases:
+// missing current_password, new_password too short, and no auth token.
+func TestChangeOwnPassword_ValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	const (
+		realPwd = "validpassword99"
+		email   = "changepwd-validation@example.com"
+	)
+
+	tests := []struct {
+		name       string
+		currentPwd string
+		newPwd     string
+		withToken  bool
+		wantStatus int
+		wantErrMsg string
+	}{
+		{
+			name:       "missing current_password returns 400",
+			currentPwd: "",
+			newPwd:     "validnewpwd99",
+			withToken:  true,
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "new_password shorter than 8 chars returns 400",
+			currentPwd: realPwd,
+			newPwd:     "short",
+			withToken:  true,
+			wantStatus: fiber.StatusBadRequest,
+		},
+		{
+			name:       "no auth token returns 401",
+			currentPwd: realPwd,
+			newPwd:     "validnewpwd99",
+			withToken:  false,
+			wantStatus: fiber.StatusUnauthorized,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dsnSuffix := strings.ReplaceAll(tc.name, " ", "_")
+			app, database, _ := setupTestApp(t, "file:TestChangePwd_Val_"+dsnSuffix+"?mode=memory&cache=private")
+
+			orgSlug := "val-org-" + strings.ReplaceAll(tc.name, " ", "-")
+			if len(orgSlug) > 50 {
+				orgSlug = orgSlug[:50]
+			}
+			setupLocalUser(t, database, orgSlug, email, "Validation User", realPwd)
+
+			var token string
+			if tc.withToken {
+				token = doLogin(t, app, email, realPwd)
+			}
+
+			status, _ := doChangePassword(t, app, token, tc.currentPwd, tc.newPwd)
+			if status != tc.wantStatus {
+				t.Errorf("status = %d, want %d", status, tc.wantStatus)
+			}
+		})
+	}
+}
+
+// TestChangeOwnPassword_MaxLength verifies that a new_password longer than 128
+// characters is rejected with 400 before any bcrypt work is done.
+func TestChangeOwnPassword_MaxLength(t *testing.T) {
+	t.Parallel()
+
+	const (
+		pwd   = "validpassword1"
+		email = "changepwd-maxlen@example.com"
+	)
+
+	app, database, _ := setupTestApp(t, "file:TestChangePwd_MaxLen?mode=memory&cache=private")
+	setupLocalUser(t, database, "maxlen-org", email, "MaxLen User", pwd)
+
+	token := doLogin(t, app, email, pwd)
+
+	tooLong := strings.Repeat("a", 129)
+	status, msg := doChangePassword(t, app, token, pwd, tooLong)
+	if status != fiber.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for password > 128 chars", status)
+	}
+	if !strings.Contains(msg, "at most 128") {
+		t.Errorf("error.message = %q, want it to contain %q", msg, "at most 128")
+	}
+}
+
+// TestChangeOwnPassword_MaxLengthBoundary verifies that a new_password of
+// exactly 128 characters is rejected with 400 (one over the limit), and that a
+// password of 127 characters is accepted.
+func TestChangeOwnPassword_MaxLengthBoundary(t *testing.T) {
+	t.Parallel()
+
+	const (
+		pwd   = "validpassword2"
+		email = "changepwd-maxbound@example.com"
+	)
+
+	app, database, _ := setupTestApp(t, "file:TestChangePwd_MaxBound?mode=memory&cache=private")
+	setupLocalUser(t, database, "maxbound-org", email, "MaxBound User", pwd)
+
+	// 129 chars must be rejected.
+	token := doLogin(t, app, email, pwd)
+	tooLong := strings.Repeat("b", 129)
+	status, msg := doChangePassword(t, app, token, pwd, tooLong)
+	if status != fiber.StatusBadRequest {
+		t.Errorf("129-char password: status = %d, msg: %s — want 400", status, msg)
+	}
+
+	// 64 chars (well within bcrypt's 72-byte limit and under 128) must be accepted.
+	token2 := doLogin(t, app, email, pwd)
+	exactly64 := strings.Repeat("c", 64)
+	status2, msg2 := doChangePassword(t, app, token2, pwd, exactly64)
+	if status2 != fiber.StatusOK {
+		t.Errorf("64-char password: status = %d, msg: %s — want 200", status2, msg2)
+	}
+}
+
+// TestChangeOwnPassword_CurrentSessionSurvivesInDB verifies that after a
+// successful password change the current session's row is NOT deleted from the
+// database. This prevents the user from being silently logged out when the
+// in-memory key cache is next reloaded from the database (~30 s interval).
+func TestChangeOwnPassword_CurrentSessionSurvivesInDB(t *testing.T) {
+	t.Parallel()
+
+	const (
+		oldPwd = "dbsurvive_old"
+		newPwd = "dbsurvive_new"
+	)
+
+	const email = "changepwd-dbsurvive@example.com"
+
+	dsn := "file:TestChangePwd_DBSurvive?mode=memory&cache=private"
+	app, database, keyCache := setupTestApp(t, dsn)
+
+	setupLocalUser(t, database, "db-survive-org", email, "DB Survive User", oldPwd)
+
+	// Obtain the current session via login.
+	token1 := doLogin(t, app, email, oldPwd)
+	token1Hash := keygen.Hash(token1, testHMACSecret)
+
+	ki1, ok := keyCache.Get(token1Hash)
+	if !ok {
+		t.Fatal("token1 not found in cache after login")
+	}
+
+	// Inject a second session to verify it is removed from the DB.
+	userObj, err := database.GetUserByEmail(context.Background(), email)
+	if err != nil {
+		t.Fatalf("GetUserByEmail: %v", err)
+	}
+	token2 := injectSession(t, database, keyCache, userObj, "Second session DB test")
+	token2Hash := keygen.Hash(token2, testHMACSecret)
+	ki2, ok := keyCache.Get(token2Hash)
+	if !ok {
+		t.Fatal("token2 not found in cache after inject")
+	}
+
+	// Change the password using token1.
+	status, msg := doChangePassword(t, app, token1, oldPwd, newPwd)
+	if status != fiber.StatusOK {
+		t.Fatalf("change password: status = %d, msg: %s", status, msg)
+	}
+
+	// token1's DB row must still exist (RevokeUserSessionsExcept preserves it).
+	var count1 int
+	if err := database.SQL().QueryRowContext(context.Background(),
+		"SELECT COUNT(*) FROM api_keys WHERE id = ?", ki1.ID).Scan(&count1); err != nil {
+		t.Fatalf("count token1 DB row: %v", err)
+	}
+	if count1 != 1 {
+		t.Errorf("token1 DB row count = %d, want 1 — current session must survive in DB", count1)
+	}
+
+	// token2's DB row must be deleted.
+	var count2 int
+	if err := database.SQL().QueryRowContext(context.Background(),
+		"SELECT COUNT(*) FROM api_keys WHERE id = ?", ki2.ID).Scan(&count2); err != nil {
+		t.Fatalf("count token2 DB row: %v", err)
+	}
+	if count2 != 0 {
+		t.Errorf("token2 DB row count = %d, want 0 — other session must be removed from DB", count2)
+	}
+}
+
+// TestChangeOwnPassword_SSOAccount verifies that accounts created via an
+// external identity provider (auth_provider != "local", NULL password_hash)
+// receive 400 "password change not available for this account".
+func TestChangeOwnPassword_SSOAccount(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestChangePwd_SSO?mode=memory&cache=private"
+	app, database, keyCache := setupTestApp(t, dsn)
+
+	// Create an SSO-only user with no password hash.
+	extID := "oidc-sub-changepwd"
+	ssoUser, err := database.CreateUser(context.Background(), db.CreateUserParams{
+		Email:        "changepwd-sso@example.com",
+		DisplayName:  "SSO User",
+		AuthProvider: "oidc",
+		ExternalID:   &extID,
+		// PasswordHash intentionally nil — SSO account.
+	})
+	if err != nil {
+		t.Fatalf("CreateUser SSO: %v", err)
+	}
+
+	org := mustCreateOrg(t, database, "SSO Org", "sso-org-pwdchg")
+	mustCreateOrgMembership(t, database, org.ID, ssoUser.ID, auth.RoleOrgAdmin)
+
+	// Inject a fake session key for the SSO user directly (SSO login bypasses the
+	// password handler so there is no real session token to obtain via doLogin).
+	ssoToken := injectSession(t, database, keyCache, ssoUser, "SSO test session")
+
+	req := httptest.NewRequest("POST", "/api/v1/me/password",
+		bodyJSON(t, map[string]any{
+			"current_password": "anything",
+			"new_password":     "newpassword99",
+		}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ssoToken)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusBadRequest {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 400 for SSO account; body: %s", resp.StatusCode, raw)
+	}
+
+	var body map[string]any
+	decodeBody(t, resp.Body, &body)
+	if got := errMsg(body); !strings.Contains(got, "password change not available") {
+		t.Errorf("error.message = %q, want it to contain %q", got, "password change not available")
+	}
+}
+
+// TestChangeOwnPassword_OnlyOwnPassword verifies that the endpoint always acts
+// on the user identified by the bearer token. After User A changes their
+// password, User B's password must remain exactly as it was.
+func TestChangeOwnPassword_OnlyOwnPassword(t *testing.T) {
+	t.Parallel()
+
+	const (
+		pwdA = "userApwd1234"
+		pwdB = "userBpwd5678"
+		newA = "userAnewpwd99"
+	)
+
+	dsn := "file:TestChangePwd_OnlyOwn?mode=memory&cache=private"
+	app, database, _ := setupTestApp(t, dsn)
+
+	orgA := mustCreateOrg(t, database, "Org A", "only-own-org-a")
+	orgB := mustCreateOrg(t, database, "Org B", "only-own-org-b")
+
+	userA := mustCreateUserWithPassword(t, database, "changepwd-owna@example.com", "User A", pwdA)
+	userB := mustCreateUserWithPassword(t, database, "changepwd-ownb@example.com", "User B", pwdB)
+
+	mustCreateOrgMembership(t, database, orgA.ID, userA.ID, auth.RoleOrgAdmin)
+	mustCreateOrgMembership(t, database, orgB.ID, userB.ID, auth.RoleOrgAdmin)
+
+	// User A changes their own password.
+	tokenA := doLogin(t, app, "changepwd-owna@example.com", pwdA)
+	status, msg := doChangePassword(t, app, tokenA, pwdA, newA)
+	if status != fiber.StatusOK {
+		t.Fatalf("User A password change: status = %d, msg: %s", status, msg)
+	}
+
+	// User B must still be able to log in with their original password.
+	if got := doLoginStatus(t, app, "changepwd-ownb@example.com", pwdB); got != fiber.StatusOK {
+		t.Errorf("User B login after User A changed password: status = %d, want 200 — User B's password was incorrectly affected", got)
+	}
+}
+
+// TestChangeOwnPassword_SessionInvalidation verifies that after a successful
+// password change via Token 1:
+//   - Token 2 (a different session for the same user) is invalidated (401).
+//   - Token 1 (the session that performed the change) remains valid (200).
+func TestChangeOwnPassword_SessionInvalidation(t *testing.T) {
+	t.Parallel()
+
+	const (
+		oldPwd = "sessionold123"
+		newPwd = "sessionnew456"
+	)
+
+	const email = "changepwd-session@example.com"
+
+	dsn := "file:TestChangePwd_SessionInval?mode=memory&cache=private"
+	app, database, keyCache := setupTestApp(t, dsn)
+
+	setupLocalUser(t, database, "session-inval-org", email, "Session User", oldPwd)
+
+	// Token 1: obtained via real login — has a real key ID in cache and DB.
+	token1 := doLogin(t, app, email, oldPwd)
+
+	// Read back token1's KeyInfo so we know its real key ID (needed to ensure the
+	// handler's "skip current session" guard (ki.ID != currentKeyID) works).
+	token1Hash := keygen.Hash(token1, testHMACSecret)
+	ki1, ok := keyCache.Get(token1Hash)
+	if !ok {
+		t.Fatal("token1 not found in cache after login")
+	}
+	if ki1.ID == "" {
+		t.Fatal("token1 KeyInfo has empty ID")
+	}
+
+	// Resolve user from DB to get the *db.User for injectSession.
+	userObj, err := database.GetUserByEmail(context.Background(), email)
+	if err != nil {
+		t.Fatalf("GetUserByEmail: %v", err)
+	}
+
+	// Token 2: injected directly into DB + cache with a different key ID,
+	// simulating a session from another browser / device.
+	token2 := injectSession(t, database, keyCache, userObj, "Second session")
+
+	// Pre-condition: both tokens must be valid.
+	if got := doGet(t, app, "/api/v1/me", token1); got != fiber.StatusOK {
+		t.Fatalf("token1 before change: status = %d, want 200", got)
+	}
+	if got := doGet(t, app, "/api/v1/me", token2); got != fiber.StatusOK {
+		t.Fatalf("token2 before change: status = %d, want 200", got)
+	}
+
+	// Change the password using Token 1.
+	status, msg := doChangePassword(t, app, token1, oldPwd, newPwd)
+	if status != fiber.StatusOK {
+		t.Fatalf("change password: status = %d, msg: %s", status, msg)
+	}
+
+	// Token 2 must now be rejected (evicted from cache by ChangeOwnPassword).
+	if got := doGet(t, app, "/api/v1/me", token2); got != fiber.StatusUnauthorized {
+		t.Errorf("token2 after change: status = %d, want 401 (other session must be invalidated)", got)
+	}
+
+	// Token 1 (the session that performed the change) must still be valid.
+	if got := doGet(t, app, "/api/v1/me", token1); got != fiber.StatusOK {
+		t.Errorf("token1 after change: status = %d, want 200 (current session must remain valid)", got)
+	}
+}

--- a/internal/api/admin/change_password_test.go
+++ b/internal/api/admin/change_password_test.go
@@ -303,8 +303,9 @@ func TestChangeOwnPassword_ValidationErrors(t *testing.T) {
 	}
 }
 
-// TestChangeOwnPassword_MaxLength verifies that a new_password longer than 128
-// characters is rejected with 400 before any bcrypt work is done.
+// TestChangeOwnPassword_MaxLength verifies that a new_password longer than 72
+// bytes is rejected with 400 before any bcrypt work is done. The 72-byte limit
+// matches bcrypt's internal processing boundary.
 func TestChangeOwnPassword_MaxLength(t *testing.T) {
 	t.Parallel()
 
@@ -318,19 +319,20 @@ func TestChangeOwnPassword_MaxLength(t *testing.T) {
 
 	token := doLogin(t, app, email, pwd)
 
-	tooLong := strings.Repeat("a", 129)
+	tooLong := strings.Repeat("a", 73)
 	status, msg := doChangePassword(t, app, token, pwd, tooLong)
 	if status != fiber.StatusBadRequest {
-		t.Errorf("status = %d, want 400 for password > 128 chars", status)
+		t.Errorf("status = %d, want 400 for password > 72 bytes", status)
 	}
-	if !strings.Contains(msg, "at most 128") {
-		t.Errorf("error.message = %q, want it to contain %q", msg, "at most 128")
+	if !strings.Contains(msg, "at most 72") {
+		t.Errorf("error.message = %q, want it to contain %q", msg, "at most 72")
 	}
 }
 
-// TestChangeOwnPassword_MaxLengthBoundary verifies that a new_password of
-// exactly 128 characters is rejected with 400 (one over the limit), and that a
-// password of 127 characters is accepted.
+// TestChangeOwnPassword_MaxLengthBoundary verifies that a new_password of exactly
+// 73 bytes is rejected with 400 (one over bcrypt's 72-byte limit), that a
+// password of exactly 72 bytes is accepted (at the limit), and that a password
+// of 71 bytes is also accepted (well within the limit).
 func TestChangeOwnPassword_MaxLengthBoundary(t *testing.T) {
 	t.Parallel()
 
@@ -342,20 +344,20 @@ func TestChangeOwnPassword_MaxLengthBoundary(t *testing.T) {
 	app, database, _ := setupTestApp(t, "file:TestChangePwd_MaxBound?mode=memory&cache=private")
 	setupLocalUser(t, database, "maxbound-org", email, "MaxBound User", pwd)
 
-	// 129 chars must be rejected.
+	// 73 bytes must be rejected (one over the limit).
 	token := doLogin(t, app, email, pwd)
-	tooLong := strings.Repeat("b", 129)
+	tooLong := strings.Repeat("b", 73)
 	status, msg := doChangePassword(t, app, token, pwd, tooLong)
 	if status != fiber.StatusBadRequest {
-		t.Errorf("129-char password: status = %d, msg: %s — want 400", status, msg)
+		t.Errorf("73-byte password: status = %d, msg: %s — want 400", status, msg)
 	}
 
-	// 64 chars (well within bcrypt's 72-byte limit and under 128) must be accepted.
+	// 72 bytes must be accepted (exactly at bcrypt's limit).
 	token2 := doLogin(t, app, email, pwd)
-	exactly64 := strings.Repeat("c", 64)
-	status2, msg2 := doChangePassword(t, app, token2, pwd, exactly64)
+	exactly72 := strings.Repeat("c", 72)
+	status2, msg2 := doChangePassword(t, app, token2, pwd, exactly72)
 	if status2 != fiber.StatusOK {
-		t.Errorf("64-char password: status = %d, msg: %s — want 200", status2, msg2)
+		t.Errorf("72-byte password: status = %d, msg: %s — want 200", status2, msg2)
 	}
 }
 
@@ -405,7 +407,7 @@ func TestChangeOwnPassword_CurrentSessionSurvivesInDB(t *testing.T) {
 		t.Fatalf("change password: status = %d, msg: %s", status, msg)
 	}
 
-	// token1's DB row must still exist (RevokeUserSessionsExcept preserves it).
+	// token1's DB row must still exist (ChangePasswordAndRevokeOtherSessions preserves it).
 	var count1 int
 	if err := database.SQL().QueryRowContext(context.Background(),
 		"SELECT COUNT(*) FROM api_keys WHERE id = ?", ki1.ID).Scan(&count1); err != nil {

--- a/internal/api/admin/routes.go
+++ b/internal/api/admin/routes.go
@@ -37,6 +37,7 @@ func RegisterRoutes(app *fiber.App, handler *Handler, keyCache *cache.Cache[stri
 
 	// Current user profile — no role restriction.
 	api.Get("/me", handler.Me)
+	api.Post("/me/password", handler.ChangeOwnPassword)
 	api.Get("/me/available-models", handler.AvailableModels)
 
 	// Own usage — no role restriction; any authenticated key sees its own data.

--- a/internal/db/api_keys.go
+++ b/internal/db/api_keys.go
@@ -294,9 +294,10 @@ func (d *DB) UpdateAPIKey(ctx context.Context, id string, params UpdateAPIKeyPar
 
 // DeleteAPIKey soft-deletes an active API key by setting deleted_at.
 // It returns ErrNotFound if the key does not exist or is already deleted.
+
 // RevokeUserSessions hard-deletes all session keys for a user.
-// Called during login to ensure only one session exists per user.
-// Session keys are ephemeral — no audit trail needed, hard delete
+// Called during login and OIDC callback to ensure only one session exists per
+// user. Session keys are ephemeral — no audit trail needed, hard delete
 // prevents the api_keys table from filling up with dead sessions.
 func (d *DB) RevokeUserSessions(ctx context.Context, userID string) error {
 	p := d.dialect.Placeholder
@@ -305,6 +306,23 @@ func (d *DB) RevokeUserSessions(ctx context.Context, userID string) error {
 	_, err := d.sql.ExecContext(ctx, query, userID, "session_key")
 	if err != nil {
 		return fmt.Errorf("revoke user sessions %s: %w", userID, translateError(err))
+	}
+	return nil
+}
+
+// RevokeUserSessionsExcept hard-deletes all session keys for a user except the
+// one identified by exceptKeyID. Used during a password change so that the
+// current session survives the revocation — preventing the user from being
+// silently logged out when the cache is next refreshed from the database.
+func (d *DB) RevokeUserSessionsExcept(ctx context.Context, userID, exceptKeyID string) error {
+	p := d.dialect.Placeholder
+	query := "DELETE FROM api_keys WHERE user_id = " + p(1) +
+		" AND key_type = " + p(2) +
+		" AND id != " + p(3)
+
+	_, err := d.sql.ExecContext(ctx, query, userID, "session_key", exceptKeyID)
+	if err != nil {
+		return fmt.Errorf("revoke user sessions except %s: %w", userID, translateError(err))
 	}
 	return nil
 }

--- a/internal/db/api_keys.go
+++ b/internal/db/api_keys.go
@@ -310,21 +310,40 @@ func (d *DB) RevokeUserSessions(ctx context.Context, userID string) error {
 	return nil
 }
 
-// RevokeUserSessionsExcept hard-deletes all session keys for a user except the
-// one identified by exceptKeyID. Used during a password change so that the
-// current session survives the revocation — preventing the user from being
-// silently logged out when the cache is next refreshed from the database.
-func (d *DB) RevokeUserSessionsExcept(ctx context.Context, userID, exceptKeyID string) error {
+// ChangePasswordAndRevokeOtherSessions atomically updates a user's password hash
+// and hard-deletes all session keys for that user except the one identified by
+// exceptKeyID. Both operations run in a single transaction: if either fails the
+// whole operation is rolled back so the DB is never left in a partially-updated
+// state. Returns ErrNotFound if the user does not exist or has been soft-deleted.
+func (d *DB) ChangePasswordAndRevokeOtherSessions(ctx context.Context, userID, newPasswordHash, exceptKeyID string) error {
 	p := d.dialect.Placeholder
-	query := "DELETE FROM api_keys WHERE user_id = " + p(1) +
+
+	updateQuery := "UPDATE users SET password_hash = " + p(1) +
+		", updated_at = CURRENT_TIMESTAMP" +
+		" WHERE id = " + p(2) + " AND deleted_at IS NULL"
+
+	deleteQuery := "DELETE FROM api_keys WHERE user_id = " + p(1) +
 		" AND key_type = " + p(2) +
 		" AND id != " + p(3)
 
-	_, err := d.sql.ExecContext(ctx, query, userID, "session_key", exceptKeyID)
-	if err != nil {
-		return fmt.Errorf("revoke user sessions except %s: %w", userID, translateError(err))
-	}
-	return nil
+	return d.WithTx(ctx, func(q Querier) error {
+		result, err := q.ExecContext(ctx, updateQuery, newPasswordHash, userID)
+		if err != nil {
+			return fmt.Errorf("update password hash: %w", translateError(err))
+		}
+		n, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("update password hash rows affected: %w", err)
+		}
+		if n == 0 {
+			return ErrNotFound
+		}
+
+		if _, err := q.ExecContext(ctx, deleteQuery, userID, "session_key", exceptKeyID); err != nil {
+			return fmt.Errorf("revoke other sessions: %w", translateError(err))
+		}
+		return nil
+	})
 }
 
 func (d *DB) DeleteAPIKey(ctx context.Context, id string) error {

--- a/internal/db/api_keys_test.go
+++ b/internal/db/api_keys_test.go
@@ -663,6 +663,115 @@ func TestDeleteAPIKey(t *testing.T) {
 	}
 }
 
+// ---- RevokeUserSessionsExcept -----------------------------------------------
+
+// TestRevokeUserSessionsExcept verifies that the method deletes all session
+// keys for a user except the one specified by exceptKeyID.
+func TestRevokeUserSessionsExcept(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	org := mustCreateOrg(t, d, CreateOrgParams{Name: "O", Slug: "revoke-except-org"})
+	user := mustCreateUser(t, d, CreateUserParams{Email: "revoke-except@example.com", DisplayName: "RE"})
+
+	makeSessionKey := func(name string) *APIKey {
+		plain := "vl_sk_" + name + strings.Repeat("0", 48-len(name))
+		return mustCreateAPIKey(t, d, CreateAPIKeyParams{
+			KeyHash:   keygen.Hash(plain, testHMACSecret),
+			KeyHint:   keygen.Hint(plain),
+			KeyType:   "session_key",
+			Name:      name,
+			OrgID:     org.ID,
+			UserID:    ptr(user.ID),
+			CreatedBy: user.ID,
+		})
+	}
+
+	key1 := makeSessionKey("session1")
+	key2 := makeSessionKey("session2")
+
+	// Revoke all sessions except key1.
+	if err := d.RevokeUserSessionsExcept(ctx, user.ID, key1.ID); err != nil {
+		t.Fatalf("RevokeUserSessionsExcept() error = %v", err)
+	}
+
+	// key1 must still exist in the DB (raw SELECT — GetAPIKey filters deleted_at,
+	// but session keys are hard-deleted so check existence directly).
+	var count1 int
+	if err := d.SQL().QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM api_keys WHERE id = ?", key1.ID).Scan(&count1); err != nil {
+		t.Fatalf("count key1: %v", err)
+	}
+	if count1 != 1 {
+		t.Errorf("key1 count = %d after RevokeUserSessionsExcept, want 1 (key must survive)", count1)
+	}
+
+	// key2 must be gone (hard-deleted by RevokeUserSessionsExcept).
+	var count2 int
+	if err := d.SQL().QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM api_keys WHERE id = ?", key2.ID).Scan(&count2); err != nil {
+		t.Fatalf("count key2: %v", err)
+	}
+	if count2 != 0 {
+		t.Errorf("key2 count = %d after RevokeUserSessionsExcept, want 0 (key must be deleted)", count2)
+	}
+}
+
+// TestRevokeUserSessionsExcept_OnlyOwnSessions ensures the method does not
+// delete session keys belonging to a different user.
+func TestRevokeUserSessionsExcept_OnlyOwnSessions(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	org := mustCreateOrg(t, d, CreateOrgParams{Name: "O", Slug: "revoke-except-iso-org"})
+	userA := mustCreateUser(t, d, CreateUserParams{Email: "revokeA@example.com", DisplayName: "A"})
+	userB := mustCreateUser(t, d, CreateUserParams{Email: "revokeB@example.com", DisplayName: "B"})
+
+	makeSession := func(u *User, name string) *APIKey {
+		plain := "vl_sk_" + name + strings.Repeat("0", 48-len(name))
+		return mustCreateAPIKey(t, d, CreateAPIKeyParams{
+			KeyHash:   keygen.Hash(plain, testHMACSecret),
+			KeyHint:   keygen.Hint(plain),
+			KeyType:   "session_key",
+			Name:      name,
+			OrgID:     org.ID,
+			UserID:    ptr(u.ID),
+			CreatedBy: u.ID,
+		})
+	}
+
+	keyA1 := makeSession(userA, "sa1xxxxx")
+	keyA2 := makeSession(userA, "sa2xxxxx")
+	keyB := makeSession(userB, "sb1xxxxx")
+
+	// Revoke userA's sessions except keyA1.
+	if err := d.RevokeUserSessionsExcept(ctx, userA.ID, keyA1.ID); err != nil {
+		t.Fatalf("RevokeUserSessionsExcept() error = %v", err)
+	}
+
+	// keyA2 must be gone.
+	var countA2 int
+	if err := d.SQL().QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM api_keys WHERE id = ?", keyA2.ID).Scan(&countA2); err != nil {
+		t.Fatalf("count keyA2: %v", err)
+	}
+	if countA2 != 0 {
+		t.Errorf("keyA2 count = %d, want 0 (must be deleted)", countA2)
+	}
+
+	// keyB (other user) must be untouched.
+	var countB int
+	if err := d.SQL().QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM api_keys WHERE id = ?", keyB.ID).Scan(&countB); err != nil {
+		t.Fatalf("count keyB: %v", err)
+	}
+	if countB != 1 {
+		t.Errorf("keyB count = %d, want 1 (other user's session must not be deleted)", countB)
+	}
+}
+
 // ---- GetUserOrgRole ---------------------------------------------------------
 
 func TestGetUserOrgRole(t *testing.T) {

--- a/internal/db/api_keys_test.go
+++ b/internal/db/api_keys_test.go
@@ -663,17 +663,99 @@ func TestDeleteAPIKey(t *testing.T) {
 	}
 }
 
-// ---- RevokeUserSessionsExcept -----------------------------------------------
+// ---- ChangePasswordAndRevokeOtherSessions -----------------------------------
 
-// TestRevokeUserSessionsExcept verifies that the method deletes all session
-// keys for a user except the one specified by exceptKeyID.
-func TestRevokeUserSessionsExcept(t *testing.T) {
+// TestChangePasswordAndRevokeOtherSessions verifies the atomic password-change
+// + session-revocation method: the new hash is persisted, other session keys are
+// deleted, the excepted session key survives, and an unrelated user is unaffected.
+func TestChangePasswordAndRevokeOtherSessions(t *testing.T) {
 	t.Parallel()
 	d := openMigratedDB(t)
 	ctx := context.Background()
 
-	org := mustCreateOrg(t, d, CreateOrgParams{Name: "O", Slug: "revoke-except-org"})
-	user := mustCreateUser(t, d, CreateUserParams{Email: "revoke-except@example.com", DisplayName: "RE"})
+	org := mustCreateOrg(t, d, CreateOrgParams{Name: "O", Slug: "chpwd-revoke-org"})
+	user := mustCreateUser(t, d, CreateUserParams{
+		Email:        "chpwd-revoke@example.com",
+		DisplayName:  "CPR",
+		PasswordHash: ptr("$2a$10$initialhashinitialhashinitialhashinitialhashinitialh"),
+	})
+
+	makeSessionKey := func(u *User, name string) *APIKey {
+		plain := "vl_sk_" + name + strings.Repeat("0", 48-len(name))
+		return mustCreateAPIKey(t, d, CreateAPIKeyParams{
+			KeyHash:   keygen.Hash(plain, testHMACSecret),
+			KeyHint:   keygen.Hint(plain),
+			KeyType:   "session_key",
+			Name:      name,
+			OrgID:     org.ID,
+			UserID:    ptr(u.ID),
+			CreatedBy: u.ID,
+		})
+	}
+
+	currentSession := makeSessionKey(user, "current0")
+	otherSession := makeSessionKey(user, "other000")
+
+	// Unrelated user — must be completely untouched.
+	otherUser := mustCreateUser(t, d, CreateUserParams{Email: "chpwd-other@example.com", DisplayName: "O"})
+	otherUserSession := makeSessionKey(otherUser, "otherU00")
+
+	newHash := "$2a$10$newhashnewhashnewhashnewhashnewhashnewhashnewhashne"
+	if err := d.ChangePasswordAndRevokeOtherSessions(ctx, user.ID, newHash, currentSession.ID); err != nil {
+		t.Fatalf("ChangePasswordAndRevokeOtherSessions() error = %v", err)
+	}
+
+	// Password hash must be updated in the DB.
+	var storedHash *string
+	if err := d.SQL().QueryRowContext(ctx,
+		"SELECT password_hash FROM users WHERE id = ?", user.ID).Scan(&storedHash); err != nil {
+		t.Fatalf("read stored hash: %v", err)
+	}
+	if storedHash == nil || *storedHash != newHash {
+		t.Errorf("stored password hash = %v, want %q", storedHash, newHash)
+	}
+
+	// Current session must still exist.
+	var countCurrent int
+	if err := d.SQL().QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM api_keys WHERE id = ?", currentSession.ID).Scan(&countCurrent); err != nil {
+		t.Fatalf("count current session: %v", err)
+	}
+	if countCurrent != 1 {
+		t.Errorf("current session count = %d, want 1 (excepted session must survive)", countCurrent)
+	}
+
+	// Other session must be gone (hard-deleted).
+	var countOther int
+	if err := d.SQL().QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM api_keys WHERE id = ?", otherSession.ID).Scan(&countOther); err != nil {
+		t.Fatalf("count other session: %v", err)
+	}
+	if countOther != 0 {
+		t.Errorf("other session count = %d, want 0 (must be hard-deleted)", countOther)
+	}
+
+	// Other user's session must be untouched.
+	var countOtherUser int
+	if err := d.SQL().QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM api_keys WHERE id = ?", otherUserSession.ID).Scan(&countOtherUser); err != nil {
+		t.Fatalf("count other user session: %v", err)
+	}
+	if countOtherUser != 1 {
+		t.Errorf("other user session count = %d, want 1 (must not be affected)", countOtherUser)
+	}
+}
+
+// TestChangePasswordAndRevokeOtherSessions_NotFound verifies that calling the
+// method for a non-existent user returns ErrNotFound and does not delete any
+// session keys (full rollback).
+func TestChangePasswordAndRevokeOtherSessions_NotFound(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	org := mustCreateOrg(t, d, CreateOrgParams{Name: "O", Slug: "chpwd-notfound-org"})
+	user := mustCreateUser(t, d, CreateUserParams{Email: "chpwd-notfound@example.com", DisplayName: "NF"})
 
 	makeSessionKey := func(name string) *APIKey {
 		plain := "vl_sk_" + name + strings.Repeat("0", 48-len(name))
@@ -688,87 +770,25 @@ func TestRevokeUserSessionsExcept(t *testing.T) {
 		})
 	}
 
-	key1 := makeSessionKey("session1")
-	key2 := makeSessionKey("session2")
+	session1 := makeSessionKey("nf-sess1")
+	session2 := makeSessionKey("nf-sess2")
 
-	// Revoke all sessions except key1.
-	if err := d.RevokeUserSessionsExcept(ctx, user.ID, key1.ID); err != nil {
-		t.Fatalf("RevokeUserSessionsExcept() error = %v", err)
+	const nonExistentUserID = "00000000-0000-0000-0000-000000000000"
+	err := d.ChangePasswordAndRevokeOtherSessions(ctx, nonExistentUserID, "somehash", session1.ID)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("ChangePasswordAndRevokeOtherSessions() error = %v, want ErrNotFound", err)
 	}
 
-	// key1 must still exist in the DB (raw SELECT — GetAPIKey filters deleted_at,
-	// but session keys are hard-deleted so check existence directly).
-	var count1 int
-	if err := d.SQL().QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM api_keys WHERE id = ?", key1.ID).Scan(&count1); err != nil {
-		t.Fatalf("count key1: %v", err)
-	}
-	if count1 != 1 {
-		t.Errorf("key1 count = %d after RevokeUserSessionsExcept, want 1 (key must survive)", count1)
-	}
-
-	// key2 must be gone (hard-deleted by RevokeUserSessionsExcept).
-	var count2 int
-	if err := d.SQL().QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM api_keys WHERE id = ?", key2.ID).Scan(&count2); err != nil {
-		t.Fatalf("count key2: %v", err)
-	}
-	if count2 != 0 {
-		t.Errorf("key2 count = %d after RevokeUserSessionsExcept, want 0 (key must be deleted)", count2)
-	}
-}
-
-// TestRevokeUserSessionsExcept_OnlyOwnSessions ensures the method does not
-// delete session keys belonging to a different user.
-func TestRevokeUserSessionsExcept_OnlyOwnSessions(t *testing.T) {
-	t.Parallel()
-	d := openMigratedDB(t)
-	ctx := context.Background()
-
-	org := mustCreateOrg(t, d, CreateOrgParams{Name: "O", Slug: "revoke-except-iso-org"})
-	userA := mustCreateUser(t, d, CreateUserParams{Email: "revokeA@example.com", DisplayName: "A"})
-	userB := mustCreateUser(t, d, CreateUserParams{Email: "revokeB@example.com", DisplayName: "B"})
-
-	makeSession := func(u *User, name string) *APIKey {
-		plain := "vl_sk_" + name + strings.Repeat("0", 48-len(name))
-		return mustCreateAPIKey(t, d, CreateAPIKeyParams{
-			KeyHash:   keygen.Hash(plain, testHMACSecret),
-			KeyHint:   keygen.Hint(plain),
-			KeyType:   "session_key",
-			Name:      name,
-			OrgID:     org.ID,
-			UserID:    ptr(u.ID),
-			CreatedBy: u.ID,
-		})
-	}
-
-	keyA1 := makeSession(userA, "sa1xxxxx")
-	keyA2 := makeSession(userA, "sa2xxxxx")
-	keyB := makeSession(userB, "sb1xxxxx")
-
-	// Revoke userA's sessions except keyA1.
-	if err := d.RevokeUserSessionsExcept(ctx, userA.ID, keyA1.ID); err != nil {
-		t.Fatalf("RevokeUserSessionsExcept() error = %v", err)
-	}
-
-	// keyA2 must be gone.
-	var countA2 int
-	if err := d.SQL().QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM api_keys WHERE id = ?", keyA2.ID).Scan(&countA2); err != nil {
-		t.Fatalf("count keyA2: %v", err)
-	}
-	if countA2 != 0 {
-		t.Errorf("keyA2 count = %d, want 0 (must be deleted)", countA2)
-	}
-
-	// keyB (other user) must be untouched.
-	var countB int
-	if err := d.SQL().QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM api_keys WHERE id = ?", keyB.ID).Scan(&countB); err != nil {
-		t.Fatalf("count keyB: %v", err)
-	}
-	if countB != 1 {
-		t.Errorf("keyB count = %d, want 1 (other user's session must not be deleted)", countB)
+	// Both sessions must still exist — transaction was rolled back.
+	for _, key := range []*APIKey{session1, session2} {
+		var count int
+		if err := d.SQL().QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM api_keys WHERE id = ?", key.ID).Scan(&count); err != nil {
+			t.Fatalf("count session %s: %v", key.ID, err)
+		}
+		if count != 1 {
+			t.Errorf("session %s count = %d, want 1 (rollback must preserve all sessions)", key.ID, count)
+		}
 	}
 }
 

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -325,6 +325,26 @@ func (d *DB) GetUserPasswordHash(ctx context.Context, email string) (string, str
 	return id, *passwordHash, nil
 }
 
+// GetUserPasswordHashByID retrieves the auth_provider and bcrypt password hash
+// for a user identified by their ID. It is used by the self-service password
+// change endpoint to verify the current password before accepting a new one.
+// Returns ErrNotFound if the user does not exist or is deleted.
+// Returns ErrNoPassword if password_hash is NULL, indicating an SSO-only account.
+func (d *DB) GetUserPasswordHashByID(ctx context.Context, userID string) (authProvider string, hash string, err error) {
+	query := "SELECT auth_provider, password_hash FROM users WHERE id = " +
+		d.dialect.Placeholder(1) + " AND deleted_at IS NULL"
+
+	var passwordHash *string
+	scanErr := d.sql.QueryRowContext(ctx, query, userID).Scan(&authProvider, &passwordHash)
+	if scanErr != nil {
+		return "", "", fmt.Errorf("GetUserPasswordHashByID: %w", translateError(scanErr))
+	}
+	if passwordHash == nil {
+		return authProvider, "", ErrNoPassword
+	}
+	return authProvider, *passwordHash, nil
+}
+
 // ResolveUserRole determines the effective RBAC role and organization for a user.
 // If the user is a system admin, it returns RoleSystemAdmin with the first org (if any).
 // Otherwise, it returns the role from the user's first org membership.

--- a/internal/db/users_test.go
+++ b/internal/db/users_test.go
@@ -670,6 +670,109 @@ func TestGetUserPasswordHash(t *testing.T) {
 	}
 }
 
+// ---- GetUserPasswordHashByID -------------------------------------------------
+
+func TestGetUserPasswordHashByID(t *testing.T) {
+	t.Parallel()
+
+	const testPassword = "testpassword123"
+
+	tests := []struct {
+		name              string
+		setup             func(t *testing.T, d *DB) string // returns userID to look up
+		wantErr           error
+		checkAuthProvider string // non-empty: verify returned authProvider equals this
+		checkHashMatches  bool   // true: verify returned hash matches testPassword
+	}{
+		{
+			name: "local user returns auth_provider and bcrypt hash",
+			setup: func(t *testing.T, d *DB) string {
+				t.Helper()
+				u := mustCreateUser(t, d, CreateUserParams{
+					Email:        "byid-local@example.com",
+					DisplayName:  "By ID Local",
+					PasswordHash: testPasswordHash(t),
+					AuthProvider: "local",
+				})
+				return u.ID
+			},
+			wantErr:           nil,
+			checkAuthProvider: "local",
+			checkHashMatches:  true,
+		},
+		{
+			name: "non-existent ID returns ErrNotFound",
+			setup: func(t *testing.T, d *DB) string {
+				return "00000000-0000-0000-0000-000000000000"
+			},
+			wantErr: ErrNotFound,
+		},
+		{
+			name: "soft-deleted user returns ErrNotFound",
+			setup: func(t *testing.T, d *DB) string {
+				t.Helper()
+				u := mustCreateUser(t, d, CreateUserParams{
+					Email:        "byid-deleted@example.com",
+					DisplayName:  "By ID Deleted",
+					PasswordHash: testPasswordHash(t),
+				})
+				if err := d.DeleteUser(context.Background(), u.ID); err != nil {
+					t.Fatalf("DeleteUser(): %v", err)
+				}
+				return u.ID
+			},
+			wantErr: ErrNotFound,
+		},
+		{
+			name: "SSO user with NULL password_hash returns ErrNoPassword",
+			setup: func(t *testing.T, d *DB) string {
+				t.Helper()
+				extID := "oidc-sub-byid-sso"
+				u := mustCreateUser(t, d, CreateUserParams{
+					Email:        "byid-sso@example.com",
+					DisplayName:  "By ID SSO",
+					AuthProvider: "oidc",
+					ExternalID:   &extID,
+					// PasswordHash intentionally nil — SSO account.
+				})
+				return u.ID
+			},
+			wantErr: ErrNoPassword,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := openMigratedDB(t)
+
+			userID := tc.setup(t, d)
+			authProvider, hash, err := d.GetUserPasswordHashByID(context.Background(), userID)
+
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("GetUserPasswordHashByID() error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			if tc.wantErr != nil {
+				return
+			}
+
+			if tc.checkAuthProvider != "" && authProvider != tc.checkAuthProvider {
+				t.Errorf("authProvider = %q, want %q", authProvider, tc.checkAuthProvider)
+			}
+
+			if tc.checkHashMatches {
+				if hash == "" {
+					t.Error("hash is empty, want non-empty bcrypt hash")
+				}
+				if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(testPassword)); err != nil {
+					t.Errorf("returned hash does not match test password: %v", err)
+				}
+			}
+		})
+	}
+}
+
 // ---- DeleteUser --------------------------------------------------------------
 
 func TestDeleteUser(t *testing.T) {

--- a/ui/src/hooks/useProfile.ts
+++ b/ui/src/hooks/useProfile.ts
@@ -12,3 +12,18 @@ export function useUpdateProfile() {
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['me'] }),
   })
 }
+
+export interface ChangePasswordInput {
+  current_password: string
+  new_password: string
+}
+
+export function useChangePassword() {
+  return useMutation({
+    mutationFn: (data: ChangePasswordInput) =>
+      apiClient<void>('/me/password', {
+        method: 'POST',
+        body: JSON.stringify(data),
+      }),
+  })
+}

--- a/ui/src/pages/ProfilePage.tsx
+++ b/ui/src/pages/ProfilePage.tsx
@@ -4,7 +4,7 @@ import { Input } from '../components/ui/Input'
 import { Button } from '../components/ui/Button'
 import { Badge } from '../components/ui/Badge'
 import { useMe } from '../hooks/useMe'
-import { useUpdateProfile } from '../hooks/useProfile'
+import { useUpdateProfile, useChangePassword } from '../hooks/useProfile'
 import { useToast } from '../hooks/useToast'
 
 function formatRole(role?: string): string {
@@ -119,11 +119,7 @@ function EditProfileSection({ userId, initialDisplayName }: EditProfileSectionPr
 // ChangePasswordSection
 // ---------------------------------------------------------------------------
 
-interface ChangePasswordSectionProps {
-  userId: string
-}
-
-function ChangePasswordSection({ userId }: ChangePasswordSectionProps) {
+function ChangePasswordSection() {
   const [currentPassword, setCurrentPassword] = useState('')
   const [newPassword, setNewPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
@@ -131,7 +127,7 @@ function ChangePasswordSection({ userId }: ChangePasswordSectionProps) {
   const [newPasswordError, setNewPasswordError] = useState<string | undefined>()
   const [confirmPasswordError, setConfirmPasswordError] = useState<string | undefined>()
 
-  const updateProfile = useUpdateProfile()
+  const changePassword = useChangePassword()
   const { toast } = useToast()
 
   function handleSubmit(e: React.FormEvent) {
@@ -167,14 +163,8 @@ function ChangePasswordSection({ userId }: ChangePasswordSectionProps) {
 
     if (hasError) return
 
-    updateProfile.mutate(
-      {
-        userId,
-        params: {
-          current_password: currentPassword,
-          new_password: newPassword,
-        },
-      },
+    changePassword.mutate(
+      { current_password: currentPassword, new_password: newPassword },
       {
         onSuccess: () => {
           toast({ variant: 'success', message: 'Password changed' })
@@ -183,10 +173,14 @@ function ChangePasswordSection({ userId }: ChangePasswordSectionProps) {
           setConfirmPassword('')
         },
         onError: (err) => {
-          toast({
-            variant: 'error',
-            message: err instanceof Error ? err.message : 'Failed to change password',
-          })
+          const message = err instanceof Error ? err.message : 'Failed to change password'
+          // Surface "current password is incorrect" inline on the field rather than
+          // only as a toast, so the user knows exactly which field is wrong.
+          if (message.toLowerCase().includes('current password')) {
+            setCurrentPasswordError(message)
+          } else {
+            toast({ variant: 'error', message })
+          }
         },
       },
     )
@@ -205,7 +199,7 @@ function ChangePasswordSection({ userId }: ChangePasswordSectionProps) {
           }}
           placeholder=""
           error={currentPasswordError}
-          disabled={updateProfile.isPending}
+          disabled={changePassword.isPending}
           autoComplete="current-password"
         />
         <Input
@@ -218,7 +212,7 @@ function ChangePasswordSection({ userId }: ChangePasswordSectionProps) {
           }}
           placeholder=""
           error={newPasswordError}
-          disabled={updateProfile.isPending}
+          disabled={changePassword.isPending}
           autoComplete="new-password"
           description="At least 8 characters"
         />
@@ -232,11 +226,11 @@ function ChangePasswordSection({ userId }: ChangePasswordSectionProps) {
           }}
           placeholder=""
           error={confirmPasswordError}
-          disabled={updateProfile.isPending}
+          disabled={changePassword.isPending}
           autoComplete="new-password"
         />
         <div className="flex justify-end">
-          <Button type="submit" loading={updateProfile.isPending}>
+          <Button type="submit" loading={changePassword.isPending}>
             Change Password
           </Button>
         </div>
@@ -293,7 +287,7 @@ export default function ProfilePage() {
         </SectionCard>
 
         <EditProfileSection userId={me.id} initialDisplayName={me.display_name} />
-        <ChangePasswordSection userId={me.id} />
+        <ChangePasswordSection />
       </div>
     </>
   )


### PR DESCRIPTION
Fixes #99

## Problem

The profile page sent `{current_password, new_password}` to `PATCH /users/:id`, whose body struct only declares `password`. Go's JSON decoder silently drops the unknown fields, so `req.Password == nil`: the handler ran no password update and returned **200**, the UI showed "password changed", and the stored hash never changed. The generic update path also never verified the current password.

## Fix

Dedicated self-service endpoint **`POST /me/password`**:

- Verifies `current_password` with bcrypt **before** changing anything; wrong current → 400 "current password is incorrect".
- Changes only the **authenticated** user's password (user ID from the token, never from body/path).
- Rejects SSO / password-less accounts; enforces 8..128 length.
- On success, revokes the user's **other** sessions (`RevokeUserSessionsExcept`) while keeping the current session valid in **both** the DB and the cache - so the user stays logged in on the current device and any stolen session elsewhere is killed.
- Burns a bcrypt comparison on the SSO/no-password paths so response timing does not reveal the account type.
- Writes an audit event (metadata only, never the password).

The profile UI calls the new endpoint and surfaces the real backend error instead of always reporting success.

## Known limitation

There is no per-attempt throttle on the current-password check yet (the caller already holds a valid session token). This will be wired through the login-throttle infrastructure from #104 once that lands, rather than adding a second throttle here.

## Tests

- Happy path **regression**: after change, login with the new password succeeds and the old password fails (would fail on the old code, which reported success without changing anything).
- Wrong current → 400 + hash unchanged; short/long new → 400; SSO account → 400; no token → 401; only-own-password; session invalidation (other session 401, current survives in DB).
- `go test -race ./internal/api/admin/ ./internal/db/` and `tsc --noEmit` clean.