### PR TITLE
chore: release 0.0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to VoidLLM are documented in this file.
 
+## [0.0.21] - 2026-06-19
+
+### Features
+- Usage analytics (LLM and MCP) and the audit log now resolve user, key, team, organization, and service-account IDs to human-readable names instead of showing raw UUIDs. Audit actor names are resolved org-scoped so cross-org identities are never exposed (#125)
+- The in-app "update available" dialog now renders release notes as formatted markdown instead of raw text (#132)
+
+### Fixes
+- Documentation: the README and pricing pages now show prices in EUR (matching billing) and list usage export as a Community feature, and the README gained an architecture overview, a "who it's for" section, and a production checklist (#131)
+
+### Security
+- Rebuilt the published container image on patched Alpine (3.21.7) and Go (1.26.4) to clear base-image and toolchain advisories. No application code changed (#126)
+
+### Dependencies
+- Go toolchain 1.26.1 → 1.26.4 and Alpine base image 3.21.6 → 3.21.7 (#126)
+
+---
+
 ## [0.0.20] - 2026-06-16
 
 ### Features

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 COPY --from=ui-builder /app/ui/dist ./ui/dist
-ARG VERSION=0.0.20
+ARG VERSION=0.0.21
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -ldflags="-s -w -X 'github.com/voidmind-io/voidllm/internal/api/health.Version=${VERSION}'" \
     -o /voidllm ./cmd/voidllm

--- a/chart/voidllm/Chart.yaml
+++ b/chart/voidllm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: voidllm
 description: Privacy-first LLM proxy and AI gateway with load balancing, RBAC, MCP gateway, and built-in admin UI. Self-hosted, single binary, sub-500us overhead.
 type: application
-version: 0.0.20
-appVersion: "0.0.20"
+version: 0.0.21
+appVersion: "0.0.21"
 home: https://voidllm.ai
 icon: https://voidllm.ai/logo.svg
 sources:

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -89,5 +89,5 @@ The Docker image sets `VOIDLLM_DATABASE_DSN=/data/voidllm.db` by default. Overri
 
 ```bash
 curl http://localhost:8080/healthz
-# {"status":"ok","uptime_seconds":42,"version":"0.0.20"}
+# {"status":"ok","uptime_seconds":42,"version":"0.0.21"}
 ```


### PR DESCRIPTION
Release 0.0.21. Bumps `CHANGELOG.md`, `Dockerfile` (`ARG VERSION`), `chart/voidllm/Chart.yaml` (version + appVersion), and the `docs/deployment/docker.md` healthz example.

Contents since v0.0.20:
- **Features** — human-readable entity names in usage analytics + audit log (org-scoped) (#125); markdown-rendered release notes in the update dialog (#132)
- **Fixes** — README/pricing documentation corrections (EUR, usage-export tier, architecture/who-it's-for/production-checklist) (#131)
- **Security** — container image rebuilt on patched Alpine 3.21.7 + Go 1.26.4 to clear base-image/toolchain advisories (#126)

Merge this, then push tag `v0.0.21` to trigger the image/binary build (held for confirmation).
