### PR TITLE
feat: resolve entity names in usage analytics & audit log (#124)

### DIFF
--- a/internal/api/admin/audit.go
+++ b/internal/api/admin/audit.go
@@ -19,6 +19,7 @@ type auditEventResponse struct {
 	OrgID        string `json:"org_id"`
 	ActorID      string `json:"actor_id"`
 	ActorType    string `json:"actor_type"`
+	ActorName    string `json:"actor_name,omitempty"`
 	ActorKeyID   string `json:"actor_key_id"`
 	Action       string `json:"action"`
 	ResourceType string `json:"resource_type"`
@@ -125,17 +126,68 @@ func (h *Handler) ListAuditLogs(c fiber.Ctx) error {
 		return apierror.InternalError(c, "failed to retrieve audit logs")
 	}
 
+	// Collect actor IDs by type so we can resolve human-readable names in bulk.
+	var userIDs, saIDs []string
+	for _, ev := range result.Events {
+		if ev.ActorID == "" {
+			continue
+		}
+		switch ev.ActorType {
+		case "user":
+			userIDs = append(userIDs, ev.ActorID)
+		case "service_account":
+			saIDs = append(saIDs, ev.ActorID)
+		}
+	}
+
+	// Resolve actor IDs to display labels. system_admin uses an unscoped global
+	// lookup (by design — they can see all orgs). org_admin path is restricted to
+	// actors belonging to their own org to prevent cross-org name disclosure.
+	actorNames := map[string]string{}
+	if auth.HasRole(keyInfo.Role, auth.RoleSystemAdmin) {
+		userNames, err := h.DB.ResolveGroupLabels(c.Context(), "user", userIDs)
+		if err != nil {
+			h.Log.WarnContext(c.Context(), "resolve audit actor names", slog.String("error", err.Error()))
+			userNames = map[string]string{}
+		}
+		saNames, err := h.DB.ResolveGroupLabels(c.Context(), "service_account", saIDs)
+		if err != nil {
+			h.Log.WarnContext(c.Context(), "resolve audit actor names", slog.String("error", err.Error()))
+			saNames = map[string]string{}
+		}
+		for id, name := range userNames {
+			actorNames[id] = name
+		}
+		for id, name := range saNames {
+			actorNames[id] = name
+		}
+	} else {
+		// org_admin: orgID is already forced to keyInfo.OrgID above.
+		resolved, err := h.DB.ResolveOrgActorLabels(c.Context(), orgID, userIDs, saIDs)
+		if err != nil {
+			h.Log.WarnContext(c.Context(), "resolve audit actor names", slog.String("error", err.Error()))
+		} else {
+			actorNames = resolved
+		}
+	}
+
 	resp := auditListResponse{
 		Data:    make([]auditEventResponse, 0, len(result.Events)),
 		HasMore: result.HasMore,
 	}
 	for _, ev := range result.Events {
+		var actorName string
+		switch ev.ActorType {
+		case "user", "service_account":
+			actorName = actorNames[ev.ActorID]
+		}
 		resp.Data = append(resp.Data, auditEventResponse{
 			ID:           ev.ID,
 			Timestamp:    ev.Timestamp.UTC().Format(time.RFC3339),
 			OrgID:        ev.OrgID,
 			ActorID:      ev.ActorID,
 			ActorType:    ev.ActorType,
+			ActorName:    actorName,
 			ActorKeyID:   ev.ActorKeyID,
 			Action:       ev.Action,
 			ResourceType: ev.ResourceType,

--- a/internal/api/admin/audit_test.go
+++ b/internal/api/admin/audit_test.go
@@ -1,0 +1,654 @@
+package admin_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/voidmind-io/voidllm/internal/auth"
+	"github.com/voidmind-io/voidllm/internal/db"
+)
+
+// insertAuditLogDirect inserts a single audit_logs row into the database,
+// bypassing the async logger. It is used to seed deterministic test data for
+// ListAuditLogs handler tests.
+func insertAuditLogDirect(t *testing.T, database *db.DB, id, orgID, actorID, actorType, action, resourceType string) {
+	t.Helper()
+	const insertSQL = `INSERT INTO audit_logs
+		(id, timestamp, org_id, actor_id, actor_type, actor_key_id,
+		 action, resource_type, resource_id, description, ip_address, status_code, request_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+
+	ts := time.Now().UTC().Format(time.RFC3339)
+	_, err := database.SQL().ExecContext(context.Background(), insertSQL,
+		id, ts, orgID, actorID, actorType, "test-key-id",
+		action, resourceType, "res-"+id,
+		fmt.Sprintf("%s %s %s", actorID, action, resourceType),
+		"127.0.0.1", 200, "",
+	)
+	if err != nil {
+		t.Fatalf("insertAuditLogDirect id=%q: %v", id, err)
+	}
+}
+
+// seedSAForAudit creates a service account owned by the given user inside the
+// given org and returns its ID and name.
+func seedSAForAudit(t *testing.T, database *db.DB, orgID, createdBy, name string) (saID, saName string) {
+	t.Helper()
+	sa, err := database.CreateServiceAccount(context.Background(), db.CreateServiceAccountParams{
+		Name:      name,
+		OrgID:     orgID,
+		TeamID:    nil,
+		CreatedBy: createdBy,
+	})
+	if err != nil {
+		t.Fatalf("seedSAForAudit(%q): %v", name, err)
+	}
+	return sa.ID, sa.Name
+}
+
+// auditURL returns the URL for GET /api/v1/audit-logs with an optional org_id
+// query parameter.
+func auditURL(orgID string) string {
+	if orgID == "" {
+		return "/api/v1/audit-logs"
+	}
+	return "/api/v1/audit-logs?org_id=" + orgID
+}
+
+// ---- actor_name resolution in GET /api/v1/audit-logs ------------------------
+
+// TestListAuditLogs_ActorName_User verifies that a "user" actor event returns
+// actor_name equal to the user's display_name when the user is a member of the
+// queried org (org_admin path uses org-scoped resolution).
+func TestListAuditLogs_ActorName_User(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestListAuditLogs_ActorName_User?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Actor Name Org", "actor-name-org-user")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	user := mustCreateUser(t, database, "actor-user@example.com", "Alice Auditperson")
+	// org_admin resolution only resolves users who are org members; add the membership.
+	mustCreateOrgMembership(t, database, org.ID, user.ID, "member")
+	insertAuditLogDirect(t, database, "audit-user-1", org.ID, user.ID, "user", "create", "model")
+
+	req := httptest.NewRequest("GET", auditURL(org.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []map[string]any `json:"data"`
+	}
+	decodeBody(t, resp.Body, &envelope)
+
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one event")
+	}
+
+	row := envelope.Data[0]
+	if row["actor_type"] != "user" {
+		t.Fatalf("actor_type = %q, want %q", row["actor_type"], "user")
+	}
+	if row["actor_name"] != "Alice Auditperson" {
+		t.Errorf("actor_name = %v, want %q (user display_name)", row["actor_name"], "Alice Auditperson")
+	}
+}
+
+// TestListAuditLogs_ActorName_ServiceAccount verifies that a "service_account"
+// actor event returns actor_name equal to the service account's name.
+func TestListAuditLogs_ActorName_ServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestListAuditLogs_ActorName_SA?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "SA Actor Org", "actor-name-org-sa")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	creator := mustCreateUser(t, database, "sa-creator@example.com", "SA Creator")
+	saID, saName := seedSAForAudit(t, database, org.ID, creator.ID, "Deploy Bot")
+	insertAuditLogDirect(t, database, "audit-sa-1", org.ID, saID, "service_account", "update", "model")
+
+	req := httptest.NewRequest("GET", auditURL(org.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []map[string]any `json:"data"`
+	}
+	decodeBody(t, resp.Body, &envelope)
+
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one event")
+	}
+
+	row := envelope.Data[0]
+	if row["actor_type"] != "service_account" {
+		t.Fatalf("actor_type = %q, want %q", row["actor_type"], "service_account")
+	}
+	if row["actor_name"] != saName {
+		t.Errorf("actor_name = %v, want %q (service account name)", row["actor_name"], saName)
+	}
+}
+
+// TestListAuditLogs_ActorName_System verifies that a "system" actor event has
+// no actor_name key in the JSON response (omitempty — key must be absent).
+func TestListAuditLogs_ActorName_System(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestListAuditLogs_ActorName_System?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "System Actor Org", "actor-name-org-system")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	// system actor has no actor_id in the DB (stored as empty string).
+	insertAuditLogDirect(t, database, "audit-sys-1", org.ID, "", "system", "delete", "org")
+
+	req := httptest.NewRequest("GET", auditURL(org.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []map[string]any `json:"data"`
+	}
+	decodeBody(t, resp.Body, &envelope)
+
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one event")
+	}
+
+	row := envelope.Data[0]
+	if row["actor_type"] != "system" {
+		t.Fatalf("actor_type = %q, want %q", row["actor_type"], "system")
+	}
+	if _, present := row["actor_name"]; present {
+		t.Errorf("actor_name must be absent (omitempty) for system actor, but found: %v", row["actor_name"])
+	}
+}
+
+// TestListAuditLogs_ActorName_UnknownActorID verifies that when an event's
+// actor_id does not match any row in the resolved tables, the response is 200
+// and actor_name is absent from that event's JSON.
+func TestListAuditLogs_ActorName_UnknownActorID(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestListAuditLogs_ActorName_Unknown?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Unknown Actor Org", "actor-name-org-unknown")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	// Insert event whose actor_id does not correspond to any user row.
+	const ghostUserID = "00000000-0000-0000-0000-000000009999"
+	insertAuditLogDirect(t, database, "audit-ghost-1", org.ID, ghostUserID, "user", "create", "key")
+
+	req := httptest.NewRequest("GET", auditURL(org.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []map[string]any `json:"data"`
+	}
+	decodeBody(t, resp.Body, &envelope)
+
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one event")
+	}
+
+	row := envelope.Data[0]
+	if row["actor_id"] != ghostUserID {
+		t.Fatalf("actor_id = %v, want %q", row["actor_id"], ghostUserID)
+	}
+	if _, present := row["actor_name"]; present {
+		t.Errorf("actor_name must be absent when actor_id has no matching row, but found: %v", row["actor_name"])
+	}
+}
+
+// TestListAuditLogs_ActorName_TableDriven exercises all actor_name resolution
+// paths in a single table-driven test.
+func TestListAuditLogs_ActorName_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		actorType      string
+		setup          func(t *testing.T, database *db.DB, orgID string) (actorID string)
+		wantActorName  string
+		wantNameAbsent bool
+	}{
+		{
+			name:      "user actor returns display_name",
+			actorType: "user",
+			setup: func(t *testing.T, database *db.DB, orgID string) string {
+				t.Helper()
+				u := mustCreateUser(t, database, "td-user@example.com", "TD User Name")
+				// org_admin resolution requires the user to be a member of the org.
+				mustCreateOrgMembership(t, database, orgID, u.ID, "member")
+				return u.ID
+			},
+			wantActorName: "TD User Name",
+		},
+		{
+			name:      "service_account actor returns sa name",
+			actorType: "service_account",
+			setup: func(t *testing.T, database *db.DB, orgID string) string {
+				t.Helper()
+				creator := mustCreateUser(t, database, "td-sa-creator@example.com", "SA Creator")
+				saID, _ := seedSAForAudit(t, database, orgID, creator.ID, "TD SA Name")
+				return saID
+			},
+			wantActorName: "TD SA Name",
+		},
+		{
+			name:      "system actor has no actor_name",
+			actorType: "system",
+			setup: func(t *testing.T, _ *db.DB, _ string) string {
+				return "" // system actors have no actor_id
+			},
+			wantNameAbsent: true,
+		},
+		{
+			name:      "user actor with unknown actor_id has no actor_name",
+			actorType: "user",
+			setup: func(t *testing.T, _ *db.DB, _ string) string {
+				return "00000000-0000-0000-0000-dead00000001"
+			},
+			wantNameAbsent: true,
+		},
+		{
+			name:      "service_account actor with unknown actor_id has no actor_name",
+			actorType: "service_account",
+			setup: func(t *testing.T, _ *db.DB, _ string) string {
+				return "00000000-0000-0000-0000-dead00000002"
+			},
+			wantNameAbsent: true,
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dsn := fmt.Sprintf("file:TestListAuditLogs_TD_%d?mode=memory&cache=private", i)
+			app, database, keyCache := setupTestApp(t, dsn)
+			org := mustCreateOrg(t, database, "TD Org", fmt.Sprintf("audit-td-org-%d", i))
+			testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+			actorID := tc.setup(t, database, org.ID)
+			auditID := fmt.Sprintf("audit-td-%d", i)
+			insertAuditLogDirect(t, database, auditID, org.ID, actorID, tc.actorType, "create", "key")
+
+			req := httptest.NewRequest("GET", auditURL(org.ID), nil)
+			req.Header.Set("Authorization", "Bearer "+testKey)
+
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+			if err != nil {
+				t.Fatalf("app.Test: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != fiber.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+			}
+
+			var envelope struct {
+				Data []map[string]any `json:"data"`
+			}
+			decodeBody(t, resp.Body, &envelope)
+
+			if len(envelope.Data) == 0 {
+				t.Fatal("data is empty, want at least one event")
+			}
+
+			row := envelope.Data[0]
+
+			if tc.wantNameAbsent {
+				if _, present := row["actor_name"]; present {
+					t.Errorf("actor_name must be absent (omitempty) for %s actor with no match, but found: %v",
+						tc.actorType, row["actor_name"])
+				}
+				return
+			}
+
+			actorName, _ := row["actor_name"].(string)
+			if actorName != tc.wantActorName {
+				t.Errorf("actor_name = %q, want %q", actorName, tc.wantActorName)
+			}
+		})
+	}
+}
+
+// TestListAuditLogs_ActorName_ResponseIsValidJSON verifies that the full
+// response can be decoded into the typed auditEventResponse-shaped struct and
+// that actor_name is populated in the typed fields too.
+func TestListAuditLogs_ActorName_ResponseIsValidJSON(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestListAuditLogs_ActorName_JSON?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "JSON Org", "actor-name-org-json")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	user := mustCreateUser(t, database, "json-user@example.com", "JSON User")
+	// org_admin resolution requires the user to be a member of the org.
+	mustCreateOrgMembership(t, database, org.ID, user.ID, "member")
+	insertAuditLogDirect(t, database, "audit-json-1", org.ID, user.ID, "user", "create", "team")
+
+	req := httptest.NewRequest("GET", auditURL(org.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	type auditEventShape struct {
+		ID           string `json:"id"`
+		Timestamp    string `json:"timestamp"`
+		OrgID        string `json:"org_id"`
+		ActorID      string `json:"actor_id"`
+		ActorType    string `json:"actor_type"`
+		ActorName    string `json:"actor_name"`
+		Action       string `json:"action"`
+		ResourceType string `json:"resource_type"`
+		StatusCode   int    `json:"status_code"`
+	}
+
+	var envelope struct {
+		Data    []auditEventShape `json:"data"`
+		HasMore bool              `json:"has_more"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one event")
+	}
+
+	ev := envelope.Data[0]
+	if ev.OrgID != org.ID {
+		t.Errorf("org_id = %q, want %q", ev.OrgID, org.ID)
+	}
+	if ev.ActorID != user.ID {
+		t.Errorf("actor_id = %q, want %q", ev.ActorID, user.ID)
+	}
+	if ev.ActorType != "user" {
+		t.Errorf("actor_type = %q, want %q", ev.ActorType, "user")
+	}
+	if ev.ActorName != "JSON User" {
+		t.Errorf("actor_name = %q, want %q", ev.ActorName, "JSON User")
+	}
+	if ev.Timestamp == "" {
+		t.Error("timestamp is empty")
+	}
+	if ev.StatusCode != 200 {
+		t.Errorf("status_code = %d, want 200", ev.StatusCode)
+	}
+}
+
+// ---- org-aware actor resolution boundary (security fix) ----------------------
+
+// TestListAuditLogs_OrgAdmin_UserMemberResolves verifies that an org_admin
+// querying their own org sees actor_name for a user who IS a member of that org.
+func TestListAuditLogs_OrgAdmin_UserMemberResolves(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestListAuditLogs_OrgAdmin_UserMemberResolves?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Member Org", "org-admin-member-resolves")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	member := mustCreateUser(t, database, "member@example.com", "Member User")
+	mustCreateOrgMembership(t, database, org.ID, member.ID, "member")
+	insertAuditLogDirect(t, database, "audit-member-1", org.ID, member.ID, "user", "create", "key")
+
+	req := httptest.NewRequest("GET", auditURL(org.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []map[string]any `json:"data"`
+	}
+	decodeBody(t, resp.Body, &envelope)
+
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one event")
+	}
+	if name := envelope.Data[0]["actor_name"]; name != "Member User" {
+		t.Errorf("actor_name = %v, want %q (user is an org member)", name, "Member User")
+	}
+}
+
+// TestListAuditLogs_OrgAdmin_UserNonMemberAbsent verifies that an org_admin
+// querying their own org does NOT see actor_name for a user who is NOT a member
+// of that org (cross-org actor — the cross-org leak must stay closed).
+func TestListAuditLogs_OrgAdmin_UserNonMemberAbsent(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestListAuditLogs_OrgAdmin_UserNonMemberAbsent?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Target Org", "org-admin-nonmember-absent")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	// This user exists in the DB but has no membership in org — simulates a
+	// system_admin or a user from another org who performed an action logged here.
+	outsider := mustCreateUser(t, database, "outsider@example.com", "Outsider User")
+	insertAuditLogDirect(t, database, "audit-outsider-1", org.ID, outsider.ID, "user", "delete", "org")
+
+	req := httptest.NewRequest("GET", auditURL(org.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []map[string]any `json:"data"`
+	}
+	decodeBody(t, resp.Body, &envelope)
+
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one event")
+	}
+	row := envelope.Data[0]
+	if row["actor_id"] != outsider.ID {
+		t.Fatalf("actor_id = %v, want %q", row["actor_id"], outsider.ID)
+	}
+	// Cross-org user must NOT resolve — actor_name must be absent.
+	if _, present := row["actor_name"]; present {
+		t.Errorf("actor_name must be absent for cross-org user actor, but got: %v", row["actor_name"])
+	}
+}
+
+// TestListAuditLogs_OrgAdmin_SAInOrgResolves verifies that a service account
+// whose org_id matches the queried org resolves to its name for an org_admin.
+func TestListAuditLogs_OrgAdmin_SAInOrgResolves(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestListAuditLogs_OrgAdmin_SAInOrgResolves?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "SA Org", "org-admin-sa-in-org")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	creator := mustCreateUser(t, database, "sa-in-org-creator@example.com", "Creator")
+	saID, saName := seedSAForAudit(t, database, org.ID, creator.ID, "In-Org Bot")
+	insertAuditLogDirect(t, database, "audit-sa-inorg-1", org.ID, saID, "service_account", "create", "team")
+
+	req := httptest.NewRequest("GET", auditURL(org.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []map[string]any `json:"data"`
+	}
+	decodeBody(t, resp.Body, &envelope)
+
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one event")
+	}
+	if name := envelope.Data[0]["actor_name"]; name != saName {
+		t.Errorf("actor_name = %v, want %q (SA in same org)", name, saName)
+	}
+}
+
+// TestListAuditLogs_OrgAdmin_SAOutOfOrgAbsent verifies that a service account
+// whose org_id differs from the queried org does NOT resolve for an org_admin.
+func TestListAuditLogs_OrgAdmin_SAOutOfOrgAbsent(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestListAuditLogs_OrgAdmin_SAOutOfOrgAbsent?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Target Org", "org-admin-sa-out-of-org")
+	otherOrg := mustCreateOrg(t, database, "Other Org", "org-admin-sa-other-org")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	// SA belongs to otherOrg but has an event logged against org.
+	creator := mustCreateUser(t, database, "sa-other-org-creator@example.com", "Creator")
+	saID, _ := seedSAForAudit(t, database, otherOrg.ID, creator.ID, "Other-Org Bot")
+	insertAuditLogDirect(t, database, "audit-sa-outorg-1", org.ID, saID, "service_account", "delete", "key")
+
+	req := httptest.NewRequest("GET", auditURL(org.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []map[string]any `json:"data"`
+	}
+	decodeBody(t, resp.Body, &envelope)
+
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one event")
+	}
+	row := envelope.Data[0]
+	if row["actor_id"] != saID {
+		t.Fatalf("actor_id = %v, want %q", row["actor_id"], saID)
+	}
+	// SA from a different org must NOT resolve — actor_name must be absent.
+	if _, present := row["actor_name"]; present {
+		t.Errorf("actor_name must be absent for out-of-org SA, but got: %v", row["actor_name"])
+	}
+}
+
+// TestListAuditLogs_SystemAdmin_CrossOrgResolvesGlobally verifies that a
+// system_admin sees actor_name for a user who is NOT a member of the queried
+// org. system_admin uses global (unscoped) resolution by design.
+func TestListAuditLogs_SystemAdmin_CrossOrgResolvesGlobally(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestListAuditLogs_SystemAdmin_CrossOrg?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Some Org", "sysadmin-cross-org-resolve")
+	// system_admin key has no org affiliation (empty orgID).
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	// User exists but has no membership in org — cross-org actor.
+	crossOrgUser := mustCreateUser(t, database, "cross-org@example.com", "Cross Org User")
+	insertAuditLogDirect(t, database, "audit-cross-1", org.ID, crossOrgUser.ID, "user", "create", "model")
+
+	req := httptest.NewRequest("GET", auditURL(org.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []map[string]any `json:"data"`
+	}
+	decodeBody(t, resp.Body, &envelope)
+
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one event")
+	}
+	// system_admin is omniscient — cross-org actor must still resolve.
+	if name := envelope.Data[0]["actor_name"]; name != "Cross Org User" {
+		t.Errorf("actor_name = %v, want %q (system_admin resolves globally)", name, "Cross Org User")
+	}
+}

--- a/internal/api/admin/group_label_enrichment_test.go
+++ b/internal/api/admin/group_label_enrichment_test.go
@@ -1,0 +1,382 @@
+package admin_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/voidmind-io/voidllm/internal/auth"
+	"github.com/voidmind-io/voidllm/internal/cache"
+	"github.com/voidmind-io/voidllm/internal/db"
+	"github.com/voidmind-io/voidllm/pkg/keygen"
+)
+
+// systemUsageURL constructs the GET /api/v1/usage URL with the given query params.
+func systemUsageURL(from, to, groupBy string) string {
+	params := []string{}
+	if from != "" {
+		params = append(params, "from="+from)
+	}
+	if to != "" {
+		params = append(params, "to="+to)
+	}
+	if groupBy != "" {
+		params = append(params, "group_by="+groupBy)
+	}
+	u := "/api/v1/usage"
+	if len(params) > 0 {
+		u += "?" + strings.Join(params, "&")
+	}
+	return u
+}
+
+// myUsageURL constructs the GET /api/v1/usage/me URL with the given query params.
+func myUsageURL(from, to, groupBy string) string {
+	params := []string{}
+	if from != "" {
+		params = append(params, "from="+from)
+	}
+	if to != "" {
+		params = append(params, "to="+to)
+	}
+	if groupBy != "" {
+		params = append(params, "group_by="+groupBy)
+	}
+	u := "/api/v1/usage/me"
+	if len(params) > 0 {
+		u += "?" + strings.Join(params, "&")
+	}
+	return u
+}
+
+// insertMCPToolCallWithUserHTTP inserts a mcp_tool_calls row with a specific
+// user_id so that group_by=user label resolution can be tested.
+func insertMCPToolCallWithUserHTTP(t *testing.T, database *db.DB, id, userID, orgID, serverAlias, toolName string, createdAt time.Time) {
+	t.Helper()
+	query := fmt.Sprintf(
+		`INSERT INTO mcp_tool_calls
+			(id, key_id, key_type, org_id, user_id,
+			 server_alias, tool_name, duration_ms, status, code_mode, created_at)
+		 VALUES
+			('%s', 'key-mcp-user', 'user_key', '%s', '%s',
+			 '%s', '%s', 100, 'success', 0, '%s')`,
+		id, orgID, userID,
+		serverAlias, toolName,
+		createdAt.UTC().Format(time.RFC3339),
+	)
+	if _, err := database.SQL().ExecContext(context.Background(), query); err != nil {
+		t.Fatalf("insertMCPToolCallWithUserHTTP id=%q: %v", id, err)
+	}
+}
+
+// addTestKeyWithIDAndUserAndOrg generates a key with a specific key ID, user ID,
+// and org ID in the cache. Used to seed MyUsage tests where the handler uses
+// keyInfo.UserID and keyInfo.ID to build the scoped filter.
+func addTestKeyWithIDAndUserAndOrg(t *testing.T, keyCache *cache.Cache[string, auth.KeyInfo], role, orgID, keyID, userID string) string {
+	t.Helper()
+
+	plaintext, err := keygen.Generate(keygen.KeyTypeUser)
+	if err != nil {
+		t.Fatalf("generate test key: %v", err)
+	}
+
+	hash := keygen.Hash(plaintext, testHMACSecret)
+	keyCache.Set(hash, auth.KeyInfo{
+		ID:      keyID,
+		KeyType: keygen.KeyTypeUser,
+		Role:    role,
+		OrgID:   orgID,
+		UserID:  userID,
+		Name:    "test key " + role,
+	})
+
+	return plaintext
+}
+
+// ---- SystemAdminUsage group_label enrichment tests ---------------------------
+
+// TestSystemAdminUsage_GroupByUser_HasGroupLabel verifies that the system-wide
+// GET /api/v1/usage endpoint sets group_label to the user's display_name when
+// group_by=user and a matching user row exists.
+func TestSystemAdminUsage_GroupByUser_HasGroupLabel(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestSysUsage_GBUser_Label?mode=memory&cache=private")
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	// Create a real user whose ID will appear in usage_events.user_id.
+	user, err := database.CreateUser(context.Background(), db.CreateUserParams{
+		Email:       "sys-usage-user@example.com",
+		DisplayName: "System Usage User",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	now := time.Now().UTC()
+	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Minute).Format(time.RFC3339)
+
+	// Seed a usage event referencing the created user's ID.
+	insertUsageEventWithUserHTTP(t, database, "sys-gl-user-1", "key-sys-user", user.ID, "org-sys-user", "gpt-4",
+		300, now.Add(-30*time.Minute))
+
+	req := httptest.NewRequest("GET", systemUsageURL(from, to, "user"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []struct {
+			GroupKey   string `json:"group_key"`
+			GroupLabel string `json:"group_label"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one row")
+	}
+
+	// Find the data point whose group_key matches our user's ID.
+	var found bool
+	for _, row := range envelope.Data {
+		if row.GroupKey == user.ID {
+			found = true
+			if row.GroupLabel != "System Usage User" {
+				t.Errorf("group_label = %q, want %q", row.GroupLabel, "System Usage User")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("no data point with group_key = %q; all keys: %v", user.ID, envelope.Data)
+	}
+}
+
+// TestSystemAdminUsage_GroupByOrg_HasGroupLabel verifies that the system-wide
+// GET /api/v1/usage endpoint sets group_label to the org's name when
+// group_by=org and a matching org row exists.
+func TestSystemAdminUsage_GroupByOrg_HasGroupLabel(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestSysUsage_GBOrg_Label?mode=memory&cache=private")
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	// Create a real org so ResolveGroupLabels can find it by ID.
+	org := mustCreateOrg(t, database, "Known Org Name", "known-org-name")
+
+	now := time.Now().UTC()
+	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Minute).Format(time.RFC3339)
+
+	// Seed a usage event in that org.
+	insertUsageEventHTTP(t, database, "sys-gl-org-1", "key-sys-org", "", org.ID, "gpt-4",
+		100, 50, 150, now.Add(-30*time.Minute))
+
+	req := httptest.NewRequest("GET", systemUsageURL(from, to, "org"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []struct {
+			GroupKey   string `json:"group_key"`
+			GroupLabel string `json:"group_label"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one row")
+	}
+
+	var found bool
+	for _, row := range envelope.Data {
+		if row.GroupKey == org.ID {
+			found = true
+			if row.GroupLabel != "Known Org Name" {
+				t.Errorf("group_label = %q, want %q", row.GroupLabel, "Known Org Name")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("no data point with group_key = %q; all data: %v", org.ID, envelope.Data)
+	}
+}
+
+// ---- MyUsage group_label enrichment tests ------------------------------------
+
+// TestMyUsage_GroupByKey_HasGroupLabel verifies that GET /api/v1/usage/me with
+// group_by=key returns a data point whose group_label equals the key's Name when
+// the calling key has a user_id and the key exists in api_keys.
+func TestMyUsage_GroupByKey_HasGroupLabel(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestMyUsage_GBKey_Label?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "My Usage Org", "my-usage-org")
+
+	// Create a real user and a real api_key row so the label resolver finds them.
+	creator, err := database.CreateUser(context.Background(), db.CreateUserParams{
+		Email:       "my-usage-creator@example.com",
+		DisplayName: "My Usage Creator",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	apiKey, err := database.CreateAPIKey(context.Background(), db.CreateAPIKeyParams{
+		KeyHash:   "dummy-hash-my-usage-key",
+		KeyHint:   "vl_uk_...mu",
+		KeyType:   "user_key",
+		Name:      "My Labeled Key",
+		OrgID:     org.ID,
+		CreatedBy: creator.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+
+	// The test key in the cache must have UserID set (so MyUsage scopes by user_id)
+	// and have the same OrgID so the scoped query targets the right org.
+	testKey := addTestKeyWithIDAndUserAndOrg(t, keyCache, auth.RoleMember, org.ID, apiKey.ID, creator.ID)
+
+	now := time.Now().UTC()
+	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Minute).Format(time.RFC3339)
+
+	// Seed usage events with the user_id so that the scoped-by-user filter picks them up.
+	insertUsageEventWithUserHTTP(t, database, "my-gl-key-1", apiKey.ID, creator.ID, org.ID, "gpt-4",
+		150, now.Add(-30*time.Minute))
+
+	req := httptest.NewRequest("GET", myUsageURL(from, to, "key"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []struct {
+			GroupKey   string `json:"group_key"`
+			GroupLabel string `json:"group_label"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one row")
+	}
+
+	row := envelope.Data[0]
+	if row.GroupKey != apiKey.ID {
+		t.Errorf("group_key = %q, want %q", row.GroupKey, apiKey.ID)
+	}
+	if row.GroupLabel != "My Labeled Key" {
+		t.Errorf("group_label = %q, want %q", row.GroupLabel, "My Labeled Key")
+	}
+}
+
+// ---- GetSystemMCPUsage group_label enrichment tests -------------------------
+
+// TestGetSystemMCPUsage_GroupByUser_HasGroupLabel verifies that GET /api/v1/mcp-usage
+// with group_by=user sets group_label to the user's display_name when the user
+// row exists in the database.
+func TestGetSystemMCPUsage_GroupByUser_HasGroupLabel(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestSysMCPUsage_GBUser_Label?mode=memory&cache=private")
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	// Create a real user whose ID will appear in mcp_tool_calls.user_id.
+	user, err := database.CreateUser(context.Background(), db.CreateUserParams{
+		Email:       "mcp-sys-user@example.com",
+		DisplayName: "MCP System User",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	now := time.Now().UTC()
+	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Minute).Format(time.RFC3339)
+
+	// Seed an mcp_tool_calls row with the user's ID.
+	insertMCPToolCallWithUserHTTP(t, database, "sys-mcp-gl-user-1", user.ID, "org-mcp-sys", "server-a", "tool-x",
+		now.Add(-30*time.Minute))
+
+	req := httptest.NewRequest("GET", systemMCPUsageURL(from, to, "user"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []struct {
+			GroupKey   string `json:"group_key"`
+			GroupLabel string `json:"group_label"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one row")
+	}
+
+	var found bool
+	for _, row := range envelope.Data {
+		if row.GroupKey == user.ID {
+			found = true
+			if row.GroupLabel != "MCP System User" {
+				t.Errorf("group_label = %q, want %q", row.GroupLabel, "MCP System User")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("no data point with group_key = %q; all data: %v", user.ID, envelope.Data)
+	}
+}

--- a/internal/api/admin/mcp_usage.go
+++ b/internal/api/admin/mcp_usage.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"log/slog"
 	"time"
 
@@ -24,6 +25,7 @@ type mcpUsageResponse struct {
 // an MCP usage response.
 type mcpUsageDataPoint struct {
 	GroupKey      string  `json:"group_key,omitempty"`
+	GroupLabel    string  `json:"group_label,omitempty"`
 	TotalCalls    int64   `json:"total_calls"`
 	SuccessCount  int64   `json:"success_count"`
 	ErrorCount    int64   `json:"error_count"`
@@ -111,6 +113,7 @@ func mcpAggregatesToDataPoints(aggs []db.MCPUsageAggregate) []mcpUsageDataPoint 
 	for i, a := range aggs {
 		data[i] = mcpUsageDataPoint{
 			GroupKey:      a.GroupKey,
+			GroupLabel:    a.GroupLabel,
 			TotalCalls:    a.TotalCalls,
 			SuccessCount:  a.SuccessCount,
 			ErrorCount:    a.ErrorCount,
@@ -120,6 +123,41 @@ func mcpAggregatesToDataPoints(aggs []db.MCPUsageAggregate) []mcpUsageDataPoint 
 		}
 	}
 	return data
+}
+
+// enrichMCPGroupLabels resolves entity IDs in the MCP aggregates to
+// human-readable labels for key/user/team/org groupings, mutating each
+// aggregate's GroupLabel in place. Resolution failure is non-fatal: it logs a
+// warning and leaves labels empty so the response still returns the raw group
+// keys. Dimensions such as server, tool, and status are not resolvable and
+// ResolveGroupLabels returns an empty map for them — they remain label-less.
+//
+// ResolveGroupLabels is intentionally unscoped (no org filter). This is safe
+// because the group-key IDs come from MCP usage rows the proxy wrote with
+// org-scoped key context — a user/key/team ID present in an org's usage
+// necessarily belongs to that org. Resolving its display name (including
+// soft-deleted entities, for historical reporting) does not cross tenant
+// boundaries under normal operation.
+func (h *Handler) enrichMCPGroupLabels(ctx context.Context, groupBy string, aggs []db.MCPUsageAggregate) {
+	ids := make([]string, 0, len(aggs))
+	for _, a := range aggs {
+		ids = append(ids, a.GroupKey)
+	}
+
+	labels, err := h.DB.ResolveGroupLabels(ctx, groupBy, ids)
+	if err != nil {
+		h.Log.WarnContext(ctx, "resolve usage group labels",
+			slog.String("group_by", groupBy),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	for i := range aggs {
+		if label, ok := labels[aggs[i].GroupKey]; ok {
+			aggs[i].GroupLabel = label
+		}
+	}
 }
 
 // GetOrgMCPUsage handles GET /api/v1/orgs/:org_id/mcp-usage.
@@ -164,6 +202,8 @@ func (h *Handler) GetOrgMCPUsage(c fiber.Ctx) error {
 		)
 		return apierror.InternalError(c, "failed to retrieve MCP usage data")
 	}
+
+	h.enrichMCPGroupLabels(c.Context(), groupBy, aggregates)
 
 	return c.JSON(mcpUsageResponse{
 		OrgID:   orgID,
@@ -215,6 +255,8 @@ func (h *Handler) GetSystemMCPUsage(c fiber.Ctx) error {
 		)
 		return apierror.InternalError(c, "failed to retrieve MCP usage data")
 	}
+
+	h.enrichMCPGroupLabels(c.Context(), groupBy, aggregates)
 
 	return c.JSON(mcpUsageResponse{
 		From:    from.UTC().Format(time.RFC3339),

--- a/internal/api/admin/mcp_usage_test.go
+++ b/internal/api/admin/mcp_usage_test.go
@@ -2,6 +2,7 @@ package admin_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http/httptest"
@@ -562,5 +563,189 @@ func TestGetSystemMCPUsage_MissingFrom_Returns400(t *testing.T) {
 	if resp.StatusCode != fiber.StatusBadRequest {
 		body, _ := io.ReadAll(resp.Body)
 		t.Errorf("status = %d, want 400; body: %s", resp.StatusCode, body)
+	}
+}
+
+// ---- MCP group_label enrichment tests ----------------------------------------
+
+// insertMCPToolCallWithKeyHTTP inserts a mcp_tool_calls row using a specific
+// key_id so the group_by=key label resolution can match an api_keys row.
+func insertMCPToolCallWithKeyHTTP(t *testing.T, database *db.DB, id, keyID, orgID, serverAlias, toolName string, createdAt time.Time) {
+	t.Helper()
+	query := fmt.Sprintf(
+		`INSERT INTO mcp_tool_calls
+			(id, key_id, key_type, org_id,
+			 server_alias, tool_name, duration_ms, status, code_mode, created_at)
+		 VALUES
+			('%s', '%s', 'user_key', '%s',
+			 '%s', '%s', 100, 'success', 0, '%s')`,
+		id, keyID, orgID,
+		serverAlias, toolName,
+		createdAt.UTC().Format(time.RFC3339),
+	)
+	if _, err := database.SQL().ExecContext(context.Background(), query); err != nil {
+		t.Fatalf("insertMCPToolCallWithKeyHTTP id=%q: %v", id, err)
+	}
+}
+
+// TestGetOrgMCPUsage_GroupByKey_HasGroupLabel verifies that when group_by=key
+// and the key exists in api_keys, each data point carries a populated
+// group_label matching the key name.
+func TestGetOrgMCPUsage_GroupByKey_HasGroupLabel(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestMCPUsage_GBKey_Label?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "MCP Key Label Org", "mcp-key-label-org")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	creator, err := database.CreateUser(context.Background(), db.CreateUserParams{
+		Email:       "mcp-key-label-creator@example.com",
+		DisplayName: "MCP Creator",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	apiKey, err := database.CreateAPIKey(context.Background(), db.CreateAPIKeyParams{
+		KeyHash:   "dummy-hash-mcp-key-label",
+		KeyHint:   "vl_uk_...mcp",
+		KeyType:   "user_key",
+		Name:      "MCP Named Key",
+		OrgID:     org.ID,
+		CreatedBy: creator.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+
+	now := time.Now().UTC()
+	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Minute).Format(time.RFC3339)
+
+	insertMCPToolCallWithKeyHTTP(t, database, "mcp-gl-key-1", apiKey.ID, org.ID, "server-a", "tool-x", now.Add(-30*time.Minute))
+
+	req := httptest.NewRequest("GET", mcpUsageURL(org.ID, from, to, "key"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []struct {
+			GroupKey   string `json:"group_key"`
+			GroupLabel string `json:"group_label"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one row")
+	}
+
+	row := envelope.Data[0]
+	if row.GroupKey != apiKey.ID {
+		t.Errorf("group_key = %q, want %q", row.GroupKey, apiKey.ID)
+	}
+	if row.GroupLabel != "MCP Named Key" {
+		t.Errorf("group_label = %q, want %q", row.GroupLabel, "MCP Named Key")
+	}
+}
+
+// TestGetOrgMCPUsage_GroupByServer_NoGroupLabel verifies that group_by=server
+// data points do NOT carry a group_label (server is not a resolvable dimension;
+// omitempty means the JSON key is absent).
+func TestGetOrgMCPUsage_GroupByServer_NoGroupLabel(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestMCPUsage_GBServer_NoLabel?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "MCP Server Label Org", "mcp-server-label-org")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	now := time.Now().UTC()
+	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Minute).Format(time.RFC3339)
+
+	insertMCPToolCallHTTP(t, database, "mcp-gl-srv-1", org.ID, "", "server-alpha", "tool-y", "success", 80, false, now.Add(-30*time.Minute))
+
+	req := httptest.NewRequest("GET", mcpUsageURL(org.ID, from, to, "server"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one row")
+	}
+
+	row := envelope.Data[0]
+	if _, hasLabel := row["group_label"]; hasLabel {
+		t.Errorf("group_label must be absent for group_by=server, but present: %v", row["group_label"])
+	}
+}
+
+// TestGetOrgMCPUsage_GroupByStatus_NoGroupLabel verifies that group_by=status
+// data points do NOT carry a group_label.
+func TestGetOrgMCPUsage_GroupByStatus_NoGroupLabel(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestMCPUsage_GBStatus_NoLabel?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "MCP Status Label Org", "mcp-status-label-org")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	now := time.Now().UTC()
+	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Minute).Format(time.RFC3339)
+
+	insertMCPToolCallHTTP(t, database, "mcp-gl-st-1", org.ID, "", "server-b", "tool-z", "success", 60, false, now.Add(-30*time.Minute))
+
+	req := httptest.NewRequest("GET", mcpUsageURL(org.ID, from, to, "status"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one row")
+	}
+
+	row := envelope.Data[0]
+	if _, hasLabel := row["group_label"]; hasLabel {
+		t.Errorf("group_label must be absent for group_by=status, but present: %v", row["group_label"])
 	}
 }

--- a/internal/api/admin/usage.go
+++ b/internal/api/admin/usage.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"log/slog"
 	"time"
 
@@ -22,6 +23,7 @@ type usageResponse struct {
 // usageDataPoint holds aggregated metrics for one group within a usage response.
 type usageDataPoint struct {
 	GroupKey         string  `json:"group_key,omitempty"`
+	GroupLabel       string  `json:"group_label,omitempty"`
 	TotalRequests    int64   `json:"total_requests"`
 	PromptTokens     int64   `json:"prompt_tokens"`
 	CompletionTokens int64   `json:"completion_tokens"`
@@ -145,6 +147,7 @@ func aggregatesToDataPoints(aggs []db.UsageAggregate) []usageDataPoint {
 	for i, a := range aggs {
 		data[i] = usageDataPoint{
 			GroupKey:         a.GroupKey,
+			GroupLabel:       a.GroupLabel,
 			TotalRequests:    a.TotalRequests,
 			PromptTokens:     a.PromptTokens,
 			CompletionTokens: a.CompletionTokens,
@@ -154,6 +157,38 @@ func aggregatesToDataPoints(aggs []db.UsageAggregate) []usageDataPoint {
 		}
 	}
 	return data
+}
+
+// enrichGroupLabels resolves entity IDs in the aggregates to human-readable
+// labels for key/user/team/org groupings, mutating each aggregate's GroupLabel
+// in place. Resolution failure is non-fatal: it logs a warning and leaves
+// labels empty so the response still returns the raw group keys.
+//
+// ResolveGroupLabels is intentionally unscoped (no org filter). This is safe
+// because the group-key IDs come from usage rows the proxy wrote with org-scoped
+// key context — a user/key/team ID present in an org's usage necessarily belongs
+// to that org. Resolving its display name (including soft-deleted entities, for
+// historical reporting) does not cross tenant boundaries under normal operation.
+func (h *Handler) enrichGroupLabels(ctx context.Context, groupBy string, aggs []db.UsageAggregate) {
+	ids := make([]string, 0, len(aggs))
+	for _, a := range aggs {
+		ids = append(ids, a.GroupKey)
+	}
+
+	labels, err := h.DB.ResolveGroupLabels(ctx, groupBy, ids)
+	if err != nil {
+		h.Log.WarnContext(ctx, "resolve usage group labels",
+			slog.String("group_by", groupBy),
+			slog.String("error", err.Error()),
+		)
+		return
+	}
+
+	for i := range aggs {
+		if label, ok := labels[aggs[i].GroupKey]; ok {
+			aggs[i].GroupLabel = label
+		}
+	}
 }
 
 // GetOrgUsage handles GET /api/v1/orgs/:org_id/usage.
@@ -198,6 +233,8 @@ func (h *Handler) GetOrgUsage(c fiber.Ctx) error {
 		)
 		return apierror.InternalError(c, "failed to retrieve usage data")
 	}
+
+	h.enrichGroupLabels(c.Context(), groupBy, aggregates)
 
 	return c.JSON(usageResponse{
 		OrgID:   orgID,
@@ -249,6 +286,8 @@ func (h *Handler) SystemAdminUsage(c fiber.Ctx) error {
 		)
 		return apierror.InternalError(c, "failed to retrieve usage data")
 	}
+
+	h.enrichGroupLabels(c.Context(), groupBy, aggregates)
 
 	return c.JSON(usageResponse{
 		From:    from.UTC().Format(time.RFC3339),
@@ -308,6 +347,8 @@ func (h *Handler) MyUsage(c fiber.Ctx) error {
 		)
 		return apierror.InternalError(c, "failed to retrieve usage data")
 	}
+
+	h.enrichGroupLabels(c.Context(), groupBy, aggregates)
 
 	return c.JSON(usageResponse{
 		OrgID:   keyInfo.OrgID,

--- a/internal/api/admin/usage_test.go
+++ b/internal/api/admin/usage_test.go
@@ -685,3 +685,305 @@ func TestGetOrgUsage_EventsOutsideRange_NotCounted(t *testing.T) {
 		t.Errorf("total_tokens = %v, want 150", totalTokens)
 	}
 }
+
+// insertUsageEventWithUserHTTP inserts a single usage_events row that includes
+// a user_id column so that group_by=user label resolution can be tested.
+func insertUsageEventWithUserHTTP(t *testing.T, database *db.DB, id, keyID, userID, orgID, modelName string, totalTokens int64, createdAt time.Time) {
+	t.Helper()
+	query := fmt.Sprintf(
+		`INSERT INTO usage_events
+			(id, key_id, key_type, org_id, user_id, model_name,
+			 prompt_tokens, completion_tokens, total_tokens, status_code, created_at)
+		 VALUES
+			('%s', '%s', 'user_key', '%s', '%s', '%s',
+			 0, %d, %d, 200, '%s')`,
+		id, keyID, orgID, userID, modelName,
+		totalTokens, totalTokens,
+		createdAt.UTC().Format(time.RFC3339),
+	)
+	if _, err := database.SQL().ExecContext(context.Background(), query); err != nil {
+		t.Fatalf("insertUsageEventWithUserHTTP id=%q: %v", id, err)
+	}
+}
+
+// ---- group_label enrichment tests -------------------------------------------
+
+// TestGetOrgUsage_GroupByKey_HasGroupLabel verifies that when group_by=key and
+// the key exists in api_keys, each data point carries a populated group_label.
+func TestGetOrgUsage_GroupByKey_HasGroupLabel(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestGetOrgUsage_GBKey_Label?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Key Label Org", "key-label-org")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	// Create a real user + api_key so ResolveGroupLabels can find it.
+	creator, err := database.CreateUser(context.Background(), db.CreateUserParams{
+		Email:       "key-label-creator@example.com",
+		DisplayName: "Creator",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	apiKey, err := database.CreateAPIKey(context.Background(), db.CreateAPIKeyParams{
+		KeyHash:   "dummy-hash-key-label-test",
+		KeyHint:   "vl_uk_...test",
+		KeyType:   "user_key",
+		Name:      "My Labeled Key",
+		OrgID:     org.ID,
+		CreatedBy: creator.ID,
+	})
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+
+	now := time.Now().UTC()
+	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Minute).Format(time.RFC3339)
+
+	// Insert a usage event whose key_id matches the real api_key row.
+	insertUsageEventHTTP(t, database, "gl-key-1", apiKey.ID, "", org.ID, "gpt-4",
+		100, 50, 150, now.Add(-30*time.Minute))
+
+	req := httptest.NewRequest("GET", usageURL(org.ID, from, to, "key"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []struct {
+			GroupKey   string `json:"group_key"`
+			GroupLabel string `json:"group_label"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one row")
+	}
+
+	row := envelope.Data[0]
+	if row.GroupKey != apiKey.ID {
+		t.Errorf("group_key = %q, want %q", row.GroupKey, apiKey.ID)
+	}
+	if row.GroupLabel != "My Labeled Key" {
+		t.Errorf("group_label = %q, want %q", row.GroupLabel, "My Labeled Key")
+	}
+}
+
+// TestGetOrgUsage_GroupByUser_HasGroupLabel verifies group_label is set for
+// group_by=user when the user exists in the users table.
+func TestGetOrgUsage_GroupByUser_HasGroupLabel(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestGetOrgUsage_GBUser_Label?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "User Label Org", "user-label-org")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	// Create a real user whose ID we'll embed in usage_events.user_id.
+	user, err := database.CreateUser(context.Background(), db.CreateUserParams{
+		Email:       "labeled-user@example.com",
+		DisplayName: "Labeled Display Name",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	now := time.Now().UTC()
+	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Minute).Format(time.RFC3339)
+
+	insertUsageEventWithUserHTTP(t, database, "gl-user-1", "key-gl-user", user.ID, org.ID, "gpt-4",
+		200, now.Add(-30*time.Minute))
+
+	req := httptest.NewRequest("GET", usageURL(org.ID, from, to, "user"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []struct {
+			GroupKey   string `json:"group_key"`
+			GroupLabel string `json:"group_label"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one row")
+	}
+
+	row := envelope.Data[0]
+	if row.GroupKey != user.ID {
+		t.Errorf("group_key = %q, want %q", row.GroupKey, user.ID)
+	}
+	if row.GroupLabel != "Labeled Display Name" {
+		t.Errorf("group_label = %q, want %q", row.GroupLabel, "Labeled Display Name")
+	}
+}
+
+// TestGetOrgUsage_GroupByModel_NoGroupLabel verifies that group_by=model data
+// points do NOT carry a group_label field (non-resolvable dimension; omitempty
+// means the JSON key must be absent entirely).
+func TestGetOrgUsage_GroupByModel_NoGroupLabel(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestGetOrgUsage_GBModel_NoLabel?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Model Label Org", "model-label-org")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	now := time.Now().UTC()
+	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Minute).Format(time.RFC3339)
+
+	insertUsageEventHTTP(t, database, "gl-model-1", "key-model", "", org.ID, "gpt-4o",
+		100, 50, 150, now.Add(-30*time.Minute))
+
+	req := httptest.NewRequest("GET", usageURL(org.ID, from, to, "model"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	// Decode into a raw map so we can detect the absence of "group_label".
+	var envelope struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one row")
+	}
+
+	row := envelope.Data[0]
+	if _, hasLabel := row["group_label"]; hasLabel {
+		t.Errorf("group_label must be absent for group_by=model (omitempty), but it is present: %v", row["group_label"])
+	}
+}
+
+// TestGetOrgUsage_GroupByDay_NoGroupLabel verifies that group_by=day data
+// points also do not carry a group_label (omitempty absent in JSON).
+func TestGetOrgUsage_GroupByDay_NoGroupLabel(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestGetOrgUsage_GBDay_NoLabel?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Day Label Org", "day-label-org")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	day := time.Date(2024, 4, 1, 12, 0, 0, 0, time.UTC)
+	from := time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+	to := time.Date(2024, 4, 1, 23, 59, 59, 0, time.UTC).Format(time.RFC3339)
+
+	insertUsageEventHTTP(t, database, "gl-day-1", "key-day", "", org.ID, "gpt-4",
+		50, 20, 70, day)
+
+	req := httptest.NewRequest("GET", usageURL(org.ID, from, to, "day"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one row")
+	}
+
+	row := envelope.Data[0]
+	if _, hasLabel := row["group_label"]; hasLabel {
+		t.Errorf("group_label must be absent for group_by=day (omitempty), but present: %v", row["group_label"])
+	}
+}
+
+// TestGetOrgUsage_GroupByKey_UnknownKeyID_NoGroupLabel verifies that when the
+// key_id in usage_events does not exist in api_keys, the data point has no
+// group_label (absent due to omitempty) and the request succeeds.
+func TestGetOrgUsage_GroupByKey_UnknownKeyID_NoGroupLabel(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestGetOrgUsage_GBKey_Unknown?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Unknown Key Org", "unknown-key-org")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	now := time.Now().UTC()
+	from := now.Add(-2 * time.Hour).Format(time.RFC3339)
+	to := now.Add(time.Minute).Format(time.RFC3339)
+
+	// Insert event whose key_id does not correspond to any api_keys row.
+	insertUsageEventHTTP(t, database, "gl-unk-1", "nonexistent-key-id", "", org.ID, "gpt-4",
+		100, 50, 150, now.Add(-30*time.Minute))
+
+	req := httptest.NewRequest("GET", usageURL(org.ID, from, to, "key"), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one row")
+	}
+
+	row := envelope.Data[0]
+	// group_key must be the raw ID; group_label must be absent (no entity found).
+	if row["group_key"] != "nonexistent-key-id" {
+		t.Errorf("group_key = %v, want %q", row["group_key"], "nonexistent-key-id")
+	}
+	if _, hasLabel := row["group_label"]; hasLabel {
+		t.Errorf("group_label must be absent when key is unknown, but present: %v", row["group_label"])
+	}
+}

--- a/internal/db/mcp_usage_queries.go
+++ b/internal/db/mcp_usage_queries.go
@@ -11,7 +11,12 @@ import (
 type MCPUsageAggregate struct {
 	// GroupKey is the value of the grouped column (e.g. server alias, tool name, date).
 	// It is empty when no grouping is requested.
-	GroupKey      string
+	GroupKey string
+	// GroupLabel is the resolved human-readable name for the entity identified by
+	// GroupKey (e.g. key name/hint, user display name, team name, org name).
+	// It is populated by the handler layer after the aggregate query, not by SQL.
+	// Empty for non-resolvable dimensions such as server, tool, status, day, or hour.
+	GroupLabel    string
 	TotalCalls    int64
 	SuccessCount  int64
 	ErrorCount    int64

--- a/internal/db/usage_labels.go
+++ b/internal/db/usage_labels.go
@@ -1,0 +1,203 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// labelResolveChunkSize is the maximum number of IDs processed per IN-list query.
+// Keeping this below the SQLite bind-parameter limit (~999) avoids driver errors at
+// high cardinality while still requiring very few round-trips in practice.
+const labelResolveChunkSize = 500
+
+// ResolveGroupLabels returns a map from entity ID to a human-readable display
+// label for the given usage groupBy dimension. The resolvable dimensions are
+// "key", "user", "team", "org", and "service_account"; for any other dimension
+// (model/day/hour/server/tool/status/"") it returns an empty, non-nil map.
+// Soft-deleted rows are intentionally included so historical usage still resolves
+// to a name. IDs not found are simply absent from the returned map.
+//
+// This is an UNSCOPED global lookup by id. Callers MUST pass only IDs already
+// constrained to the caller's authorized scope — this function does not enforce
+// tenant or org boundaries itself.
+func (d *DB) ResolveGroupLabels(ctx context.Context, groupBy string, ids []string) (map[string]string, error) {
+	if len(ids) == 0 {
+		return map[string]string{}, nil
+	}
+
+	// Map groupBy to a hardcoded (table, labelExpr) pair.
+	// User input never reaches the query string — only the switch selects the
+	// expressions, and IDs are always passed as bind parameters.
+	var table, labelExpr string
+	switch groupBy {
+	case "key":
+		table = "api_keys"
+		labelExpr = "CASE WHEN name != '' THEN name ELSE key_hint END"
+	case "user":
+		table = "users"
+		labelExpr = "display_name"
+	case "team":
+		table = "teams"
+		labelExpr = "name"
+	case "org":
+		table = "organizations"
+		labelExpr = "name"
+	case "service_account":
+		table = "service_accounts"
+		labelExpr = "name"
+	default:
+		// Non-resolvable dimension (model, day, hour, server, tool, status, "").
+		return map[string]string{}, nil
+	}
+
+	// De-duplicate and strip empty-string IDs (the coalesced "" placeholder for
+	// NULL group columns) — there is no row in any entity table with id = "".
+	filtered := deduplicateIDs(ids)
+
+	if len(filtered) == 0 {
+		return map[string]string{}, nil
+	}
+
+	result := make(map[string]string, len(filtered))
+
+	// Process IDs in chunks to stay below the DB bind-parameter limit.
+	for start := 0; start < len(filtered); start += labelResolveChunkSize {
+		end := start + labelResolveChunkSize
+		if end > len(filtered) {
+			end = len(filtered)
+		}
+		chunk := filtered[start:end]
+
+		placeholders := make([]string, len(chunk))
+		args := make([]any, len(chunk))
+		for i, id := range chunk {
+			placeholders[i] = d.dialect.Placeholder(i + 1)
+			args[i] = id
+		}
+
+		query := "SELECT id, " + labelExpr +
+			" FROM " + table +
+			" WHERE id IN (" + strings.Join(placeholders, ", ") + ")"
+
+		if err := d.queryLabelsInto(ctx, result, "ResolveGroupLabels "+groupBy, query, args...); err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}
+
+// ResolveOrgActorLabels resolves audit actor IDs to display labels, restricted to
+// actors that belong to the given organization. User IDs resolve to
+// users.display_name only when the user is a member of orgID (via org_memberships);
+// service-account IDs resolve to service_accounts.name only when scoped to orgID.
+// IDs outside the org are simply absent from the returned map. Chunked like
+// ResolveGroupLabels. Returns a non-nil map.
+//
+// This enforces tenant boundaries: only actors that belong to orgID are resolved.
+// It is safe to call with IDs collected from a cross-org audit query provided by
+// a system_admin; for org_admin callers pass only their own orgID.
+func (d *DB) ResolveOrgActorLabels(ctx context.Context, orgID string, userIDs, saIDs []string) (map[string]string, error) {
+	result := make(map[string]string)
+
+	// Resolve user IDs scoped to org via membership join.
+	filteredUsers := deduplicateIDs(userIDs)
+	for start := 0; start < len(filteredUsers); start += labelResolveChunkSize {
+		end := start + labelResolveChunkSize
+		if end > len(filteredUsers) {
+			end = len(filteredUsers)
+		}
+		chunk := filteredUsers[start:end]
+
+		// orgID occupies position 1; user IDs follow from position 2.
+		placeholders := make([]string, len(chunk))
+		args := make([]any, 1+len(chunk))
+		args[0] = orgID
+		for i, id := range chunk {
+			placeholders[i] = d.dialect.Placeholder(i + 2)
+			args[i+1] = id
+		}
+
+		query := "SELECT u.id, u.display_name" +
+			" FROM users u" +
+			" JOIN org_memberships m ON m.user_id = u.id" +
+			" WHERE m.org_id = " + d.dialect.Placeholder(1) +
+			" AND u.id IN (" + strings.Join(placeholders, ", ") + ")"
+
+		if err := d.queryLabelsInto(ctx, result, "ResolveOrgActorLabels", query, args...); err != nil {
+			return nil, err
+		}
+	}
+
+	// Resolve service-account IDs scoped to org.
+	filteredSAs := deduplicateIDs(saIDs)
+	for start := 0; start < len(filteredSAs); start += labelResolveChunkSize {
+		end := start + labelResolveChunkSize
+		if end > len(filteredSAs) {
+			end = len(filteredSAs)
+		}
+		chunk := filteredSAs[start:end]
+
+		// orgID occupies position 1; SA IDs follow from position 2.
+		placeholders := make([]string, len(chunk))
+		args := make([]any, 1+len(chunk))
+		args[0] = orgID
+		for i, id := range chunk {
+			placeholders[i] = d.dialect.Placeholder(i + 2)
+			args[i+1] = id
+		}
+
+		query := "SELECT id, name" +
+			" FROM service_accounts" +
+			" WHERE org_id = " + d.dialect.Placeholder(1) +
+			" AND id IN (" + strings.Join(placeholders, ", ") + ")"
+
+		if err := d.queryLabelsInto(ctx, result, "ResolveOrgActorLabels", query, args...); err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}
+
+// queryLabelsInto runs query with args, scanning each (id, label) row into dst.
+// It closes its rows before returning so chunked callers do not accumulate open
+// result sets across iterations. errCtx is prepended to any error message.
+func (d *DB) queryLabelsInto(ctx context.Context, dst map[string]string, errCtx, query string, args ...any) error {
+	rows, err := d.sql.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("%s: %w", errCtx, err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var id, label string
+		if err := rows.Scan(&id, &label); err != nil {
+			return fmt.Errorf("%s: %w", errCtx, err)
+		}
+		dst[id] = label
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("%s: %w", errCtx, err)
+	}
+	return nil
+}
+
+// deduplicateIDs returns a new slice with empty strings removed and duplicates
+// eliminated, preserving first-occurrence order.
+func deduplicateIDs(ids []string) []string {
+	seen := make(map[string]struct{}, len(ids))
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out
+}

--- a/internal/db/usage_labels_test.go
+++ b/internal/db/usage_labels_test.go
@@ -1,0 +1,888 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/voidmind-io/voidllm/pkg/keygen"
+)
+
+// ---- helpers -----------------------------------------------------------------
+
+// seedOrgForLabels creates an org and returns its ID and name.
+func seedOrgForLabels(t *testing.T, d *DB, name, slug string) (id, label string) {
+	t.Helper()
+	org := mustCreateOrg(t, d, CreateOrgParams{Name: name, Slug: slug})
+	return org.ID, org.Name
+}
+
+// seedUserForLabels creates a user and returns its ID and display_name.
+func seedUserForLabels(t *testing.T, d *DB, email, displayName string) (id, label string) {
+	t.Helper()
+	user := mustCreateUser(t, d, CreateUserParams{Email: email, DisplayName: displayName})
+	return user.ID, user.DisplayName
+}
+
+// seedTeamForLabels creates a team inside org and returns its ID and name.
+func seedTeamForLabels(t *testing.T, d *DB, orgID, name, slug string) (id, label string) {
+	t.Helper()
+	team := mustCreateTeam(t, d, CreateTeamParams{OrgID: orgID, Name: name, Slug: slug})
+	return team.ID, team.Name
+}
+
+// seedCreatorUser creates a minimal user to satisfy api_keys.created_by FK.
+// It uses the email as the unique discriminator so multiple calls per test
+// with the same email are idempotent at the DB level.
+func seedCreatorUser(t *testing.T, d *DB, email string) string {
+	t.Helper()
+	user := mustCreateUser(t, d, CreateUserParams{Email: email, DisplayName: "creator"})
+	return user.ID
+}
+
+// seedAPIKeyForLabels creates an API key and returns its ID, plus the expected
+// label (name if non-empty, else hint). createdBy must be a valid user ID.
+func seedAPIKeyForLabels(t *testing.T, d *DB, orgID, keyName, createdBy string) (id, label string) {
+	t.Helper()
+	plaintext := "vl_uk_deadbeefdeadbeefdeadbeefdeadbeefdeadbeef00"
+	params := CreateAPIKeyParams{
+		KeyHash:   keygen.Hash(plaintext+orgID+keyName, testHMACSecret),
+		KeyHint:   keygen.Hint(plaintext),
+		KeyType:   keygen.KeyTypeUser,
+		Name:      keyName,
+		OrgID:     orgID,
+		CreatedBy: createdBy,
+	}
+	key := mustCreateAPIKey(t, d, params)
+	if keyName != "" {
+		label = keyName
+	} else {
+		label = keygen.Hint(plaintext)
+	}
+	return key.ID, label
+}
+
+// ---- ResolveGroupLabels — non-resolvable dimensions --------------------------
+
+func TestResolveGroupLabels_NonResolvableDimensions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		groupBy string
+	}{
+		{name: "empty groupBy", groupBy: ""},
+		{name: "model", groupBy: "model"},
+		{name: "day", groupBy: "day"},
+		{name: "hour", groupBy: "hour"},
+		{name: "server", groupBy: "server"},
+		{name: "tool", groupBy: "tool"},
+		{name: "status", groupBy: "status"},
+		{name: "unknown value", groupBy: "unknown_xyz"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := openMigratedDB(t)
+
+			got, err := d.ResolveGroupLabels(context.Background(), tc.groupBy, []string{"any-id"})
+			if err != nil {
+				t.Fatalf("ResolveGroupLabels(%q) error = %v, want nil", tc.groupBy, err)
+			}
+			if got == nil {
+				t.Fatalf("ResolveGroupLabels(%q) returned nil map, want empty non-nil map", tc.groupBy)
+			}
+			if len(got) != 0 {
+				t.Errorf("ResolveGroupLabels(%q) len = %d, want 0; got: %v", tc.groupBy, len(got), got)
+			}
+		})
+	}
+}
+
+// ---- ResolveGroupLabels — empty / blank id inputs ----------------------------
+
+func TestResolveGroupLabels_EmptyIDsSlice(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+
+	for _, groupBy := range []string{"key", "user", "team", "org"} {
+		got, err := d.ResolveGroupLabels(context.Background(), groupBy, []string{})
+		if err != nil {
+			t.Fatalf("groupBy=%q empty ids error = %v, want nil", groupBy, err)
+		}
+		if got == nil {
+			t.Fatalf("groupBy=%q returned nil map, want empty non-nil map", groupBy)
+		}
+		if len(got) != 0 {
+			t.Errorf("groupBy=%q len = %d, want 0", groupBy, len(got))
+		}
+	}
+}
+
+func TestResolveGroupLabels_OnlyEmptyStringIDs(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+
+	for _, groupBy := range []string{"key", "user", "team", "org"} {
+		got, err := d.ResolveGroupLabels(context.Background(), groupBy, []string{"", "", ""})
+		if err != nil {
+			t.Fatalf("groupBy=%q all-empty ids error = %v, want nil", groupBy, err)
+		}
+		if got == nil {
+			t.Fatalf("groupBy=%q returned nil map, want empty non-nil map", groupBy)
+		}
+		if len(got) != 0 {
+			t.Errorf("groupBy=%q len = %d, want 0", groupBy, len(got))
+		}
+	}
+}
+
+// ---- ResolveGroupLabels — org dimension --------------------------------------
+
+func TestResolveGroupLabels_Org(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, d *DB) (ids []string, wantLabels map[string]string)
+		wantErr bool
+	}{
+		{
+			name: "single org resolves to name",
+			setup: func(t *testing.T, d *DB) ([]string, map[string]string) {
+				t.Helper()
+				id, label := seedOrgForLabels(t, d, "Acme Corp", "acme-corp-label-1")
+				return []string{id}, map[string]string{id: label}
+			},
+		},
+		{
+			name: "multiple orgs resolve correctly",
+			setup: func(t *testing.T, d *DB) ([]string, map[string]string) {
+				t.Helper()
+				id1, label1 := seedOrgForLabels(t, d, "Alpha Org", "alpha-org-label-1")
+				id2, label2 := seedOrgForLabels(t, d, "Beta Org", "beta-org-label-1")
+				return []string{id1, id2}, map[string]string{id1: label1, id2: label2}
+			},
+		},
+		{
+			name: "non-existent id is absent from result",
+			setup: func(t *testing.T, d *DB) ([]string, map[string]string) {
+				t.Helper()
+				id1, label1 := seedOrgForLabels(t, d, "Real Org", "real-org-label-1")
+				ghost := "00000000-0000-0000-0000-000000000099"
+				return []string{id1, ghost}, map[string]string{id1: label1}
+			},
+		},
+		{
+			name: "soft-deleted org still resolves",
+			setup: func(t *testing.T, d *DB) ([]string, map[string]string) {
+				t.Helper()
+				id, label := seedOrgForLabels(t, d, "Deleted Org", "deleted-org-label-1")
+				if err := d.DeleteOrg(context.Background(), id); err != nil {
+					t.Fatalf("DeleteOrg: %v", err)
+				}
+				return []string{id}, map[string]string{id: label}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := openMigratedDB(t)
+			ids, wantLabels := tc.setup(t, d)
+
+			got, err := d.ResolveGroupLabels(context.Background(), "org", ids)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("ResolveGroupLabels() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ResolveGroupLabels() error = %v, want nil", err)
+			}
+			if len(got) != len(wantLabels) {
+				t.Fatalf("len(got) = %d, want %d; got: %v", len(got), len(wantLabels), got)
+			}
+			for id, wantLabel := range wantLabels {
+				if got[id] != wantLabel {
+					t.Errorf("got[%q] = %q, want %q", id, got[id], wantLabel)
+				}
+			}
+		})
+	}
+}
+
+// ---- ResolveGroupLabels — user dimension -------------------------------------
+
+func TestResolveGroupLabels_User(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, d *DB) (ids []string, wantLabels map[string]string)
+	}{
+		{
+			name: "single user resolves to display_name",
+			setup: func(t *testing.T, d *DB) ([]string, map[string]string) {
+				t.Helper()
+				id, label := seedUserForLabels(t, d, "alice@example.com", "Alice Smith")
+				return []string{id}, map[string]string{id: label}
+			},
+		},
+		{
+			name: "multiple users resolve correctly",
+			setup: func(t *testing.T, d *DB) ([]string, map[string]string) {
+				t.Helper()
+				id1, label1 := seedUserForLabels(t, d, "bob@example.com", "Bob Jones")
+				id2, label2 := seedUserForLabels(t, d, "carol@example.com", "Carol White")
+				return []string{id1, id2}, map[string]string{id1: label1, id2: label2}
+			},
+		},
+		{
+			name: "non-existent user id is absent",
+			setup: func(t *testing.T, d *DB) ([]string, map[string]string) {
+				t.Helper()
+				id, label := seedUserForLabels(t, d, "dave@example.com", "Dave Brown")
+				ghost := "00000000-0000-0000-0000-000000000088"
+				return []string{id, ghost}, map[string]string{id: label}
+			},
+		},
+		{
+			name: "soft-deleted user still resolves",
+			setup: func(t *testing.T, d *DB) ([]string, map[string]string) {
+				t.Helper()
+				id, label := seedUserForLabels(t, d, "eve@example.com", "Eve Ghost")
+				if err := d.DeleteUser(context.Background(), id); err != nil {
+					t.Fatalf("DeleteUser: %v", err)
+				}
+				return []string{id}, map[string]string{id: label}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := openMigratedDB(t)
+			ids, wantLabels := tc.setup(t, d)
+
+			got, err := d.ResolveGroupLabels(context.Background(), "user", ids)
+			if err != nil {
+				t.Fatalf("ResolveGroupLabels(user) error = %v, want nil", err)
+			}
+			if len(got) != len(wantLabels) {
+				t.Fatalf("len(got) = %d, want %d; got: %v", len(got), len(wantLabels), got)
+			}
+			for id, wantLabel := range wantLabels {
+				if got[id] != wantLabel {
+					t.Errorf("got[%q] = %q, want %q", id, got[id], wantLabel)
+				}
+			}
+		})
+	}
+}
+
+// ---- ResolveGroupLabels — team dimension -------------------------------------
+
+func TestResolveGroupLabels_Team(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, d *DB) (ids []string, wantLabels map[string]string)
+	}{
+		{
+			name: "single team resolves to name",
+			setup: func(t *testing.T, d *DB) ([]string, map[string]string) {
+				t.Helper()
+				org := mustCreateOrg(t, d, CreateOrgParams{Name: "Org", Slug: "org-tm-single"})
+				id, label := seedTeamForLabels(t, d, org.ID, "Engineering", "engineering-tm-single")
+				return []string{id}, map[string]string{id: label}
+			},
+		},
+		{
+			name: "multiple teams resolve correctly",
+			setup: func(t *testing.T, d *DB) ([]string, map[string]string) {
+				t.Helper()
+				org := mustCreateOrg(t, d, CreateOrgParams{Name: "Org", Slug: "org-tm-multi"})
+				id1, label1 := seedTeamForLabels(t, d, org.ID, "Backend", "backend-tm-multi")
+				id2, label2 := seedTeamForLabels(t, d, org.ID, "Frontend", "frontend-tm-multi")
+				return []string{id1, id2}, map[string]string{id1: label1, id2: label2}
+			},
+		},
+		{
+			name: "non-existent team id is absent",
+			setup: func(t *testing.T, d *DB) ([]string, map[string]string) {
+				t.Helper()
+				org := mustCreateOrg(t, d, CreateOrgParams{Name: "Org", Slug: "org-tm-ghost"})
+				id, label := seedTeamForLabels(t, d, org.ID, "Platform", "platform-tm-ghost")
+				ghost := "00000000-0000-0000-0000-000000000077"
+				return []string{id, ghost}, map[string]string{id: label}
+			},
+		},
+		{
+			name: "soft-deleted team still resolves",
+			setup: func(t *testing.T, d *DB) ([]string, map[string]string) {
+				t.Helper()
+				org := mustCreateOrg(t, d, CreateOrgParams{Name: "Org", Slug: "org-tm-deleted"})
+				id, label := seedTeamForLabels(t, d, org.ID, "Disbanded Team", "disbanded-tm-deleted")
+				if err := d.DeleteTeam(context.Background(), id); err != nil {
+					t.Fatalf("DeleteTeam: %v", err)
+				}
+				return []string{id}, map[string]string{id: label}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := openMigratedDB(t)
+			ids, wantLabels := tc.setup(t, d)
+
+			got, err := d.ResolveGroupLabels(context.Background(), "team", ids)
+			if err != nil {
+				t.Fatalf("ResolveGroupLabels(team) error = %v, want nil", err)
+			}
+			if len(got) != len(wantLabels) {
+				t.Fatalf("len(got) = %d, want %d; got: %v", len(got), len(wantLabels), got)
+			}
+			for id, wantLabel := range wantLabels {
+				if got[id] != wantLabel {
+					t.Errorf("got[%q] = %q, want %q", id, got[id], wantLabel)
+				}
+			}
+		})
+	}
+}
+
+// ---- ResolveGroupLabels — key dimension --------------------------------------
+
+func TestResolveGroupLabels_Key_WithName(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	org := mustCreateOrg(t, d, CreateOrgParams{Name: "Org", Slug: "org-key-named"})
+	creatorID := seedCreatorUser(t, d, "creator-key-named@example.com")
+
+	// Key with a non-empty name — label should be the name.
+	plaintext := "vl_uk_aabbccddaabbccddaabbccddaabbccddaabbccddaabb"
+	params := CreateAPIKeyParams{
+		KeyHash:   keygen.Hash(plaintext, testHMACSecret),
+		KeyHint:   keygen.Hint(plaintext),
+		KeyType:   keygen.KeyTypeUser,
+		Name:      "My Named Key",
+		OrgID:     org.ID,
+		CreatedBy: creatorID,
+	}
+	key := mustCreateAPIKey(t, d, params)
+
+	got, err := d.ResolveGroupLabels(context.Background(), "key", []string{key.ID})
+	if err != nil {
+		t.Fatalf("ResolveGroupLabels(key) error = %v, want nil", err)
+	}
+	if got[key.ID] != "My Named Key" {
+		t.Errorf("label = %q, want %q (key name)", got[key.ID], "My Named Key")
+	}
+}
+
+func TestResolveGroupLabels_Key_WithoutName_FallsBackToHint(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	org := mustCreateOrg(t, d, CreateOrgParams{Name: "Org", Slug: "org-key-unnamed"})
+	creatorID := seedCreatorUser(t, d, "creator-key-unnamed@example.com")
+
+	plaintext := "vl_uk_11223344112233441122334411223344112233441122"
+	hint := keygen.Hint(plaintext)
+	params := CreateAPIKeyParams{
+		KeyHash:   keygen.Hash(plaintext, testHMACSecret),
+		KeyHint:   hint,
+		KeyType:   keygen.KeyTypeUser,
+		Name:      "", // empty name
+		OrgID:     org.ID,
+		CreatedBy: creatorID,
+	}
+	key := mustCreateAPIKey(t, d, params)
+
+	got, err := d.ResolveGroupLabels(context.Background(), "key", []string{key.ID})
+	if err != nil {
+		t.Fatalf("ResolveGroupLabels(key) error = %v, want nil", err)
+	}
+	if got[key.ID] != hint {
+		t.Errorf("label = %q, want hint %q (name was empty)", got[key.ID], hint)
+	}
+}
+
+func TestResolveGroupLabels_Key_SoftDeleted_StillResolves(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	org := mustCreateOrg(t, d, CreateOrgParams{Name: "Org", Slug: "org-key-softdel"})
+	creatorID := seedCreatorUser(t, d, "creator-key-softdel@example.com")
+
+	plaintext := "vl_uk_ffeeddccffeeddccffeeddccffeeddccffeeddccffee"
+	params := CreateAPIKeyParams{
+		KeyHash:   keygen.Hash(plaintext, testHMACSecret),
+		KeyHint:   keygen.Hint(plaintext),
+		KeyType:   keygen.KeyTypeUser,
+		Name:      "Ghost Key",
+		OrgID:     org.ID,
+		CreatedBy: creatorID,
+	}
+	key := mustCreateAPIKey(t, d, params)
+
+	if err := d.DeleteAPIKey(context.Background(), key.ID); err != nil {
+		t.Fatalf("DeleteAPIKey: %v", err)
+	}
+
+	got, err := d.ResolveGroupLabels(context.Background(), "key", []string{key.ID})
+	if err != nil {
+		t.Fatalf("ResolveGroupLabels(key) soft-deleted error = %v, want nil", err)
+	}
+	if got[key.ID] != "Ghost Key" {
+		t.Errorf("label = %q, want %q (soft-deleted key must still resolve)", got[key.ID], "Ghost Key")
+	}
+}
+
+func TestResolveGroupLabels_Key_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		keyName     string
+		wantLabelFn func(hint string) string
+	}{
+		{
+			name:        "named key returns key name",
+			keyName:     "Production Key",
+			wantLabelFn: func(_ string) string { return "Production Key" },
+		},
+		{
+			name:        "unnamed key returns key hint",
+			keyName:     "",
+			wantLabelFn: func(hint string) string { return hint },
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := openMigratedDB(t)
+			org := mustCreateOrg(t, d, CreateOrgParams{
+				Name: "Org",
+				Slug: fmt.Sprintf("org-key-td-%d", i),
+			})
+			creatorID := seedCreatorUser(t, d, fmt.Sprintf("creator-key-td-%d@example.com", i))
+
+			// Use a unique plaintext per sub-test to avoid hash collisions.
+			plaintext := fmt.Sprintf("vl_uk_%048d", i)
+			hint := keygen.Hint(plaintext)
+
+			params := CreateAPIKeyParams{
+				KeyHash:   keygen.Hash(plaintext, testHMACSecret),
+				KeyHint:   hint,
+				KeyType:   keygen.KeyTypeUser,
+				Name:      tc.keyName,
+				OrgID:     org.ID,
+				CreatedBy: creatorID,
+			}
+			key := mustCreateAPIKey(t, d, params)
+
+			got, err := d.ResolveGroupLabels(context.Background(), "key", []string{key.ID})
+			if err != nil {
+				t.Fatalf("ResolveGroupLabels(key) error = %v, want nil", err)
+			}
+			wantLabel := tc.wantLabelFn(hint)
+			if got[key.ID] != wantLabel {
+				t.Errorf("label = %q, want %q", got[key.ID], wantLabel)
+			}
+		})
+	}
+}
+
+// ---- ResolveGroupLabels — service_account dimension -------------------------
+
+func TestResolveGroupLabels_ServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, d *DB) (ids []string, wantLabels map[string]string)
+	}{
+		{
+			name: "single service_account resolves to name",
+			setup: func(t *testing.T, d *DB) ([]string, map[string]string) {
+				t.Helper()
+				org := mustCreateOrg(t, d, CreateOrgParams{Name: "Org", Slug: "org-sa-single"})
+				creator := mustCreateUser(t, d, CreateUserParams{
+					Email:        "sa-creator-single@example.com",
+					DisplayName:  "Creator",
+					PasswordHash: testPasswordHash(t),
+					AuthProvider: "local",
+				})
+				sa := mustCreateServiceAccount(t, d, CreateServiceAccountParams{
+					Name:      "Deploy Bot",
+					OrgID:     org.ID,
+					CreatedBy: creator.ID,
+				})
+				return []string{sa.ID}, map[string]string{sa.ID: "Deploy Bot"}
+			},
+		},
+		{
+			name: "multiple service_accounts resolve correctly",
+			setup: func(t *testing.T, d *DB) ([]string, map[string]string) {
+				t.Helper()
+				org := mustCreateOrg(t, d, CreateOrgParams{Name: "Org", Slug: "org-sa-multi"})
+				creator := mustCreateUser(t, d, CreateUserParams{
+					Email:        "sa-creator-multi@example.com",
+					DisplayName:  "Creator",
+					PasswordHash: testPasswordHash(t),
+					AuthProvider: "local",
+				})
+				sa1 := mustCreateServiceAccount(t, d, CreateServiceAccountParams{
+					Name:      "CI Runner",
+					OrgID:     org.ID,
+					CreatedBy: creator.ID,
+				})
+				sa2 := mustCreateServiceAccount(t, d, CreateServiceAccountParams{
+					Name:      "Release Bot",
+					OrgID:     org.ID,
+					CreatedBy: creator.ID,
+				})
+				return []string{sa1.ID, sa2.ID}, map[string]string{sa1.ID: "CI Runner", sa2.ID: "Release Bot"}
+			},
+		},
+		{
+			name: "non-existent service_account id is absent",
+			setup: func(t *testing.T, d *DB) ([]string, map[string]string) {
+				t.Helper()
+				org := mustCreateOrg(t, d, CreateOrgParams{Name: "Org", Slug: "org-sa-ghost"})
+				creator := mustCreateUser(t, d, CreateUserParams{
+					Email:        "sa-creator-ghost@example.com",
+					DisplayName:  "Creator",
+					PasswordHash: testPasswordHash(t),
+					AuthProvider: "local",
+				})
+				sa := mustCreateServiceAccount(t, d, CreateServiceAccountParams{
+					Name:      "Real SA",
+					OrgID:     org.ID,
+					CreatedBy: creator.ID,
+				})
+				ghost := "00000000-0000-0000-0000-000000000066"
+				return []string{sa.ID, ghost}, map[string]string{sa.ID: "Real SA"}
+			},
+		},
+		{
+			name: "soft-deleted service_account still resolves",
+			setup: func(t *testing.T, d *DB) ([]string, map[string]string) {
+				t.Helper()
+				org := mustCreateOrg(t, d, CreateOrgParams{Name: "Org", Slug: "org-sa-deleted"})
+				creator := mustCreateUser(t, d, CreateUserParams{
+					Email:        "sa-creator-deleted@example.com",
+					DisplayName:  "Creator",
+					PasswordHash: testPasswordHash(t),
+					AuthProvider: "local",
+				})
+				sa := mustCreateServiceAccount(t, d, CreateServiceAccountParams{
+					Name:      "Decommissioned Bot",
+					OrgID:     org.ID,
+					CreatedBy: creator.ID,
+				})
+				if err := d.DeleteServiceAccount(context.Background(), sa.ID); err != nil {
+					t.Fatalf("DeleteServiceAccount: %v", err)
+				}
+				return []string{sa.ID}, map[string]string{sa.ID: "Decommissioned Bot"}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := openMigratedDB(t)
+			ids, wantLabels := tc.setup(t, d)
+
+			got, err := d.ResolveGroupLabels(context.Background(), "service_account", ids)
+			if err != nil {
+				t.Fatalf("ResolveGroupLabels(service_account) error = %v, want nil", err)
+			}
+			if len(got) != len(wantLabels) {
+				t.Fatalf("len(got) = %d, want %d; got: %v", len(got), len(wantLabels), got)
+			}
+			for id, wantLabel := range wantLabels {
+				if got[id] != wantLabel {
+					t.Errorf("got[%q] = %q, want %q", id, got[id], wantLabel)
+				}
+			}
+		})
+	}
+}
+
+// ---- ResolveGroupLabels — de-duplication -------------------------------------
+
+func TestResolveGroupLabels_Deduplication(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	id, _ := seedOrgForLabels(t, d, "Dedup Org", "dedup-org-label")
+
+	// Pass the same id three times — result must still have exactly one entry.
+	got, err := d.ResolveGroupLabels(context.Background(), "org", []string{id, id, id})
+	if err != nil {
+		t.Fatalf("ResolveGroupLabels error = %v, want nil", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("len(got) = %d, want 1 (same id passed three times)", len(got))
+	}
+}
+
+// ---- ResolveGroupLabels — mixed empty + valid IDs ----------------------------
+
+func TestResolveGroupLabels_EmptyStringIDsFiltered(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	id, label := seedOrgForLabels(t, d, "Mixed Org", "mixed-org-label")
+
+	// Pass empty strings mixed with a valid id.
+	got, err := d.ResolveGroupLabels(context.Background(), "org", []string{"", id, ""})
+	if err != nil {
+		t.Fatalf("ResolveGroupLabels error = %v, want nil", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(got) = %d, want 1", len(got))
+	}
+	if got[id] != label {
+		t.Errorf("got[%q] = %q, want %q", id, got[id], label)
+	}
+}
+
+// ---- ResolveGroupLabels — all four resolvable dimensions, table-driven -------
+
+func TestResolveGroupLabels_AllResolvableDimensions(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	// Seed one entity of each type.
+	orgID, orgLabel := seedOrgForLabels(t, d, "Dimension Org", "dimension-org-label")
+	userID, userLabel := seedUserForLabels(t, d, "dimension@example.com", "Dimension User")
+	teamID, teamLabel := seedTeamForLabels(t, d, orgID, "Dimension Team", "dimension-team-label")
+
+	creatorID := seedCreatorUser(t, d, "dimension-creator@example.com")
+	plaintext := "vl_uk_99887766998877669988776699887766998877669988"
+	keyParams := CreateAPIKeyParams{
+		KeyHash:   keygen.Hash(plaintext, testHMACSecret),
+		KeyHint:   keygen.Hint(plaintext),
+		KeyType:   keygen.KeyTypeUser,
+		Name:      "Dimension Key",
+		OrgID:     orgID,
+		CreatedBy: creatorID,
+	}
+	key := mustCreateAPIKey(t, d, keyParams)
+	keyLabel := "Dimension Key"
+
+	tests := []struct {
+		groupBy   string
+		id        string
+		wantLabel string
+	}{
+		{groupBy: "org", id: orgID, wantLabel: orgLabel},
+		{groupBy: "user", id: userID, wantLabel: userLabel},
+		{groupBy: "team", id: teamID, wantLabel: teamLabel},
+		{groupBy: "key", id: key.ID, wantLabel: keyLabel},
+	}
+
+	for _, tc := range tests {
+		t.Run("groupBy="+tc.groupBy, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := d.ResolveGroupLabels(ctx, tc.groupBy, []string{tc.id})
+			if err != nil {
+				t.Fatalf("ResolveGroupLabels(%q) error = %v, want nil", tc.groupBy, err)
+			}
+			if got[tc.id] != tc.wantLabel {
+				t.Errorf("label = %q, want %q", got[tc.id], tc.wantLabel)
+			}
+		})
+	}
+}
+
+// ---- ResolveOrgActorLabels ---------------------------------------------------
+
+// TestResolveOrgActorLabels exercises the org-scoped resolution used by the
+// org_admin audit log path.
+func TestResolveOrgActorLabels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, d *DB) (orgID string, userIDs, saIDs []string, wantLabels map[string]string)
+	}{
+		{
+			name: "member user resolves to display_name",
+			setup: func(t *testing.T, d *DB) (string, []string, []string, map[string]string) {
+				t.Helper()
+				org := mustCreateOrg(t, d, CreateOrgParams{Name: "Org", Slug: "orgl-member-user"})
+				user := mustCreateUser(t, d, CreateUserParams{Email: "orgl-member@example.com", DisplayName: "Member"})
+				mustCreateMembership(t, d, CreateOrgMembershipParams{OrgID: org.ID, UserID: user.ID, Role: "member"})
+				return org.ID, []string{user.ID}, nil, map[string]string{user.ID: "Member"}
+			},
+		},
+		{
+			name: "non-member user is absent",
+			setup: func(t *testing.T, d *DB) (string, []string, []string, map[string]string) {
+				t.Helper()
+				org := mustCreateOrg(t, d, CreateOrgParams{Name: "Org", Slug: "orgl-nonmember-user"})
+				// User exists but has no membership in org.
+				outsider := mustCreateUser(t, d, CreateUserParams{Email: "orgl-outsider@example.com", DisplayName: "Outsider"})
+				return org.ID, []string{outsider.ID}, nil, map[string]string{}
+			},
+		},
+		{
+			name: "SA in org resolves to name",
+			setup: func(t *testing.T, d *DB) (string, []string, []string, map[string]string) {
+				t.Helper()
+				org := mustCreateOrg(t, d, CreateOrgParams{Name: "Org", Slug: "orgl-sa-in-org"})
+				creator := mustCreateUser(t, d, CreateUserParams{Email: "orgl-sa-creator@example.com", DisplayName: "Creator"})
+				sa := mustCreateServiceAccount(t, d, CreateServiceAccountParams{
+					Name:      "In-Org SA",
+					OrgID:     org.ID,
+					CreatedBy: creator.ID,
+				})
+				return org.ID, nil, []string{sa.ID}, map[string]string{sa.ID: "In-Org SA"}
+			},
+		},
+		{
+			name: "SA in different org is absent",
+			setup: func(t *testing.T, d *DB) (string, []string, []string, map[string]string) {
+				t.Helper()
+				org := mustCreateOrg(t, d, CreateOrgParams{Name: "Target Org", Slug: "orgl-target-org"})
+				otherOrg := mustCreateOrg(t, d, CreateOrgParams{Name: "Other Org", Slug: "orgl-other-org"})
+				creator := mustCreateUser(t, d, CreateUserParams{Email: "orgl-other-creator@example.com", DisplayName: "Creator"})
+				sa := mustCreateServiceAccount(t, d, CreateServiceAccountParams{
+					Name:      "Other-Org SA",
+					OrgID:     otherOrg.ID,
+					CreatedBy: creator.ID,
+				})
+				return org.ID, nil, []string{sa.ID}, map[string]string{}
+			},
+		},
+		{
+			name: "empty inputs return empty non-nil map",
+			setup: func(t *testing.T, d *DB) (string, []string, []string, map[string]string) {
+				t.Helper()
+				org := mustCreateOrg(t, d, CreateOrgParams{Name: "Org", Slug: "orgl-empty-inputs"})
+				return org.ID, nil, nil, map[string]string{}
+			},
+		},
+		{
+			name: "member user and SA in same org both resolve",
+			setup: func(t *testing.T, d *DB) (string, []string, []string, map[string]string) {
+				t.Helper()
+				org := mustCreateOrg(t, d, CreateOrgParams{Name: "Org", Slug: "orgl-mixed-both"})
+				user := mustCreateUser(t, d, CreateUserParams{Email: "orgl-both-user@example.com", DisplayName: "Both User"})
+				mustCreateMembership(t, d, CreateOrgMembershipParams{OrgID: org.ID, UserID: user.ID, Role: "org_admin"})
+				creator := mustCreateUser(t, d, CreateUserParams{Email: "orgl-both-creator@example.com", DisplayName: "Creator"})
+				sa := mustCreateServiceAccount(t, d, CreateServiceAccountParams{
+					Name:      "Both SA",
+					OrgID:     org.ID,
+					CreatedBy: creator.ID,
+				})
+				return org.ID, []string{user.ID}, []string{sa.ID}, map[string]string{
+					user.ID: "Both User",
+					sa.ID:   "Both SA",
+				}
+			},
+		},
+		{
+			name: "cross-org user mixed with member — only member resolves",
+			setup: func(t *testing.T, d *DB) (string, []string, []string, map[string]string) {
+				t.Helper()
+				org := mustCreateOrg(t, d, CreateOrgParams{Name: "Org", Slug: "orgl-cross-org-mixed"})
+				member := mustCreateUser(t, d, CreateUserParams{Email: "orgl-cross-member@example.com", DisplayName: "Member"})
+				mustCreateMembership(t, d, CreateOrgMembershipParams{OrgID: org.ID, UserID: member.ID, Role: "member"})
+				outsider := mustCreateUser(t, d, CreateUserParams{Email: "orgl-cross-outsider@example.com", DisplayName: "Outsider"})
+				return org.ID, []string{member.ID, outsider.ID}, nil, map[string]string{member.ID: "Member"}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := openMigratedDB(t)
+			orgID, userIDs, saIDs, wantLabels := tc.setup(t, d)
+
+			got, err := d.ResolveOrgActorLabels(context.Background(), orgID, userIDs, saIDs)
+			if err != nil {
+				t.Fatalf("ResolveOrgActorLabels() error = %v, want nil", err)
+			}
+			if got == nil {
+				t.Fatal("ResolveOrgActorLabels() returned nil map, want non-nil")
+			}
+			if len(got) != len(wantLabels) {
+				t.Fatalf("len(got) = %d, want %d; got: %v", len(got), len(wantLabels), got)
+			}
+			for id, wantLabel := range wantLabels {
+				if got[id] != wantLabel {
+					t.Errorf("got[%q] = %q, want %q", id, got[id], wantLabel)
+				}
+			}
+		})
+	}
+}
+
+// ---- ResolveGroupLabels — chunking -------------------------------------------
+
+// TestResolveGroupLabels_Chunking seeds more than labelResolveChunkSize (500)
+// users and asserts that all of them are resolved in a single call. This proves
+// the chunking loop works correctly and does not drop entities at chunk
+// boundaries.
+func TestResolveGroupLabels_Chunking(t *testing.T) {
+	t.Parallel()
+
+	const count = 600 // deliberately exceeds the 500-ID chunk size
+
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	ids := make([]string, 0, count)
+	wantLabels := make(map[string]string, count)
+
+	for i := range count {
+		user := mustCreateUser(t, d, CreateUserParams{
+			Email:       fmt.Sprintf("chunk-user-%04d@example.com", i),
+			DisplayName: fmt.Sprintf("Chunk User %04d", i),
+		})
+		ids = append(ids, user.ID)
+		wantLabels[user.ID] = user.DisplayName
+	}
+
+	got, err := d.ResolveGroupLabels(ctx, "user", ids)
+	if err != nil {
+		t.Fatalf("ResolveGroupLabels() error = %v, want nil", err)
+	}
+	if len(got) != count {
+		t.Fatalf("len(got) = %d, want %d (chunking must not drop entries)", len(got), count)
+	}
+	for id, wantLabel := range wantLabels {
+		if got[id] != wantLabel {
+			t.Errorf("got[%q] = %q, want %q", id, got[id], wantLabel)
+		}
+	}
+}

--- a/internal/db/usage_queries.go
+++ b/internal/db/usage_queries.go
@@ -23,7 +23,12 @@ func coalesceSelectCol(groupCol string) string {
 type UsageAggregate struct {
 	// GroupKey is the value of the grouped column (e.g. model name, team ID, date).
 	// It is empty when no grouping is requested.
-	GroupKey         string
+	GroupKey string
+	// GroupLabel is the resolved human-readable name for the entity identified by
+	// GroupKey (e.g. key name/hint, user display name, team name, org name).
+	// It is populated by the handler layer after the aggregate query, not by SQL.
+	// Empty for non-resolvable dimensions such as model, day, or hour.
+	GroupLabel       string
 	TotalRequests    int64
 	PromptTokens     int64
 	CompletionTokens int64

--- a/ui/src/hooks/useAuditLog.ts
+++ b/ui/src/hooks/useAuditLog.ts
@@ -7,6 +7,7 @@ export interface AuditEvent {
   org_id: string
   actor_id: string
   actor_type: string
+  actor_name?: string
   actor_key_id: string
   action: string
   resource_type: string

--- a/ui/src/hooks/useMCPUsage.ts
+++ b/ui/src/hooks/useMCPUsage.ts
@@ -3,6 +3,7 @@ import apiClient from '../api/client'
 
 export interface MCPUsageDataPoint {
   group_key: string
+  group_label?: string
   total_calls: number
   success_count: number
   error_count: number

--- a/ui/src/hooks/useUsage.ts
+++ b/ui/src/hooks/useUsage.ts
@@ -3,6 +3,7 @@ import apiClient from '../api/client'
 
 export interface UsageDataPoint {
   group_key: string
+  group_label?: string
   total_requests: number
   prompt_tokens: number
   completion_tokens: number

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -31,3 +31,9 @@ export function formatCost(n: number): string {
 export function formatDate(iso: string): string {
   return new Date(iso).toLocaleString()
 }
+
+/** Truncate a UUID or long ID for use as a secondary display hint. */
+export function shortenId(id: string): string {
+  if (!id) return ''
+  return id.length <= 12 ? id : `${id.slice(0, 8)}…`
+}

--- a/ui/src/pages/AuditLogPage.tsx
+++ b/ui/src/pages/AuditLogPage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { shortenId } from '../lib/utils'
 import { PageHeader } from '../components/ui/PageHeader'
 import { Table } from '../components/ui/Table'
 import type { Column } from '../components/ui/Table'
@@ -127,16 +128,6 @@ function statusBadgeVariant(code: number): BadgeVariant {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function shortenId(id: string): string {
-  if (!id) return '—'
-  if (id.length <= 12) return id
-  return `${id.slice(0, 8)}…`
-}
-
-// ---------------------------------------------------------------------------
 // Table columns
 // ---------------------------------------------------------------------------
 
@@ -149,12 +140,19 @@ const columns: Column<AuditEvent>[] = [
   {
     key: 'actor',
     header: 'Actor',
-    render: (row) => (
-      <span className="font-mono text-xs text-text-secondary" title={row.actor_id}>
-        <span className="text-text-tertiary mr-1">{row.actor_type}</span>
-        {shortenId(row.actor_id)}
-      </span>
-    ),
+    render: (row) =>
+      row.actor_name ? (
+        <span className="flex items-center gap-1.5" title={row.actor_id}>
+          <span className="text-text-tertiary">{row.actor_type}</span>
+          <span className="text-text-secondary">{row.actor_name}</span>
+          <span className="font-mono text-xs text-text-tertiary">{shortenId(row.actor_id)}</span>
+        </span>
+      ) : (
+        <span className="font-mono text-xs text-text-secondary" title={row.actor_id}>
+          <span className="text-text-tertiary mr-1">{row.actor_type}</span>
+          {shortenId(row.actor_id)}
+        </span>
+      ),
   },
   {
     key: 'action',

--- a/ui/src/pages/usage/LLMUsagePage.tsx
+++ b/ui/src/pages/usage/LLMUsagePage.tsx
@@ -8,7 +8,7 @@ import { AreaChart, DonutChart, HorizontalBar } from '../../components/ui/charts
 import { useMe } from '../../hooks/useMe'
 import { useUsage, useCrossOrgUsage } from '../../hooks/useUsage'
 import type { UsageDataPoint } from '../../hooks/useUsage'
-import { formatNumber, formatTokens, formatCost } from '../../lib/utils'
+import { formatNumber, formatTokens, formatCost, shortenId } from '../../lib/utils'
 import { exportData } from '../../lib/export'
 
 const TIME_RANGES = ['24h', '7d', '30d', '90d'] as const
@@ -56,9 +56,17 @@ function buildColumns(groupBy: string): Column<UsageDataPoint>[] {
     {
       key: 'group_key',
       header: GROUP_BY_HEADERS[groupBy] ?? 'Group',
-      render: (row) => (
-        <span className="font-mono text-text-primary">{row.group_key}</span>
-      ),
+      render: (row) =>
+        row.group_label ? (
+          <span className="flex items-center gap-2">
+            <span className="text-text-primary">{row.group_label}</span>
+            <span className="font-mono text-xs text-text-tertiary" title={row.group_key}>
+              {shortenId(row.group_key)}
+            </span>
+          </span>
+        ) : (
+          <span className="font-mono text-text-primary">{row.group_key}</span>
+        ),
     },
     {
       key: 'total_requests',
@@ -113,6 +121,7 @@ function buildColumns(groupBy: string): Column<UsageDataPoint>[] {
 
 const USAGE_EXPORT_HEADERS = [
   { key: 'group_key', label: 'Group' },
+  { key: 'group_label', label: 'Name' },
   { key: 'total_requests', label: 'Requests' },
   { key: 'prompt_tokens', label: 'Prompt Tokens' },
   { key: 'completion_tokens', label: 'Completion Tokens' },
@@ -385,7 +394,7 @@ export default function LLMUsagePage() {
           <h3 className="text-sm font-semibold text-text-primary mb-4">Top by Tokens</h3>
           <HorizontalBar
             items={top5.map((d) => ({
-              label: d.group_key,
+              label: d.group_label || d.group_key,
               value: d.total_tokens,
               detail: formatTokens(d.total_tokens),
             }))}

--- a/ui/src/pages/usage/MCPUsagePage.tsx
+++ b/ui/src/pages/usage/MCPUsagePage.tsx
@@ -8,7 +8,7 @@ import { AreaChart, DonutChart, HorizontalBar } from '../../components/ui/charts
 import { useMe } from '../../hooks/useMe'
 import { useMCPUsage, useCrossOrgMCPUsage } from '../../hooks/useMCPUsage'
 import type { MCPUsageDataPoint } from '../../hooks/useMCPUsage'
-import { formatNumber } from '../../lib/utils'
+import { formatNumber, shortenId } from '../../lib/utils'
 import { exportData } from '../../lib/export'
 
 const TIME_RANGES = ['24h', '7d', '30d', '90d'] as const
@@ -60,9 +60,17 @@ function buildColumns(groupBy: string): Column<MCPUsageDataPoint>[] {
     {
       key: 'group_key',
       header: GROUP_BY_HEADERS[groupBy] ?? 'Group',
-      render: (row) => (
-        <span className="font-mono text-text-primary">{row.group_key}</span>
-      ),
+      render: (row) =>
+        row.group_label ? (
+          <span className="flex items-center gap-2">
+            <span className="text-text-primary">{row.group_label}</span>
+            <span className="font-mono text-xs text-text-tertiary" title={row.group_key}>
+              {shortenId(row.group_key)}
+            </span>
+          </span>
+        ) : (
+          <span className="font-mono text-text-primary">{row.group_key}</span>
+        ),
     },
     {
       key: 'total_calls',
@@ -121,6 +129,7 @@ function buildColumns(groupBy: string): Column<MCPUsageDataPoint>[] {
 
 const MCP_EXPORT_HEADERS = [
   { key: 'group_key', label: 'Group' },
+  { key: 'group_label', label: 'Name' },
   { key: 'total_calls', label: 'Total Calls' },
   { key: 'success_count', label: 'Success' },
   { key: 'error_count', label: 'Errors' },
@@ -421,7 +430,7 @@ export default function MCPUsagePage() {
             <h3 className="text-sm font-semibold text-text-primary mb-4">Top Servers by Calls</h3>
             <HorizontalBar
               items={topServers.map((d) => ({
-                label: d.group_key,
+                label: d.group_label || d.group_key,
                 value: d.total_calls,
                 detail: formatNumber(d.total_calls),
               }))}
@@ -432,7 +441,7 @@ export default function MCPUsagePage() {
             <h3 className="text-sm font-semibold text-text-primary mb-4">Top Tools by Calls</h3>
             <HorizontalBar
               items={topTools.map((d) => ({
-                label: d.group_key,
+                label: d.group_label || d.group_key,
                 value: d.total_calls,
                 detail: formatNumber(d.total_calls),
               }))}


### PR DESCRIPTION
## Summary

Usage analytics and the audit log previously displayed only raw entity UUIDs when referencing users, keys, teams, orgs, or audit actors. There was no way to tell which entity a row referred to without a separate Admin API lookup. This PR resolves those IDs to human-readable names across all three views.

Closes #124.

## Changes

### Usage analytics (LLM + MCP)
- New shared, chunked DB resolver `ResolveGroupLabels` mapping `key`/`user`/`team`/`org`/`service_account` IDs to display labels (key falls back to `key_hint`).
- New `group_label` (`omitempty`) on usage data points, populated for entity groupings; `model`/`day`/`hour`/`server`/`tool`/`status` stay label-less (already readable).
- UI shows the name with a shortened UUID hint (full UUID in tooltip). Charts and CSV/JSON export use the label too.

### Audit log
- New `actor_name` on audit events, resolved by `actor_type`.
- **Org-aware:** org admins only see names of actors belonging to their org (`ResolveOrgActorLabels`, scoped via `org_memberships` and `service_accounts.org_id`); system admins resolve globally by design. This closes a cross-org actor-identity disclosure found in review.

## Safety / privacy
- Resolution is **non-fatal**: on error the response still returns raw keys/IDs (logged at warn).
- Only metadata is surfaced (names, key hints) - never `email`, never prompt/response content. Consistent with the zero-knowledge design.
- SQL is parameterized; table/column come from a hardcoded switch. IN-lists are chunked (500) to stay under DB bind-parameter limits.
- Soft-deleted entities still resolve (intentional, for historical reporting).

## Testing & review
- Unit + handler tests for the resolver, label wiring, org-aware boundary (member resolves / non-member absent), and chunking (>500 entities). `go test`, `go vet`, UI type-check/lint/build all clean.
- Reviewed internally (code + security) and by two external models; all findings addressed.

## Commits
- `feat: resolve entity names in usage analytics (#124)`
- `feat: resolve actor names in audit log (#124)`

Kept as two commits so the usage (OSS) and audit-log (Enterprise) work can be split into separate PRs if preferred.
