### PR TITLE
chore: bump base images and Go to patch image CVEs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build UI (arch-independent, runs on build platform)
-FROM --platform=$BUILDPLATFORM node:20-alpine@sha256:42d1d5b07c84257b55d409f4e6e3be3b55d42867afce975a5648a3f231bf7e81 AS ui-builder
+FROM --platform=$BUILDPLATFORM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS ui-builder
 WORKDIR /app/ui
 COPY ui/package.json ui/package-lock.json ./
 RUN npm ci
@@ -7,7 +7,7 @@ COPY ui/ ./
 RUN npm run build
 
 # Stage 2: Build Go binary (cross-compiles on build platform)
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:d337ecb3075f0ec76d81652b3fa52af47c3eba6c8ba9f93b835752df7ce62946 AS go-builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS go-builder
 ARG TARGETOS
 ARG TARGETARCH
 RUN apk add --no-cache git
@@ -22,8 +22,9 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -o /voidllm ./cmd/voidllm
 
 # Stage 3: Runtime
-FROM alpine:3.21@sha256:22e0ec13c0db6b3e1ba3280e831fc50ba7bffe58e81f31670a64b1afede247bc
-RUN apk add --no-cache ca-certificates tzdata \
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
+RUN apk upgrade --no-cache \
+    && apk add --no-cache ca-certificates tzdata \
     && addgroup -S voidllm && adduser -S -G voidllm voidllm \
     && mkdir -p /data && chown voidllm:voidllm /data
 COPY --from=go-builder /voidllm /usr/local/bin/voidllm

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/voidmind-io/voidllm
 
-go 1.26.1
+go 1.26.4
 
 require (
 	github.com/bytedance/sonic v1.15.1


### PR DESCRIPTION
## Summary

Artifact Hub / Trivy flagged **36 vulnerabilities (2 critical, 23 high, 11 medium)** in `ghcr.io/voidmind-io/voidllm:0.0.20`. All of them are stale base-image and Go-toolchain packages - **no application code is affected**. This PR refreshes the pinned images so a rebuilt image carries the patched versions.

## Changes

| Pin | Before | After | Fixes |
|---|---|---|---|
| `golang:1.26-alpine` (builder) | Go 1.26.1 | Go 1.26.4 | 18 stdlib CVEs (CVE-2026-33810, -32280/1/2/3, -33811/14, -39820/3/5/6, -42499/504/507, -27145, -32288/9) |
| `alpine:3.21` (runtime) | 3.21.6 | 3.21.7 | libssl3/libcrypto3 → 3.3.7-r0 (incl. **critical** CVE-2026-31789), musl → 1.2.5-r11, zlib → 1.3.2-r0 |
| `node:20-alpine` (ui-builder) | refreshed | latest | hygiene |

Also:
- Added `apk upgrade --no-cache` to the runtime stage as a backstop, so OS package CVEs are patched at build time even if the base tag lags briefly.
- Bumped the `go.mod` go directive to `1.26.4`.
- Added the **`docker`** ecosystem to `dependabot.yml` so base-image digests get bumped automatically from now on (this class of finding should not recur).

## Verification

Built the image locally and confirmed every flagged package now meets its fixed-in version:
```
libcrypto3 3.3.7-r0   libssl3 3.3.7-r0
musl 1.2.5-r11        musl-utils 1.2.5-r11
zlib 1.3.2-r0
binary: go1.26.4
```
`go build ./...` clean.

## Publishing

The image is only built/pushed on a release tag, so these fixes ship with the **next release (0.0.21)** - the vulnerable `0.0.20` image stays as-is historically.
