### PR TITLE
chore(deps): bump vite to 7.3.5 (security patch)

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -33,7 +33,7 @@
         "tailwindcss": "^4.2.4",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.59.2",
-        "vite": "^7.3.2",
+        "vite": "^7.3.5",
         "vitest": "^4.1.2"
       }
     },
@@ -5292,9 +5292,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -36,7 +36,7 @@
     "tailwindcss": "^4.2.4",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.59.2",
-    "vite": "^7.3.2",
+    "vite": "^7.3.5",
     "vitest": "^4.1.2"
   }
 }


### PR DESCRIPTION
Patch-level vite bump (7.3.2 → 7.3.5) that closes the **high + moderate vite advisories** without the vite 8 major jump. Verified: `tsc`, `vitest` 317/317, `npm run build` green.