### PR TITLE
feat: PII anonymization (Stage 0a) — zero-knowledge de-tokenizer firewall

### DIFF
--- a/internal/api/admin/deployments.go
+++ b/internal/api/admin/deployments.go
@@ -28,6 +28,9 @@ type createDeploymentRequest struct {
 	GCPLocation string `json:"gcp_location"`
 	Weight      int    `json:"weight"`
 	Priority    int    `json:"priority"`
+	// PIIFilter explicitly enables or disables PII anonymization for requests
+	// routed to this deployment. Omit to inherit from the model or network default.
+	PIIFilter *bool `json:"pii_filter,omitempty"`
 }
 
 // updateDeploymentRequest is the JSON body accepted by updateDeployment.
@@ -45,6 +48,10 @@ type updateDeploymentRequest struct {
 	GCPLocation *string `json:"gcp_location"`
 	Weight      *int    `json:"weight"`
 	Priority    *int    `json:"priority"`
+	// PIIFilter, when non-nil, replaces the PII anonymization override for
+	// this deployment. Pass true to force anonymization on, false to force it off.
+	// Omit the field entirely to leave the existing setting unchanged.
+	PIIFilter *bool `json:"pii_filter"`
 }
 
 // deploymentResponse is the JSON representation of a deployment returned by the API.
@@ -64,8 +71,12 @@ type deploymentResponse struct {
 	Weight      int    `json:"weight"`
 	Priority    int    `json:"priority"`
 	IsActive    bool   `json:"is_active"`
-	CreatedAt   string `json:"created_at"`
-	UpdatedAt   string `json:"updated_at"`
+	// PIIFilter is the per-deployment PII anonymization override. Nil means
+	// inherit from the model-level or network-level default; true forces
+	// anonymization on; false forces it off.
+	PIIFilter *bool  `json:"pii_filter,omitempty"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
 }
 
 // deploymentAAD returns the additional authenticated data used when encrypting
@@ -90,6 +101,7 @@ func deploymentToResponse(d *db.Deployment) deploymentResponse {
 		Weight:          d.Weight,
 		Priority:        d.Priority,
 		IsActive:        d.IsActive,
+		PIIFilter:       d.PIIFilter,
 		CreatedAt:       d.CreatedAt,
 		UpdatedAt:       d.UpdatedAt,
 	}
@@ -173,6 +185,7 @@ func (h *Handler) createDeployment(c fiber.Ctx) error {
 		GCPLocation:     req.GCPLocation,
 		Weight:          req.Weight,
 		Priority:        req.Priority,
+		PIIFilter:       req.PIIFilter,
 	})
 	if err != nil {
 		if errors.Is(err, db.ErrConflict) {
@@ -283,6 +296,10 @@ func (h *Handler) updateDeployment(c fiber.Ctx) error {
 	if err := c.Bind().JSON(&req); err != nil {
 		return apierror.BadRequest(c, "invalid request body")
 	}
+	// Capture body bytes for field-presence detection before any further
+	// processing. c.Body() is safe to call after Bind().JSON() in Fiber v3.
+	rawBody := append([]byte(nil), c.Body()...)
+	piiPresent, piiIsNull := parsePIIFilterField(rawBody)
 
 	if req.Provider != nil && !provider.ValidProviders[*req.Provider] {
 		return apierror.BadRequest(c, "provider must be one of: "+strings.Join(provider.Names(), ", "))
@@ -305,6 +322,20 @@ func (h *Handler) updateDeployment(c fiber.Ctx) error {
 		return apierror.Send(c, fiber.StatusNotFound, "not_found", "deployment not found")
 	}
 
+	// Resolve the tri-state pii_filter semantics:
+	//   - key absent in JSON  → do not touch the column (piiPresent=false)
+	//   - key present, null   → clear column to NULL    (piiIsNull=true)
+	//   - key present, bool   → write the bool value
+	var piiFilter *bool
+	var clearPIIFilter bool
+	if piiPresent {
+		if piiIsNull {
+			clearPIIFilter = true
+		} else {
+			piiFilter = req.PIIFilter
+		}
+	}
+
 	params := db.UpdateDeploymentParams{
 		Name:            req.Name,
 		Provider:        req.Provider,
@@ -315,6 +346,8 @@ func (h *Handler) updateDeployment(c fiber.Ctx) error {
 		GCPLocation:     req.GCPLocation,
 		Weight:          req.Weight,
 		Priority:        req.Priority,
+		PIIFilter:       piiFilter,
+		ClearPIIFilter:  clearPIIFilter,
 	}
 
 	if req.APIKey != nil {

--- a/internal/api/admin/deployments.go
+++ b/internal/api/admin/deployments.go
@@ -209,6 +209,14 @@ func (h *Handler) createDeployment(c fiber.Ctx) error {
 		}
 	}
 
+	// Reload the local registry immediately so deployment changes (including
+	// pii_filter) take effect on this instance without waiting for a restart.
+	// Redis publish below covers other instances in a multi-node setup.
+	if h.ReloadModels != nil {
+		if reloadErr := h.ReloadModels(ctx); reloadErr != nil {
+			h.Log.ErrorContext(ctx, "create deployment: reload models", slog.String("error", reloadErr.Error()))
+		}
+	}
 	if h.Redis != nil {
 		if pubErr := h.Redis.PublishInvalidation(ctx, voidredis.ChannelModels, "reload"); pubErr != nil {
 			h.Log.ErrorContext(ctx, "create deployment: publish invalidation", slog.String("error", pubErr.Error()))
@@ -371,6 +379,14 @@ func (h *Handler) updateDeployment(c fiber.Ctx) error {
 		return apierror.InternalError(c, "failed to update deployment")
 	}
 
+	// Reload the local registry immediately so deployment changes (including
+	// pii_filter) take effect on this instance without waiting for a restart.
+	// Redis publish below covers other instances in a multi-node setup.
+	if h.ReloadModels != nil {
+		if reloadErr := h.ReloadModels(ctx); reloadErr != nil {
+			h.Log.ErrorContext(ctx, "update deployment: reload models", slog.String("error", reloadErr.Error()))
+		}
+	}
 	if h.Redis != nil {
 		if pubErr := h.Redis.PublishInvalidation(ctx, voidredis.ChannelModels, "reload"); pubErr != nil {
 			h.Log.ErrorContext(ctx, "update deployment: publish invalidation", slog.String("error", pubErr.Error()))
@@ -428,6 +444,14 @@ func (h *Handler) deleteDeployment(c fiber.Ctx) error {
 		return apierror.InternalError(c, "failed to delete deployment")
 	}
 
+	// Reload the local registry immediately so the deleted deployment is no
+	// longer used for routing on this instance without waiting for a restart.
+	// Redis publish below covers other instances in a multi-node setup.
+	if h.ReloadModels != nil {
+		if reloadErr := h.ReloadModels(ctx); reloadErr != nil {
+			h.Log.ErrorContext(ctx, "delete deployment: reload models", slog.String("error", reloadErr.Error()))
+		}
+	}
 	if h.Redis != nil {
 		if pubErr := h.Redis.PublishInvalidation(ctx, voidredis.ChannelModels, "reload"); pubErr != nil {
 			h.Log.ErrorContext(ctx, "delete deployment: publish invalidation", slog.String("error", pubErr.Error()))

--- a/internal/api/admin/deployments_reload_test.go
+++ b/internal/api/admin/deployments_reload_test.go
@@ -1,0 +1,434 @@
+package admin_test
+
+// deployments_reload_test.go verifies that createDeployment, updateDeployment,
+// and deleteDeployment each invoke the ReloadModels callback at least once on
+// every successful request path. This guarantees that a pii_filter change on a
+// deployment takes effect immediately on the local instance without requiring a
+// restart or a Redis pub/sub event.
+//
+// Pattern mirrors license_test.go: build a Handler with a ReloadModels closure
+// that counts invocations, wire it via setupDeploymentReloadApp, make an HTTP
+// request through app.Test, assert the counter.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/voidmind-io/voidllm/internal/api/admin"
+	"github.com/voidmind-io/voidllm/internal/auth"
+	"github.com/voidmind-io/voidllm/internal/cache"
+	"github.com/voidmind-io/voidllm/internal/config"
+	"github.com/voidmind-io/voidllm/internal/db"
+	"github.com/voidmind-io/voidllm/internal/license"
+)
+
+// setupDeploymentReloadApp creates a minimal Fiber app wired with an in-memory
+// SQLite database, an EncryptionKey, and a custom ReloadModels callback. The
+// callback is injected so tests can count its invocations.
+//
+// Redis is intentionally nil so only the local ReloadModels path is tested.
+func setupDeploymentReloadApp(
+	t *testing.T,
+	dsn string,
+	reloadModels func(context.Context) error,
+) (*fiber.App, *db.DB, *cache.Cache[string, auth.KeyInfo]) {
+	t.Helper()
+
+	ctx := context.Background()
+	database, err := db.Open(ctx, config.DatabaseConfig{
+		Driver:          "sqlite",
+		DSN:             dsn,
+		MaxOpenConns:    1,
+		MaxIdleConns:    1,
+		ConnMaxLifetime: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("setupDeploymentReloadApp: open DB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	if err := db.RunMigrations(ctx, database.SQL(), db.SQLiteDialect{}, slog.Default()); err != nil {
+		t.Fatalf("setupDeploymentReloadApp: run migrations: %v", err)
+	}
+
+	keyCache := cache.New[string, auth.KeyInfo]()
+
+	handler := &admin.Handler{
+		DB:            database,
+		HMACSecret:    testHMACSecret,
+		EncryptionKey: testEncryptionKey,
+		KeyCache:      keyCache,
+		License:       license.NewHolder(license.Verify("", true)),
+		Log:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ReloadModels:  reloadModels,
+		Redis:         nil, // local-only reload path under test
+	}
+
+	app := fiber.New()
+	admin.RegisterRoutes(app, handler, keyCache, testHMACSecret, nil)
+
+	return app, database, keyCache
+}
+
+// TestCreateDeployment_InvokesReloadModels verifies that a successful POST to
+// /api/v1/models/:model_id/deployments calls the ReloadModels callback exactly
+// once, independently of Redis.
+func TestCreateDeployment_InvokesReloadModels(t *testing.T) {
+	t.Parallel()
+
+	var reloadCalled atomic.Int32
+	reloadModels := func(_ context.Context) error {
+		reloadCalled.Add(1)
+		return nil
+	}
+
+	app, database, keyCache := setupDeploymentReloadApp(
+		t,
+		"file:TestCreateDeployment_InvokesReloadModels?mode=memory&cache=private",
+		reloadModels,
+	)
+	m := mustCreateModelForDeployment(t, database, "reload-create-model")
+	token := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("POST", deploymentURL(m.ID),
+		strings.NewReader(`{"name":"reload-dep","provider":"openai","base_url":"https://api.openai.com/v1","weight":1}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 201; body: %s", resp.StatusCode, body)
+	}
+
+	if got := reloadCalled.Load(); got < 1 {
+		t.Errorf("ReloadModels called %d times after createDeployment, want >= 1", got)
+	}
+}
+
+// TestUpdateDeployment_InvokesReloadModels verifies that a successful PATCH to
+// /api/v1/models/:model_id/deployments/:deployment_id calls the ReloadModels
+// callback at least once.
+func TestUpdateDeployment_InvokesReloadModels(t *testing.T) {
+	t.Parallel()
+
+	var reloadCalled atomic.Int32
+	reloadModels := func(_ context.Context) error {
+		reloadCalled.Add(1)
+		return nil
+	}
+
+	app, database, keyCache := setupDeploymentReloadApp(
+		t,
+		"file:TestUpdateDeployment_InvokesReloadModels?mode=memory&cache=private",
+		reloadModels,
+	)
+	m := mustCreateModelForDeployment(t, database, "reload-update-model")
+	dep := mustCreateDeploymentDB(t, database, m.ID, "reload-update-dep")
+	token := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("PATCH", deploymentItemURL(m.ID, dep.ID),
+		strings.NewReader(`{"name":"reload-updated-dep"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	if got := reloadCalled.Load(); got < 1 {
+		t.Errorf("ReloadModels called %d times after updateDeployment, want >= 1", got)
+	}
+}
+
+// TestDeleteDeployment_InvokesReloadModels verifies that a successful DELETE to
+// /api/v1/models/:model_id/deployments/:deployment_id calls the ReloadModels
+// callback at least once.
+func TestDeleteDeployment_InvokesReloadModels(t *testing.T) {
+	t.Parallel()
+
+	var reloadCalled atomic.Int32
+	reloadModels := func(_ context.Context) error {
+		reloadCalled.Add(1)
+		return nil
+	}
+
+	app, database, keyCache := setupDeploymentReloadApp(
+		t,
+		"file:TestDeleteDeployment_InvokesReloadModels?mode=memory&cache=private",
+		reloadModels,
+	)
+	m := mustCreateModelForDeployment(t, database, "reload-delete-model")
+	dep := mustCreateDeploymentDB(t, database, m.ID, "reload-delete-dep")
+	token := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("DELETE", deploymentItemURL(m.ID, dep.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusNoContent {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 204; body: %s", resp.StatusCode, body)
+	}
+
+	if got := reloadCalled.Load(); got < 1 {
+		t.Errorf("ReloadModels called %d times after deleteDeployment, want >= 1", got)
+	}
+}
+
+// TestDeploymentReload_NilCallbackIsNoOp verifies that all three mutating
+// deployment handlers succeed when ReloadModels is nil. This ensures that the
+// nil-guard in each handler works correctly and no panic occurs.
+func TestDeploymentReload_NilCallbackIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupDeploymentReloadApp(
+		t,
+		"file:TestDeploymentReload_NilCallbackIsNoOp?mode=memory&cache=private",
+		nil, // no callback
+	)
+	m := mustCreateModelForDeployment(t, database, "nil-reload-model")
+	token := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	// Create
+	createReq := httptest.NewRequest("POST", deploymentURL(m.ID),
+		strings.NewReader(`{"name":"nil-reload-dep","provider":"openai","base_url":"https://api.openai.com/v1","weight":1}`))
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.Header.Set("Authorization", "Bearer "+token)
+	createResp, err := app.Test(createReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("create: app.Test: %v", err)
+	}
+	defer createResp.Body.Close()
+	if createResp.StatusCode != fiber.StatusCreated {
+		body, _ := io.ReadAll(createResp.Body)
+		t.Fatalf("create: status = %d, want 201; body: %s", createResp.StatusCode, body)
+	}
+	var created map[string]any
+	decodeBody(t, createResp.Body, &created)
+	depID, _ := created["id"].(string)
+
+	// Update
+	updateReq := httptest.NewRequest("PATCH", deploymentItemURL(m.ID, depID),
+		strings.NewReader(`{"name":"nil-reload-dep-updated"}`))
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateReq.Header.Set("Authorization", "Bearer "+token)
+	updateResp, err := app.Test(updateReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("update: app.Test: %v", err)
+	}
+	defer updateResp.Body.Close()
+	if updateResp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(updateResp.Body)
+		t.Fatalf("update: status = %d, want 200; body: %s", updateResp.StatusCode, body)
+	}
+
+	// Delete
+	deleteReq := httptest.NewRequest("DELETE", deploymentItemURL(m.ID, depID), nil)
+	deleteReq.Header.Set("Authorization", "Bearer "+token)
+	deleteResp, err := app.Test(deleteReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("delete: app.Test: %v", err)
+	}
+	defer deleteResp.Body.Close()
+	if deleteResp.StatusCode != fiber.StatusNoContent {
+		body, _ := io.ReadAll(deleteResp.Body)
+		t.Fatalf("delete: status = %d, want 204; body: %s", deleteResp.StatusCode, body)
+	}
+}
+
+// TestDeploymentReload_CallbackErrorDoesNotFailRequest verifies that all three
+// mutating deployment handlers return a success response even when the
+// ReloadModels callback returns an error. The error is logged but must not
+// propagate to the HTTP client.
+func TestDeploymentReload_CallbackErrorDoesNotFailRequest(t *testing.T) {
+	t.Parallel()
+
+	stubErr := errors.New("stub reload error")
+	var reloadCalled atomic.Int32
+	reloadModels := func(_ context.Context) error {
+		reloadCalled.Add(1)
+		return stubErr
+	}
+
+	app, database, keyCache := setupDeploymentReloadApp(
+		t,
+		"file:TestDeploymentReload_CallbackErrorDoesNotFailRequest?mode=memory&cache=private",
+		reloadModels,
+	)
+	m := mustCreateModelForDeployment(t, database, "err-reload-model")
+	token := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	// Create must succeed despite reload error.
+	createReq := httptest.NewRequest("POST", deploymentURL(m.ID),
+		strings.NewReader(`{"name":"err-reload-dep","provider":"openai","base_url":"https://api.openai.com/v1","weight":1}`))
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.Header.Set("Authorization", "Bearer "+token)
+	createResp, err := app.Test(createReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("create: app.Test: %v", err)
+	}
+	defer createResp.Body.Close()
+	if createResp.StatusCode != fiber.StatusCreated {
+		body, _ := io.ReadAll(createResp.Body)
+		t.Fatalf("create: status = %d, want 201 (reload error must not propagate); body: %s", createResp.StatusCode, body)
+	}
+
+	var created map[string]any
+	decodeBody(t, createResp.Body, &created)
+	depID, _ := created["id"].(string)
+
+	// Update must succeed despite reload error.
+	updateReq := httptest.NewRequest("PATCH", deploymentItemURL(m.ID, depID),
+		strings.NewReader(`{"name":"err-reload-dep-updated"}`))
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateReq.Header.Set("Authorization", "Bearer "+token)
+	updateResp, err := app.Test(updateReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("update: app.Test: %v", err)
+	}
+	defer updateResp.Body.Close()
+	if updateResp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(updateResp.Body)
+		t.Fatalf("update: status = %d, want 200 (reload error must not propagate); body: %s", updateResp.StatusCode, body)
+	}
+
+	// Delete must succeed despite reload error.
+	deleteReq := httptest.NewRequest("DELETE", deploymentItemURL(m.ID, depID), nil)
+	deleteReq.Header.Set("Authorization", "Bearer "+token)
+	deleteResp, err := app.Test(deleteReq, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("delete: app.Test: %v", err)
+	}
+	defer deleteResp.Body.Close()
+	if deleteResp.StatusCode != fiber.StatusNoContent {
+		body, _ := io.ReadAll(deleteResp.Body)
+		t.Fatalf("delete: status = %d, want 204 (reload error must not propagate); body: %s", deleteResp.StatusCode, body)
+	}
+
+	// Reload callback must have been called once per mutating operation (3 total).
+	if got := reloadCalled.Load(); got != 3 {
+		t.Errorf("ReloadModels called %d times across 3 mutating ops, want 3", got)
+	}
+}
+
+// TestCreateDeployment_PIIFilter_TriggerReload is the integration test that
+// most directly proves the pii_filter path: create a deployment with
+// pii_filter: true and verify ReloadModels was called. This ensures that the
+// pii_filter column change is immediately visible to the local registry.
+func TestCreateDeployment_PIIFilter_TriggerReload(t *testing.T) {
+	t.Parallel()
+
+	var reloadCalled atomic.Int32
+	reloadModels := func(_ context.Context) error {
+		reloadCalled.Add(1)
+		return nil
+	}
+
+	app, database, keyCache := setupDeploymentReloadApp(
+		t,
+		"file:TestCreateDeployment_PIIFilter_TriggerReload?mode=memory&cache=private",
+		reloadModels,
+	)
+	m := mustCreateModelForDeployment(t, database, "pii-reload-model")
+	token := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("POST", deploymentURL(m.ID),
+		strings.NewReader(`{"name":"pii-on-dep","provider":"openai","base_url":"https://api.openai.com/v1","weight":1,"pii_filter":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 201; body: %s", resp.StatusCode, body)
+	}
+
+	// Verify pii_filter is reflected in the response.
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+	if got["pii_filter"] != true {
+		t.Errorf("response pii_filter = %v, want true", got["pii_filter"])
+	}
+
+	// ReloadModels must have been called at least once.
+	if got := reloadCalled.Load(); got < 1 {
+		t.Errorf("ReloadModels called %d times after pii_filter create, want >= 1", got)
+	}
+}
+
+// TestUpdateDeployment_PIIFilter_TriggerReload verifies that updating
+// pii_filter via PATCH calls ReloadModels, ensuring local registry refresh.
+func TestUpdateDeployment_PIIFilter_TriggerReload(t *testing.T) {
+	t.Parallel()
+
+	var reloadCalled atomic.Int32
+	reloadModels := func(_ context.Context) error {
+		reloadCalled.Add(1)
+		return nil
+	}
+
+	app, database, keyCache := setupDeploymentReloadApp(
+		t,
+		"file:TestUpdateDeployment_PIIFilter_TriggerReload?mode=memory&cache=private",
+		reloadModels,
+	)
+	m := mustCreateModelForDeployment(t, database, "pii-update-reload-model")
+	dep := mustCreateDeploymentDB(t, database, m.ID, "pii-update-reload-dep")
+	token := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	// Reset the counter: createDeploymentDB goes through the DB directly, not
+	// the HTTP handler, so reloadCalled should still be 0 here.
+	startCount := reloadCalled.Load()
+
+	req := httptest.NewRequest("PATCH", deploymentItemURL(m.ID, dep.ID),
+		strings.NewReader(`{"pii_filter":true}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	after := reloadCalled.Load()
+	if after <= startCount {
+		t.Errorf("ReloadModels not called after pii_filter PATCH (before=%d, after=%d)", startCount, after)
+	}
+}

--- a/internal/api/admin/deployments_test.go
+++ b/internal/api/admin/deployments_test.go
@@ -704,3 +704,88 @@ func TestDeploymentAPIKeyNotInResponse(t *testing.T) {
 		}
 	}
 }
+
+// TestUpdateDeployment_PIIFilterTriState verifies the three distinct semantics
+// of the pii_filter field on a deployment PATCH:
+//
+//   - key present, true  → DB column set to 1 (true)
+//   - key present, false → DB column set to 0 (false)
+//   - key present, null  → DB column reset to NULL (revert to inherit-from-model)
+//   - key absent         → DB column left unchanged (no-op)
+func TestUpdateDeployment_PIIFilterTriState(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestUpdateDeployment_PIIFilterTriState?mode=memory&cache=private"
+	app, database, keyCache := setupTestAppWithEncKey(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	m := mustCreateModelForDeployment(t, database, "dep-pii-tristate-model")
+	dep := mustCreateDeploymentDB(t, database, m.ID, "dep-pii-tristate-dep")
+
+	patch := func(t *testing.T, rawBody string) map[string]any {
+		t.Helper()
+		req := httptest.NewRequest("PATCH", deploymentItemURL(m.ID, dep.ID),
+			strings.NewReader(rawBody))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+testKey)
+		resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+		if err != nil {
+			t.Fatalf("app.Test: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+		}
+		var got map[string]any
+		decodeBody(t, resp.Body, &got)
+		return got
+	}
+
+	dbPIIFilter := func(t *testing.T) *int64 {
+		t.Helper()
+		var v *int64
+		row := database.SQL().QueryRowContext(context.Background(),
+			"SELECT pii_filter FROM model_deployments WHERE id = ?", dep.ID)
+		if err := row.Scan(&v); err != nil {
+			t.Fatalf("scan pii_filter: %v", err)
+		}
+		return v
+	}
+
+	// (a) pii_filter: true → DB must be 1.
+	resp := patch(t, `{"pii_filter": true}`)
+	if resp["pii_filter"] != true {
+		t.Errorf("(a) response pii_filter = %v, want true", resp["pii_filter"])
+	}
+	if v := dbPIIFilter(t); v == nil || *v != 1 {
+		t.Errorf("(a) DB pii_filter = %v, want 1", v)
+	}
+
+	// (b) pii_filter: false → DB must be 0.
+	patch(t, `{"pii_filter": false}`)
+	if v := dbPIIFilter(t); v == nil || *v != 0 {
+		t.Errorf("(b) DB pii_filter = %v, want 0", v)
+	}
+
+	// (c) pii_filter: null → DB must become NULL (revert to inherit-from-model).
+	resp = patch(t, `{"pii_filter": null}`)
+	if _, present := resp["pii_filter"]; present && resp["pii_filter"] != nil {
+		t.Errorf("(c) response pii_filter = %v, want absent or null", resp["pii_filter"])
+	}
+	if v := dbPIIFilter(t); v != nil {
+		t.Errorf("(c) DB pii_filter = %d, want NULL", *v)
+	}
+
+	// Prime the DB with true again so the no-op case (d) is detectable.
+	patch(t, `{"pii_filter": true}`)
+	if v := dbPIIFilter(t); v == nil || *v != 1 {
+		t.Fatalf("priming failed: DB pii_filter = %v, want 1", v)
+	}
+
+	// (d) pii_filter key absent → DB must be unchanged (still 1).
+	patch(t, `{"weight": 2}`)
+	if v := dbPIIFilter(t); v == nil || *v != 1 {
+		t.Errorf("(d) DB pii_filter = %v, want 1 (unchanged)", v)
+	}
+}

--- a/internal/api/admin/models.go
+++ b/internal/api/admin/models.go
@@ -58,6 +58,10 @@ type createModelRequest struct {
 	// this model are unavailable. Requires an Enterprise license with the
 	// fallback_chains feature. Leave empty to disable fallback.
 	FallbackModelName string `json:"fallback_model_name,omitempty"`
+	// PIIFilter explicitly enables or disables PII anonymization for requests
+	// routed to this model. When omitted the network-level default is used.
+	// Pass true to force anonymization on, false to force it off.
+	PIIFilter *bool `json:"pii_filter,omitempty"`
 }
 
 // updateModelRequest is the JSON body accepted by UpdateModel.
@@ -92,6 +96,33 @@ type updateModelRequest struct {
 	// pointer to an empty string to clear the fallback. Requires Enterprise
 	// license with the fallback_chains feature when setting a non-empty value.
 	FallbackModelName *string `json:"fallback_model_name"`
+	// PIIFilter, when non-nil, replaces the PII anonymization override for this
+	// model. Pass true to force anonymization on, false to force it off, or
+	// omit the field entirely to leave the existing setting unchanged.
+	// Send the JSON key with a null value to clear the override and revert to
+	// the network-level default (NULL in the DB).
+	PIIFilter *bool `json:"pii_filter"`
+}
+
+// parsePIIFilterField inspects raw JSON bytes to determine how the pii_filter
+// key was supplied. It returns (present=false, isNull=false) when the key is
+// absent — the caller must not change the stored value. It returns
+// (present=true, isNull=true) when the key exists with a JSON null value —
+// the caller must clear the column to NULL. It returns (present=true,
+// isNull=false) when the key holds a concrete bool — the caller must write
+// that bool value. Standard JSON null bytes.Equal is used; no need for
+// constant-time comparison on a non-secret value.
+func parsePIIFilterField(body []byte) (present bool, isNull bool) {
+	var raw map[string]jsonx.RawMessage
+	if err := jsonx.Unmarshal(body, &raw); err != nil {
+		return false, false
+	}
+	v, ok := raw["pii_filter"]
+	if !ok {
+		return false, false
+	}
+	// encoding/json and sonic both represent JSON null as the four bytes "null".
+	return true, string(v) == "null"
 }
 
 // modelResponse is the JSON representation of a model returned by the API.
@@ -127,6 +158,9 @@ type modelResponse struct {
 	// FallbackModelName is the name of the fallback model, or empty when none
 	// is configured.
 	FallbackModelName string `json:"fallback_model_name,omitempty"`
+	// PIIFilter is the per-model PII anonymization override. Nil means the
+	// network-level default is used; true forces anonymization on; false off.
+	PIIFilter *bool `json:"pii_filter,omitempty"`
 	// Deployments contains the model's deployment entries when present.
 	Deployments []deploymentResponse `json:"deployments,omitempty"`
 	CreatedAt   string               `json:"created_at"`
@@ -193,6 +227,7 @@ func modelToResponse(m *db.Model, fallbackName string) modelResponse {
 		Strategy:          m.Strategy,
 		MaxRetries:        m.MaxRetries,
 		FallbackModelName: fallbackName,
+		PIIFilter:         m.PIIFilter,
 		CreatedAt:         m.CreatedAt,
 		UpdatedAt:         m.UpdatedAt,
 	}
@@ -232,6 +267,7 @@ func dbModelToProxy(m *db.Model, apiKeyPlaintext string, fallbackName string) pr
 		GCPLocation:       m.GCPLocation,
 		Timeout:           timeout,
 		FallbackModelName: fallbackName,
+		PIIFilter:         m.PIIFilter,
 	}
 }
 
@@ -529,6 +565,7 @@ func (h *Handler) CreateModel(c fiber.Ctx) error {
 		Strategy:         &req.Strategy,
 		MaxRetries:       &req.MaxRetries,
 		FallbackModelID:  fallbackModelID,
+		PIIFilter:        req.PIIFilter,
 	})
 	if err != nil {
 		if errors.Is(err, db.ErrConflict) {
@@ -728,6 +765,11 @@ func (h *Handler) UpdateModel(c fiber.Ctx) error {
 	if err := c.Bind().JSON(&req); err != nil {
 		return apierror.BadRequest(c, "invalid request body")
 	}
+	// Capture body bytes before any further processing. c.Body() is safe to
+	// call after Bind().JSON() — Fiber retains the raw bytes on the request
+	// context throughout the handler lifetime.
+	rawBody := append([]byte(nil), c.Body()...)
+	piiPresent, piiIsNull := parsePIIFilterField(rawBody)
 
 	// Determine the effective strategy after this update so we know whether
 	// provider/base_url are required. If strategy is being cleared (pointer to
@@ -771,6 +813,20 @@ func (h *Handler) UpdateModel(c fiber.Ctx) error {
 		}
 	}
 
+	// Resolve the tri-state pii_filter semantics:
+	//   - key absent in JSON  → do not touch the column (piiPresent=false)
+	//   - key present, null   → clear column to NULL    (piiIsNull=true)
+	//   - key present, bool   → write the bool value
+	var piiFilter *bool
+	var clearPIIFilter bool
+	if piiPresent {
+		if piiIsNull {
+			clearPIIFilter = true
+		} else {
+			piiFilter = req.PIIFilter
+		}
+	}
+
 	params := db.UpdateModelParams{
 		Name:             req.Name,
 		Provider:         req.Provider,
@@ -786,6 +842,8 @@ func (h *Handler) UpdateModel(c fiber.Ctx) error {
 		Timeout:          req.Timeout,
 		Strategy:         req.Strategy,
 		MaxRetries:       req.MaxRetries,
+		PIIFilter:        piiFilter,
+		ClearPIIFilter:   clearPIIFilter,
 	}
 
 	if req.Aliases != nil {

--- a/internal/api/admin/models_test.go
+++ b/internal/api/admin/models_test.go
@@ -2094,6 +2094,94 @@ func TestListModels_FallbackAcrossPages(t *testing.T) {
 	}
 }
 
+// TestUpdateModel_PIIFilterTriState verifies the three distinct semantics of the
+// pii_filter field on a model PATCH:
+//
+//   - key present, true  → DB column set to 1 (true)
+//   - key present, false → DB column set to 0 (false)
+//   - key present, null  → DB column reset to NULL (revert to network default)
+//   - key absent         → DB column left unchanged (no-op)
+func TestUpdateModel_PIIFilterTriState(t *testing.T) {
+	t.Parallel()
+
+	dsn := "file:TestUpdateModel_PIIFilterTriState?mode=memory&cache=private"
+	app, database, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	m := mustCreateModelForDeployment(t, database, "pii-tristate-model")
+
+	patch := func(t *testing.T, rawBody string) map[string]any {
+		t.Helper()
+		req := httptest.NewRequest("PATCH", modelItemURL(m.ID),
+			strings.NewReader(rawBody))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+testKey)
+		resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+		if err != nil {
+			t.Fatalf("app.Test: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != fiber.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+		}
+		var got map[string]any
+		decodeBody(t, resp.Body, &got)
+		return got
+	}
+
+	dbPIIFilter := func(t *testing.T) *int64 {
+		t.Helper()
+		var v *int64
+		row := database.SQL().QueryRowContext(context.Background(),
+			"SELECT pii_filter FROM models WHERE id = ?", m.ID)
+		if err := row.Scan(&v); err != nil {
+			t.Fatalf("scan pii_filter: %v", err)
+		}
+		return v
+	}
+
+	// (a) pii_filter: true → DB must be 1.
+	resp := patch(t, `{"pii_filter": true}`)
+	if resp["pii_filter"] != true {
+		t.Errorf("(a) response pii_filter = %v, want true", resp["pii_filter"])
+	}
+	if v := dbPIIFilter(t); v == nil || *v != 1 {
+		t.Errorf("(a) DB pii_filter = %v, want 1", v)
+	}
+
+	// (b) pii_filter: false → DB must be 0.
+	resp = patch(t, `{"pii_filter": false}`)
+	if resp["pii_filter"] != false {
+		// The response field is omitempty so false may be absent; check DB.
+		_ = resp
+	}
+	if v := dbPIIFilter(t); v == nil || *v != 0 {
+		t.Errorf("(b) DB pii_filter = %v, want 0", v)
+	}
+
+	// (c) pii_filter: null → DB must become NULL (revert to network default).
+	resp = patch(t, `{"pii_filter": null}`)
+	if _, present := resp["pii_filter"]; present && resp["pii_filter"] != nil {
+		t.Errorf("(c) response pii_filter = %v, want absent or null", resp["pii_filter"])
+	}
+	if v := dbPIIFilter(t); v != nil {
+		t.Errorf("(c) DB pii_filter = %d, want NULL", *v)
+	}
+
+	// Prime the DB with true again so the no-op case (d) is detectable.
+	patch(t, `{"pii_filter": true}`)
+	if v := dbPIIFilter(t); v == nil || *v != 1 {
+		t.Fatalf("priming failed: DB pii_filter = %v, want 1", v)
+	}
+
+	// (d) pii_filter key absent → DB must be unchanged (still 1).
+	patch(t, `{"max_context_tokens": 4096}`)
+	if v := dbPIIFilter(t); v == nil || *v != 1 {
+		t.Errorf("(d) DB pii_filter = %v, want 1 (unchanged)", v)
+	}
+}
+
 // TestUpdateModel_ConcurrentFallbackMutations is a race-detector test that
 // verifies concurrent PATCH requests mutating fallback relationships do not
 // produce data races or panics (Fix C3). The exact final state is not asserted

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -38,6 +38,7 @@ import (
 	"github.com/voidmind-io/voidllm/internal/mcp"
 	"github.com/voidmind-io/voidllm/internal/metrics"
 	voidotel "github.com/voidmind-io/voidllm/internal/otel"
+	"github.com/voidmind-io/voidllm/internal/pii"
 	"github.com/voidmind-io/voidllm/internal/proxy"
 	"github.com/voidmind-io/voidllm/internal/ratelimit"
 	voidredis "github.com/voidmind-io/voidllm/internal/redis"
@@ -370,6 +371,7 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 					GCPLocation:     dep.GCPLocation,
 					Weight:          dep.Weight,
 					Priority:        dep.Priority,
+					PIIFilter:       dep.PIIFilter,
 				})
 			}
 
@@ -396,6 +398,7 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 				MaxRetries:        m.MaxRetries,
 				Deployments:       deployments,
 				FallbackModelName: fallbackName,
+				PIIFilter:         m.PIIFilter,
 			})
 		}
 		gateFallback(registry, licHolder)
@@ -669,6 +672,15 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 	proxyHandler.MaxResponseBody = cfg.Server.Proxy.MaxResponseBody
 	proxyHandler.MaxStreamDuration = cfg.Server.Proxy.MaxStreamDuration
 	proxyHandler.FallbackMaxDepth = cfg.Settings.FallbackMaxDepth
+
+	if cfg.Settings.PII.IsEnabled() {
+		piiEngine, piiErr := buildPIIEngine(encKey, cfg.Settings.PII, log)
+		if piiErr != nil {
+			redisCancel()
+			return nil, fmt.Errorf("pii engine: %w", piiErr)
+		}
+		proxyHandler.PIIEngine = piiEngine
+	}
 
 	loginThrottle := auth.NewLoginThrottle()
 
@@ -1454,7 +1466,55 @@ func (a *Application) cleanup(ctx context.Context) {
 		)
 	}
 
+	// Zero PII Engine secret material before zeroing the main keys.
+	// The Engine holds a copy of the derived pseudonym secret; Close zeroes it.
+	if a.proxyHandler != nil && a.proxyHandler.PIIEngine != nil {
+		a.proxyHandler.PIIEngine.Close()
+	}
+
 	// Zero sensitive key material after all components are stopped.
 	crypto.ZeroKey(a.hmacSecret)
 	crypto.ZeroKey(a.encKey)
+}
+
+// buildPIIEngine constructs a pii.Engine from the installation encryption key
+// and the PII configuration. The pseudonym secret is derived from encKey using
+// HKDF with the info string "voidllm-pii-pseudonym-v1", keeping it independent
+// from the key-hashing HMAC secret ("voidllm-hmac-key") and preventing cross-
+// subsystem secret reuse.
+//
+// Returns an error on any failure (HKDF error, bad custom regexp). The caller
+// must treat an error as a startup failure — running without a functional PII
+// engine when PII is enabled would silently drop the anonymization guarantee.
+// The local piiSecret copy is zeroed after the engine is constructed so that
+// the derived secret does not linger in the Go heap beyond its required lifetime.
+func buildPIIEngine(encKey []byte, cfg config.PIIConfig, log *slog.Logger) (*pii.Engine, error) {
+	// Derive a 32-byte pseudonym secret via HKDF-SHA256.
+	hkdfReader := hkdf.New(sha256.New, encKey, nil, []byte("voidllm-pii-pseudonym-v1"))
+	piiSecret := make([]byte, 32)
+	if _, err := io.ReadFull(hkdfReader, piiSecret); err != nil {
+		return nil, fmt.Errorf("derive pseudonym secret: %w", err)
+	}
+	// Zero the local copy once the engine has taken its own internal copy.
+	defer crypto.ZeroKey(piiSecret)
+
+	// Build detector list: start with built-in defaults.
+	patterns := pii.DefaultPatterns()
+
+	// Append custom patterns from config.
+	for _, cp := range cfg.Patterns {
+		patterns = append(patterns, pii.Pattern{Type: cp.Type, Regexp: cp.Regexp})
+	}
+
+	detector, err := pii.NewRegexDetector(patterns)
+	if err != nil {
+		return nil, fmt.Errorf("compile detector patterns: %w", err)
+	}
+
+	log.LogAttrs(context.Background(), slog.LevelInfo,
+		"pii anonymization enabled",
+		slog.Int("builtin_patterns", len(pii.DefaultPatterns())),
+		slog.Int("custom_patterns", len(cfg.Patterns)),
+	)
+	return pii.NewEngine(piiSecret, []pii.Detector{detector}), nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,6 +116,13 @@ type DeploymentConfig struct {
 	// Priority is the preference rank for the "priority" strategy. Lower
 	// values indicate higher priority.
 	Priority int `yaml:"priority"`
+	// PIIFilter explicitly enables or disables PII anonymization for requests
+	// routed to this deployment. When set it overrides both the model-level
+	// pii_filter and the network-based default (see ModelConfig.PIIFilter).
+	// nil means "not set — defer to model-level flag or network default".
+	//
+	// UI/DB persistence of this flag is a follow-up; for now it is YAML-only.
+	PIIFilter *bool `yaml:"pii_filter"`
 }
 
 // LogValue implements slog.LogValuer to prevent API keys from appearing in logs.
@@ -163,6 +170,14 @@ type ModelConfig struct {
 	// the model-level Provider and BaseURL fields are ignored in favour of the
 	// per-deployment values, and Strategy must be set.
 	Deployments []DeploymentConfig `yaml:"deployments"`
+	// PIIFilter explicitly enables or disables PII anonymization for requests
+	// routed to this model. When set it overrides the network-based default
+	// (public destination = anonymize, private destination = pass through).
+	// A per-deployment pii_filter takes precedence over this model-level flag.
+	// nil means "not set — use the network-based default".
+	//
+	// UI/DB persistence of this flag is a follow-up; for now it is YAML-only.
+	PIIFilter *bool `yaml:"pii_filter"`
 }
 
 // LogValue implements slog.LogValuer to prevent API keys from appearing in logs.
@@ -444,6 +459,44 @@ func (r RetentionConfig) Enabled() bool {
 	return r.UsageEvents > 0 || r.AuditLogs > 0
 }
 
+// PIIPatternConfig defines a single custom PII detection pattern to add on
+// top of the built-in defaults. Both fields are required.
+type PIIPatternConfig struct {
+	// Type is the PII category label (e.g. "PASSPORT_NO"). It must be non-empty.
+	Type string `yaml:"type"`
+	// Regexp is a valid Go regular expression matching a single PII value.
+	Regexp string `yaml:"regexp"`
+}
+
+// PIIConfig controls in-memory PII anonymization of outbound LLM requests.
+// When enabled, PII detected in message content is replaced with
+// deterministic pseudonyms before the request leaves the proxy. The
+// pseudonyms are restored in the response so the caller receives the
+// original values. No PII is ever persisted or logged.
+type PIIConfig struct {
+	// Enabled activates PII anonymization. Defaults to false (opt-in).
+	// A pointer is used so that an explicit "enabled: false" in YAML can
+	// be distinguished from the zero value after unmarshalling.
+	Enabled *bool `yaml:"enabled"`
+	// Action is the anonymization strategy. Currently only "pseudonymize"
+	// is supported. Defaults to "pseudonymize".
+	Action string `yaml:"action"`
+	// Patterns is a list of additional custom PII patterns that are
+	// applied in addition to the built-in defaults. An empty list means
+	// only the built-in patterns are used.
+	Patterns []PIIPatternConfig `yaml:"patterns"`
+}
+
+// IsEnabled returns true only when PII anonymization has been explicitly
+// enabled. A nil pointer (field absent from YAML) returns false so that
+// PII anonymization is opt-in rather than on by default.
+func (p PIIConfig) IsEnabled() bool {
+	if p.Enabled == nil {
+		return false
+	}
+	return *p.Enabled
+}
+
 // SettingsConfig holds application-level settings.
 type SettingsConfig struct {
 	AdminKey      string `yaml:"admin_key" json:"-"`
@@ -472,6 +525,8 @@ type SettingsConfig struct {
 	// distinguished from the zero value after unmarshalling. Use
 	// GetSoftLimitThreshold to read the value.
 	SoftLimitThreshold *float64 `yaml:"soft_limit_threshold"`
+	// PII holds settings for in-memory PII anonymization. Disabled by default.
+	PII PIIConfig `yaml:"pii"`
 }
 
 // LogValue implements slog.LogValuer to prevent secrets from appearing in logs.
@@ -802,6 +857,15 @@ func (c *Config) setDefaults() {
 			d := 168 * time.Hour
 			c.Settings.MCP.CodeMode.SchemaTTL = &d
 		}
+	}
+
+	// PII anonymization — disabled by default (opt-in).
+	if c.Settings.PII.Enabled == nil {
+		disabled := false
+		c.Settings.PII.Enabled = &disabled
+	}
+	if c.Settings.PII.Action == "" {
+		c.Settings.PII.Action = "pseudonymize"
 	}
 
 	// Logging

--- a/internal/config/pii_test.go
+++ b/internal/config/pii_test.go
@@ -1,0 +1,263 @@
+package config_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/voidmind-io/voidllm/internal/config"
+)
+
+// minimalValidYAMLWithPII returns a valid base config with the provided
+// settings.pii block inlined. This avoids repeating all required fields
+// in every PII-specific test case.
+func minimalValidYAMLWithPII(piiBlock string) string {
+	return `
+server:
+  proxy:
+    port: 8080
+database:
+  driver: sqlite
+  dsn: voidllm.db
+settings:
+  encryption_key: aaaaaaaaaaaaaaaa
+  usage:
+    buffer_size: 100
+  pii:
+` + piiBlock
+}
+
+// TestValidate_PII covers settings.pii validation and default handling.
+func TestValidate_PII(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		yaml        string
+		wantErr     bool
+		errContains string
+	}{
+		// ── valid configurations ────────────────────────────────────────────
+		{
+			name: "pii disabled by default, no pii block at all",
+			yaml: minimalValidYAML(),
+		},
+		{
+			name: "pii explicitly disabled, no validation of pii fields",
+			yaml: minimalValidYAMLWithPII(`
+    enabled: false
+    action: "block"
+`),
+			// action "block" would be invalid when enabled, but must be ignored when disabled.
+		},
+		{
+			name: "pii enabled with action pseudonymize",
+			yaml: minimalValidYAMLWithPII(`
+    enabled: true
+    action: "pseudonymize"
+`),
+		},
+		{
+			name: "pii enabled with valid custom pattern",
+			yaml: minimalValidYAMLWithPII(`
+    enabled: true
+    action: "pseudonymize"
+    patterns:
+      - type: "PASSPORT_NO"
+        regexp: '\b[A-Z]{1,2}[0-9]{6,9}\b'
+`),
+		},
+		{
+			name: "pii enabled with multiple valid custom patterns",
+			yaml: minimalValidYAMLWithPII(`
+    enabled: true
+    action: "pseudonymize"
+    patterns:
+      - type: "PASSPORT_NO"
+        regexp: '\b[A-Z]{1,2}[0-9]{6,9}\b'
+      - type: "EMPLOYEE_ID"
+        regexp: '\bEMP-[0-9]{5}\b'
+`),
+		},
+
+		// ── invalid configurations ──────────────────────────────────────────
+		{
+			name: "pii enabled with action block returns error",
+			yaml: minimalValidYAMLWithPII(`
+    enabled: true
+    action: "block"
+`),
+			wantErr:     true,
+			errContains: "settings.pii.action",
+		},
+		{
+			name: "pii enabled with action redact returns error",
+			yaml: minimalValidYAMLWithPII(`
+    enabled: true
+    action: "redact"
+`),
+			wantErr:     true,
+			errContains: "settings.pii.action",
+		},
+		{
+			name: "pii enabled with empty action string gets default pseudonymize",
+			// setDefaults fills in "pseudonymize" when action is empty, so this is valid.
+			yaml: minimalValidYAMLWithPII(`
+    enabled: true
+`),
+		},
+		{
+			name: "pii enabled with invalid custom pattern regexp returns error",
+			yaml: minimalValidYAMLWithPII(`
+    enabled: true
+    action: "pseudonymize"
+    patterns:
+      - type: "BROKEN"
+        regexp: '[invalid'
+`),
+			wantErr:     true,
+			errContains: "settings.pii.patterns[0].regexp",
+		},
+		{
+			name: "pii enabled with empty pattern type returns error",
+			yaml: minimalValidYAMLWithPII(`
+    enabled: true
+    action: "pseudonymize"
+    patterns:
+      - type: ""
+        regexp: '\d+'
+`),
+			wantErr:     true,
+			errContains: "settings.pii.patterns[0].type",
+		},
+		{
+			name: "pii enabled with empty pattern regexp returns error",
+			yaml: minimalValidYAMLWithPII(`
+    enabled: true
+    action: "pseudonymize"
+    patterns:
+      - type: "CUSTOM"
+        regexp: ""
+`),
+			wantErr:     true,
+			errContains: "settings.pii.patterns[0].regexp",
+		},
+		{
+			name: "pii enabled invalid pattern in second entry uses correct index",
+			yaml: minimalValidYAMLWithPII(`
+    enabled: true
+    action: "pseudonymize"
+    patterns:
+      - type: "VALID"
+        regexp: '\d+'
+      - type: "BROKEN"
+        regexp: '(?P<bad'
+`),
+			wantErr:     true,
+			errContains: "settings.pii.patterns[1].regexp",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := writeTemp(t, "voidllm.yaml", tc.yaml)
+			_, _, err := config.Load(path)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("Load() expected error, got nil")
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Load() unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// TestPIIDefaults verifies the default values for PIIConfig after setDefaults
+// runs on a minimal config that does not set any pii fields.
+func TestPIIDefaults(t *testing.T) {
+	t.Parallel()
+
+	path := writeTemp(t, "voidllm.yaml", minimalValidYAML())
+	cfg, _, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	t.Run("enabled defaults to false", func(t *testing.T) {
+		t.Parallel()
+
+		if cfg.Settings.PII.IsEnabled() {
+			t.Error("PII.IsEnabled() = true, want false (disabled by default)")
+		}
+		// The pointer must not be nil after setDefaults — it is set to &false.
+		if cfg.Settings.PII.Enabled == nil {
+			t.Error("PII.Enabled pointer is nil after setDefaults, want &false")
+		}
+		if *cfg.Settings.PII.Enabled != false {
+			t.Errorf("*PII.Enabled = %v, want false", *cfg.Settings.PII.Enabled)
+		}
+	})
+
+	t.Run("action defaults to pseudonymize", func(t *testing.T) {
+		t.Parallel()
+
+		if cfg.Settings.PII.Action != "pseudonymize" {
+			t.Errorf("PII.Action = %q, want %q", cfg.Settings.PII.Action, "pseudonymize")
+		}
+	})
+
+	t.Run("patterns defaults to nil/empty", func(t *testing.T) {
+		t.Parallel()
+
+		if len(cfg.Settings.PII.Patterns) != 0 {
+			t.Errorf("PII.Patterns = %v, want empty", cfg.Settings.PII.Patterns)
+		}
+	})
+}
+
+// TestPIIIsEnabled_ExplicitTrue verifies that IsEnabled returns true when
+// explicitly set to true in the YAML.
+func TestPIIIsEnabled_ExplicitTrue(t *testing.T) {
+	t.Parallel()
+
+	yaml := minimalValidYAMLWithPII(`
+    enabled: true
+    action: "pseudonymize"
+`)
+	path := writeTemp(t, "voidllm.yaml", yaml)
+	cfg, _, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	if !cfg.Settings.PII.IsEnabled() {
+		t.Error("PII.IsEnabled() = false, want true when enabled: true is set")
+	}
+}
+
+// TestPIIIsEnabled_ExplicitFalse verifies that IsEnabled returns false when
+// explicitly set to false in the YAML (pointer semantics: not nil, value false).
+func TestPIIIsEnabled_ExplicitFalse(t *testing.T) {
+	t.Parallel()
+
+	yaml := minimalValidYAMLWithPII(`
+    enabled: false
+`)
+	path := writeTemp(t, "voidllm.yaml", yaml)
+	cfg, _, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	if cfg.Settings.PII.IsEnabled() {
+		t.Error("PII.IsEnabled() = true, want false when enabled: false is set")
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -358,6 +358,23 @@ func (c *Config) validate() error {
 		}
 	}
 
+	// --- settings.pii ---
+	if c.Settings.PII.IsEnabled() {
+		if c.Settings.PII.Action != "pseudonymize" {
+			errs = append(errs, fmt.Errorf("settings.pii.action: only \"pseudonymize\" is supported, got %q", c.Settings.PII.Action))
+		}
+		for i, p := range c.Settings.PII.Patterns {
+			if p.Type == "" {
+				errs = append(errs, fmt.Errorf("settings.pii.patterns[%d].type: must not be empty", i))
+			}
+			if p.Regexp == "" {
+				errs = append(errs, fmt.Errorf("settings.pii.patterns[%d].regexp: must not be empty", i))
+			} else if _, reErr := regexp.Compile(p.Regexp); reErr != nil {
+				errs = append(errs, fmt.Errorf("settings.pii.patterns[%d].regexp: invalid regexp: %w", i, reErr))
+			}
+		}
+	}
+
 	// --- settings.retention ---
 	const maxRetention = 10 * 365 * 24 * time.Hour // 10 years
 	if c.Settings.Retention.UsageEvents < 0 {

--- a/internal/db/deployments.go
+++ b/internal/db/deployments.go
@@ -13,7 +13,7 @@ import (
 const deploymentSelectColumns = "id, model_id, name, provider, base_url, api_key_encrypted, " +
 	"azure_deployment, azure_api_version, gcp_project, gcp_location, " +
 	"weight, priority, is_active, " +
-	"created_at, updated_at, deleted_at"
+	"created_at, updated_at, deleted_at, pii_filter"
 
 // Deployment represents a row in the model_deployments table.
 // Each deployment is a concrete upstream endpoint associated with a model.
@@ -37,6 +37,10 @@ type Deployment struct {
 	CreatedAt   string
 	UpdatedAt   string
 	DeletedAt   *string
+	// PIIFilter explicitly enables or disables PII anonymization for requests
+	// routed to this deployment. Nil means not set — inherit the model-level or
+	// network-level default. true enables anonymization; false disables it.
+	PIIFilter *bool
 }
 
 // CreateDeploymentParams holds the input for creating a deployment.
@@ -57,6 +61,10 @@ type CreateDeploymentParams struct {
 	// Priority is the routing preference for the priority strategy; lower value
 	// means higher priority. 0 is the highest priority.
 	Priority int
+	// PIIFilter, when non-nil, stores the PII anonymization override for this
+	// deployment. true enables anonymization; false disables it. Nil stores NULL
+	// (inherit model-level or network-level default).
+	PIIFilter *bool
 }
 
 // UpdateDeploymentParams holds optional fields for a partial deployment update.
@@ -76,6 +84,12 @@ type UpdateDeploymentParams struct {
 	Weight *int
 	// Priority, when non-nil, replaces the stored routing priority.
 	Priority *int
+	// PIIFilter, when non-nil, sets the PII anonymization override for this
+	// deployment. true enables anonymization; false disables it.
+	PIIFilter *bool
+	// ClearPIIFilter, when true, sets the pii_filter column to NULL regardless
+	// of the PIIFilter pointer value. Allows callers to revert to inherit-from-model.
+	ClearPIIFilter bool
 }
 
 // CreateDeployment inserts a new deployment and returns the persisted record.
@@ -95,12 +109,12 @@ func (d *DB) CreateDeployment(ctx context.Context, params CreateDeploymentParams
 	insertQuery := "INSERT INTO model_deployments " +
 		"(id, model_id, name, provider, base_url, api_key_encrypted, " +
 		"azure_deployment, azure_api_version, gcp_project, gcp_location, " +
-		"weight, priority, is_active, " +
+		"weight, priority, is_active, pii_filter, " +
 		"created_at, updated_at) " +
 		"VALUES (" +
 		p(1) + ", " + p(2) + ", " + p(3) + ", " + p(4) + ", " + p(5) + ", " + p(6) + ", " +
 		p(7) + ", " + p(8) + ", " + p(9) + ", " + p(10) + ", " + p(11) + ", " + p(12) + ", " +
-		"1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
+		"1, " + p(13) + ", CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
 
 	selectQuery := "SELECT " + deploymentSelectColumns +
 		" FROM model_deployments WHERE id = " + p(1) + " AND deleted_at IS NULL"
@@ -120,6 +134,7 @@ func (d *DB) CreateDeployment(ctx context.Context, params CreateDeploymentParams
 			params.GCPLocation,
 			weight,
 			params.Priority,
+			boolPtrToNullableInt(params.PIIFilter),
 		)
 		if execErr != nil {
 			return translateError(execErr)
@@ -272,6 +287,13 @@ func (d *DB) UpdateDeployment(ctx context.Context, id string, params UpdateDeplo
 		args = append(args, *params.Priority)
 		argN++
 	}
+	if params.ClearPIIFilter {
+		setClauses = append(setClauses, "pii_filter = NULL")
+	} else if params.PIIFilter != nil {
+		setClauses = append(setClauses, "pii_filter = "+p(argN))
+		args = append(args, boolPtrToNullableInt(params.PIIFilter))
+		argN++
+	}
 
 	if len(setClauses) == 0 {
 		return d.GetDeployment(ctx, id)
@@ -379,15 +401,18 @@ func (d *DB) ListDeploymentsByModelIDs(ctx context.Context, modelIDs []string) (
 func scanDeployment(scanner interface{ Scan(...any) error }) (*Deployment, error) {
 	var dep Deployment
 	var isActiveInt int
+	var piiFilterInt *int64
 	err := scanner.Scan(
 		&dep.ID, &dep.ModelID, &dep.Name, &dep.Provider, &dep.BaseURL, &dep.APIKeyEncrypted,
 		&dep.AzureDeployment, &dep.AzureAPIVersion, &dep.GCPProject, &dep.GCPLocation,
 		&dep.Weight, &dep.Priority,
 		&isActiveInt, &dep.CreatedAt, &dep.UpdatedAt, &dep.DeletedAt,
+		&piiFilterInt,
 	)
 	if err != nil {
 		return nil, err
 	}
 	dep.IsActive = isActiveInt == 1
+	dep.PIIFilter = nullableIntToBoolPtr(piiFilterInt)
 	return &dep, nil
 }

--- a/internal/db/migrations/0014_pii_filter_flag.down.sql
+++ b/internal/db/migrations/0014_pii_filter_flag.down.sql
@@ -1,0 +1,12 @@
+-- Migration: 0014_pii_filter_flag.down.sql
+-- Description: Reverses 0014_pii_filter_flag.up.sql.
+--
+-- DROP COLUMN requires SQLite >= 3.35.0 and cannot be used portably across all
+-- supported SQLite versions. Following the established project convention
+-- (see 0009_gcp_fields.down.sql), this down migration is a no-op.
+-- The columns remain in place but carry no data and have no effect when the
+-- feature is not active.
+--
+-- To drop the columns manually on PostgreSQL:
+--   ALTER TABLE models DROP COLUMN IF EXISTS pii_filter;
+--   ALTER TABLE model_deployments DROP COLUMN IF EXISTS pii_filter;

--- a/internal/db/migrations/0014_pii_filter_flag.up.sql
+++ b/internal/db/migrations/0014_pii_filter_flag.up.sql
@@ -1,0 +1,23 @@
+-- Migration: 0014_pii_filter_flag.up.sql
+-- Description: Add pii_filter column to models and model_deployments.
+--
+-- The pii_filter flag controls per-model/deployment PII anonymization and
+-- overrides the network-level default configured in voidllm.yaml. Without this
+-- column the flag was present in YAML config but lost on the YAML → DB → registry
+-- roundtrip, so the DB-persisted value always silently fell back to the network
+-- default regardless of what was declared in the YAML.
+--
+-- Semantics (three-state nullable boolean):
+--   NULL  - not set; inherit the network-level pii_filter default
+--   1     - PII anonymization explicitly enabled for this model/deployment
+--   0     - PII anonymization explicitly disabled for this model/deployment
+--
+-- Stored as INTEGER (SQLite and PostgreSQL compatible). The CHECK constraint
+-- mirrors the convention used for other boolean columns in this schema
+-- (e.g. is_active on model_deployments).
+
+ALTER TABLE models
+    ADD COLUMN pii_filter INTEGER CHECK (pii_filter IN (0, 1));
+
+ALTER TABLE model_deployments
+    ADD COLUMN pii_filter INTEGER CHECK (pii_filter IN (0, 1));

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -18,7 +18,7 @@ const modelSelectColumns = "id, name, provider, model_type, base_url, api_key_en
 	"max_context_tokens, input_price_per_1m, output_price_per_1m, " +
 	"azure_deployment, azure_api_version, gcp_project, gcp_location, " +
 	"is_active, source, created_by, created_at, updated_at, deleted_at, aliases, timeout, " +
-	"strategy, max_retries, fallback_model_id"
+	"strategy, max_retries, fallback_model_id, pii_filter"
 
 // Model represents a model record in the database.
 // This is the storage layer representation; see proxy.Model for the in-memory registry type.
@@ -61,6 +61,10 @@ type Model struct {
 	// FallbackModelID is the ID of the model to try when all deployments of
 	// this model are unavailable. Nil when no fallback is configured.
 	FallbackModelID *string
+	// PIIFilter explicitly enables or disables PII anonymization for requests
+	// routed to this model. Nil means not set — inherit the network-level default.
+	// true enables anonymization; false disables it.
+	PIIFilter *bool
 }
 
 // CreateModelParams holds the input for creating a model.
@@ -95,6 +99,10 @@ type CreateModelParams struct {
 	MaxRetries *int
 	// FallbackModelID is the ID of the fallback model. Nil means no fallback.
 	FallbackModelID *string
+	// PIIFilter, when non-nil, stores the PII anonymization override for this
+	// model. true enables anonymization; false disables it. Nil stores NULL
+	// (inherit network-level default).
+	PIIFilter *bool
 }
 
 // UpdateModelParams holds optional fields for updating a model.
@@ -128,6 +136,17 @@ type UpdateModelParams struct {
 	// FallbackModelID, when non-nil, replaces the stored fallback model ID.
 	// Set to a pointer to an empty string to clear the fallback.
 	FallbackModelID *string
+	// PIIFilter, when non-nil, replaces the stored PII anonymization override.
+	// To clear the override and revert to the network-level default, set this
+	// to a special sentinel — use UpdateModelClearPIIFilter instead, or set a
+	// non-nil pointer containing the desired bool.
+	// Note: to express "clear to NULL", callers should use ClearPIIFilter bool
+	// (see below). This *bool field sets the column to 0 or 1 only.
+	PIIFilter *bool
+	// ClearPIIFilter, when true, sets the pii_filter column to NULL regardless
+	// of the PIIFilter pointer value. Allows callers to explicitly revert to the
+	// inherit-from-network-default state.
+	ClearPIIFilter bool
 }
 
 // CreateModel inserts a new model and returns the persisted record.
@@ -158,13 +177,13 @@ func (d *DB) CreateModel(ctx context.Context, params CreateModelParams) (*Model,
 		"max_context_tokens, input_price_per_1m, output_price_per_1m, " +
 		"azure_deployment, azure_api_version, gcp_project, gcp_location, " +
 		"is_active, source, created_by, aliases, timeout, strategy, max_retries, " +
-		"fallback_model_id, created_at, updated_at) " +
+		"fallback_model_id, pii_filter, created_at, updated_at) " +
 		"VALUES (" +
 		p(1) + ", " + p(2) + ", " + p(3) + ", " + p(4) + ", " + p(5) + ", " + p(6) + ", " +
 		p(7) + ", " + p(8) + ", " + p(9) + ", " +
 		p(10) + ", " + p(11) + ", " + p(12) + ", " + p(13) + ", " +
 		"1, " + p(14) + ", " + p(15) + ", " + p(16) + ", " + p(17) + ", " + p(18) + ", " + p(19) + ", " +
-		p(20) + ", " +
+		p(20) + ", " + p(21) + ", " +
 		"CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
 
 	selectQuery := "SELECT " + modelSelectColumns +
@@ -193,6 +212,7 @@ func (d *DB) CreateModel(ctx context.Context, params CreateModelParams) (*Model,
 			strategy,
 			maxRetries,
 			params.FallbackModelID,
+			boolPtrToNullableInt(params.PIIFilter),
 		)
 		if execErr != nil {
 			return translateError(execErr)
@@ -385,6 +405,13 @@ func (d *DB) UpdateModel(ctx context.Context, id string, params UpdateModelParam
 			argN++
 		}
 	}
+	if params.ClearPIIFilter {
+		setClauses = append(setClauses, "pii_filter = NULL")
+	} else if params.PIIFilter != nil {
+		setClauses = append(setClauses, "pii_filter = "+p(argN))
+		args = append(args, boolPtrToNullableInt(params.PIIFilter))
+		argN++
+	}
 
 	if len(setClauses) == 0 {
 		return d.GetModel(ctx, id)
@@ -522,11 +549,37 @@ func (d *DB) ListActiveModels(ctx context.Context) ([]Model, error) {
 	return models, nil
 }
 
+// boolPtrToNullableInt converts a *bool to a nullable integer value suitable
+// for storing in a SQLite/PostgreSQL INTEGER column that represents a
+// three-state boolean (NULL=inherit, 1=true, 0=false). A nil pointer returns
+// nil (stores NULL); true returns 1; false returns 0.
+func boolPtrToNullableInt(v *bool) any {
+	if v == nil {
+		return nil
+	}
+	if *v {
+		return 1
+	}
+	return 0
+}
+
+// nullableIntToBoolPtr converts a nullable integer column value (scanned as
+// *int64) back to a *bool. A nil pointer (NULL column) returns nil; 1 returns
+// a pointer to true; any other value returns a pointer to false.
+func nullableIntToBoolPtr(v *int64) *bool {
+	if v == nil {
+		return nil
+	}
+	b := *v == 1
+	return &b
+}
+
 // scanModel scans a single model row. The scanner may be a *sql.Row (from
 // QueryRowContext) or *sql.Rows (from QueryContext); both satisfy the interface.
 func scanModel(scanner interface{ Scan(...any) error }) (*Model, error) {
 	var m Model
 	var isActiveInt int
+	var piiFilterInt *int64
 	err := scanner.Scan(
 		&m.ID, &m.Name, &m.Provider, &m.ModelType, &m.BaseURL, &m.APIKeyEncrypted,
 		&m.MaxContextTokens, &m.InputPricePer1M, &m.OutputPricePer1M,
@@ -534,11 +587,13 @@ func scanModel(scanner interface{ Scan(...any) error }) (*Model, error) {
 		&isActiveInt, &m.Source, &m.CreatedBy,
 		&m.CreatedAt, &m.UpdatedAt, &m.DeletedAt, &m.Aliases, &m.Timeout,
 		&m.Strategy, &m.MaxRetries, &m.FallbackModelID,
+		&piiFilterInt,
 	)
 	if err != nil {
 		return nil, err
 	}
 	m.IsActive = isActiveInt == 1
+	m.PIIFilter = nullableIntToBoolPtr(piiFilterInt)
 	return &m, nil
 }
 
@@ -613,6 +668,7 @@ func (d *DB) SyncYAMLModels(ctx context.Context, models []config.ModelConfig, en
 				Timeout:          m.Timeout,
 				Strategy:         &strategy,
 				MaxRetries:       &maxRetries,
+				PIIFilter:        m.PIIFilter,
 			})
 			if createErr != nil {
 				return fmt.Errorf("sync yaml models: create %s: %w", m.Name, createErr)
@@ -680,6 +736,11 @@ func (d *DB) SyncYAMLModels(ctx context.Context, models []config.ModelConfig, en
 			Timeout:          &timeout,
 			Strategy:         &strategy,
 			MaxRetries:       &maxRetries,
+			// Sync the YAML pii_filter value. If the YAML does not set pii_filter
+			// (nil), we clear the column back to NULL so that a previously-set
+			// value does not persist after the YAML flag is removed.
+			PIIFilter:      m.PIIFilter,
+			ClearPIIFilter: m.PIIFilter == nil,
 		}
 
 		if m.APIKey != "" {
@@ -746,6 +807,7 @@ func (d *DB) syncYAMLDeployments(ctx context.Context, modelID string, cfgDeps []
 				GCPLocation:     cd.GCPLocation,
 				Weight:          weight,
 				Priority:        cd.Priority,
+				PIIFilter:       cd.PIIFilter,
 			})
 			if createErr != nil {
 				return fmt.Errorf("create deployment %s: %w", cd.Name, createErr)
@@ -786,6 +848,10 @@ func (d *DB) syncYAMLDeployments(ctx context.Context, modelID string, cfgDeps []
 			GCPLocation:     &gcpLocation,
 			Weight:          &weight,
 			Priority:        &priority,
+			// Sync the YAML pii_filter value. Clear to NULL when not set in YAML
+			// so that removing the flag from YAML also clears the DB column.
+			PIIFilter:      cd.PIIFilter,
+			ClearPIIFilter: cd.PIIFilter == nil,
 		}
 
 		if cd.APIKey != "" {

--- a/internal/pii/json.go
+++ b/internal/pii/json.go
@@ -1,0 +1,769 @@
+package pii
+
+import (
+	"errors"
+	"sort"
+	"strings"
+
+	"github.com/voidmind-io/voidllm/internal/jsonx"
+)
+
+// anonymizeWithDetectors replaces PII in all PII-bearing string fields of an
+// OpenAI-shaped request body. It handles chat completion, legacy completion,
+// and embeddings request shapes. Covered fields:
+//
+// Chat completions:
+//   - messages[].content (string or array-of-parts "text" field)
+//   - messages[].name
+//   - messages[].tool_calls[].function.arguments (JSON string, scanned as text)
+//   - messages[].function_call.arguments (legacy, JSON string, scanned as text)
+//   - tools[].function.description
+//   - tools[].function.parameters: string leaf values only (description, default,
+//     enum strings, title, etc.); object structure and keys are never modified.
+//   - top-level "user"
+//
+// Completions (legacy):
+//   - top-level "prompt" (string or array-of-strings)
+//
+// Embeddings:
+//   - top-level "input" (string or array-of-strings; array-of-ints/token-arrays left unchanged)
+//
+// detectors are called for each string value to locate PII spans. replace
+// is called once per unique (type, originalValue) to obtain the pseudonym;
+// it returns an error if the per-request mapping cap is exceeded.
+//
+// Fail-closed: returns an error when the body cannot be parsed, any covered
+// field is present but has an unexpected type/shape, any field cannot be
+// re-serialized, or replace returns an error. Error messages never contain
+// body content or PII values.
+func anonymizeWithDetectors(body []byte, detectors []Detector, replace func(typ, value string) (string, error)) ([]byte, error) {
+	detect := func(text string) (string, bool, error) {
+		var spans []Span
+		for _, d := range detectors {
+			spans = append(spans, d.Find(text)...)
+		}
+		if len(spans) == 0 {
+			return text, false, nil
+		}
+		// Sort and de-overlap merged spans from all detectors.
+		sort.Slice(spans, func(i, j int) bool {
+			if spans[i].Start != spans[j].Start {
+				return spans[i].Start < spans[j].Start
+			}
+			return spans[i].End > spans[j].End // longest first on tie
+		})
+		spans = deOverlap(spans)
+		out, touched, err := replaceSpansInText(text, spans, replace)
+		return out, touched, err
+	}
+
+	var doc map[string]jsonx.RawMessage
+	if err := jsonx.Unmarshal(body, &doc); err != nil {
+		return nil, errors.New("pii: request body could not be processed for anonymization")
+	}
+
+	touched := false
+
+	// ── top-level "user" field ──────────────────────────────────────────────
+	// Fail-closed: when "user" is present but is not a string, reject rather
+	// than silently forwarding unscanned content (e.g. an object or array).
+	if rawUser, ok := doc["user"]; ok {
+		var userStr string
+		if err := jsonx.Unmarshal(rawUser, &userStr); err != nil {
+			return nil, errors.New("pii: request body could not be processed for anonymization")
+		}
+		replaced, did, err := detect(userStr)
+		if err != nil {
+			return nil, errors.New("pii: request body could not be processed for anonymization")
+		}
+		if did {
+			newJSON, err := jsonx.Marshal(replaced)
+			if err != nil {
+				return nil, errors.New("pii: request body could not be processed for anonymization")
+			}
+			doc["user"] = jsonx.RawMessage(newJSON)
+			touched = true
+		}
+	}
+
+	// ── legacy completion "prompt" field ────────────────────────────────────
+	// /v1/completions carries text in the top-level "prompt" field, which may
+	// be a string, string[], int[], or int[][] (token arrays). String elements
+	// are scanned for PII; non-string elements (token IDs, token-ID arrays) are
+	// PII-free and passed through unchanged. When "prompt" is present but is
+	// neither a string nor an array, its shape is unsupported for a covered
+	// field — reject the request (fail-closed) rather than forwarding unscanned
+	// content. This mirrors the "input" handling for embeddings exactly.
+	if rawPrompt, ok := doc["prompt"]; ok {
+		// Try string prompt first.
+		var promptStr string
+		if err := jsonx.Unmarshal(rawPrompt, &promptStr); err == nil {
+			replaced, did, err := detect(promptStr)
+			if err != nil {
+				return nil, errors.New("pii: request body could not be processed for anonymization")
+			}
+			if did {
+				newJSON, err := jsonx.Marshal(replaced)
+				if err != nil {
+					return nil, errors.New("pii: request body could not be processed for anonymization")
+				}
+				doc["prompt"] = jsonx.RawMessage(newJSON)
+				touched = true
+			}
+		} else {
+			// Not a string: try array.
+			var promptArr []jsonx.RawMessage
+			if err2 := jsonx.Unmarshal(rawPrompt, &promptArr); err2 == nil {
+				arrTouched := false
+				for i, elem := range promptArr {
+					// Each element may be a string, an integer (token ID), or an
+					// integer array (token-ID array, int[][]). Scan string elements
+					// for PII; leave integer and integer-array elements untouched.
+					// Fail-closed on any other shape (object, bool, null) — those
+					// are not valid OpenAI prompt element types.
+					var s string
+					if err := jsonx.Unmarshal(elem, &s); err == nil {
+						replaced, did, err := detect(s)
+						if err != nil {
+							return nil, errors.New("pii: request body could not be processed for anonymization")
+						}
+						if did {
+							newJSON, err := jsonx.Marshal(replaced)
+							if err != nil {
+								return nil, errors.New("pii: request body could not be processed for anonymization")
+							}
+							promptArr[i] = jsonx.RawMessage(newJSON)
+							arrTouched = true
+						}
+						continue
+					}
+					// Not a string: must be a number or a number-array (token IDs).
+					// Validate the element is an integer or an array-of-integers so
+					// that objects, bools, and other unexpected types are rejected.
+					if !isTokenElement(elem) {
+						return nil, errors.New("pii: request body could not be processed for anonymization")
+					}
+					// Valid token-ID element (number or int[]): leave unchanged.
+				}
+				if arrTouched {
+					newJSON, err := jsonx.Marshal(promptArr)
+					if err != nil {
+						return nil, errors.New("pii: request body could not be processed for anonymization")
+					}
+					doc["prompt"] = jsonx.RawMessage(newJSON)
+					touched = true
+				}
+			} else {
+				// "prompt" is present but is neither a string nor an array:
+				// unsupported shape for a covered field → fail-closed.
+				return nil, errors.New("pii: request body could not be processed for anonymization")
+			}
+		}
+	}
+
+	// ── embeddings "input" field ─────────────────────────────────────────────
+	// /v1/embeddings carries text in the top-level "input" field, which may be
+	// a string or an array of strings (or array of token-integer-arrays, which
+	// are left unchanged). When "input" is present but is neither a string nor
+	// an array, its shape is unsupported for the covered field — reject the
+	// request (fail-closed) rather than forwarding unscanned content.
+	if rawInput, ok := doc["input"]; ok {
+		var inputStr string
+		if err := jsonx.Unmarshal(rawInput, &inputStr); err == nil {
+			// String input: scan and replace.
+			replaced, did, err := detect(inputStr)
+			if err != nil {
+				return nil, errors.New("pii: request body could not be processed for anonymization")
+			}
+			if did {
+				newJSON, err := jsonx.Marshal(replaced)
+				if err != nil {
+					return nil, errors.New("pii: request body could not be processed for anonymization")
+				}
+				doc["input"] = jsonx.RawMessage(newJSON)
+				touched = true
+			}
+		} else {
+			// Not a string: try array.
+			var inputArr []jsonx.RawMessage
+			if err2 := jsonx.Unmarshal(rawInput, &inputArr); err2 == nil {
+				arrTouched := false
+				for i, elem := range inputArr {
+					// Each element may be a string or an integer array (token array,
+					// int[][]). Scan string elements; leave integer and integer-array
+					// elements untouched. Fail-closed on any other shape (object,
+					// bool, null) — those are not valid OpenAI input element types.
+					var s string
+					if err := jsonx.Unmarshal(elem, &s); err == nil {
+						replaced, did, err := detect(s)
+						if err != nil {
+							return nil, errors.New("pii: request body could not be processed for anonymization")
+						}
+						if did {
+							newJSON, err := jsonx.Marshal(replaced)
+							if err != nil {
+								return nil, errors.New("pii: request body could not be processed for anonymization")
+							}
+							inputArr[i] = jsonx.RawMessage(newJSON)
+							arrTouched = true
+						}
+						continue
+					}
+					// Not a string: must be a number or a number-array (token IDs).
+					// Validate the element so that objects, bools, and other
+					// unexpected types are rejected (fail-closed).
+					if !isTokenElement(elem) {
+						return nil, errors.New("pii: request body could not be processed for anonymization")
+					}
+					// Valid token-ID element: leave unchanged.
+				}
+				if arrTouched {
+					newJSON, err := jsonx.Marshal(inputArr)
+					if err != nil {
+						return nil, errors.New("pii: request body could not be processed for anonymization")
+					}
+					doc["input"] = jsonx.RawMessage(newJSON)
+					touched = true
+				}
+			} else {
+				// "input" is present but is neither a string nor an array:
+				// unsupported shape for a covered field → fail-closed.
+				return nil, errors.New("pii: request body could not be processed for anonymization")
+			}
+		}
+	}
+
+	// ── tools[].function.description + parameters string leaves ─────────────
+	// tools[].function.description is scanned for PII.
+	// tools[].function.parameters: only string LEAF values are scanned (e.g.
+	// description, default, enum strings, title). Object keys and structure are
+	// never modified. "tools" present but not an array → fail-closed.
+	if rawTools, ok := doc["tools"]; ok {
+		var tools []jsonx.RawMessage
+		if err := jsonx.Unmarshal(rawTools, &tools); err != nil {
+			// "tools" is present but not an array: unsupported shape.
+			return nil, errors.New("pii: request body could not be processed for anonymization")
+		}
+		toolsTouched := false
+		for i, rawTool := range tools {
+			var tool map[string]jsonx.RawMessage
+			if err := jsonx.Unmarshal(rawTool, &tool); err != nil {
+				continue
+			}
+			rawFn, hasFn := tool["function"]
+			if !hasFn {
+				continue
+			}
+			var fn map[string]jsonx.RawMessage
+			if err := jsonx.Unmarshal(rawFn, &fn); err != nil {
+				continue
+			}
+			fnTouched := false
+
+			// tools[].function.description
+			// Fail-closed: when "description" is present but is not a string,
+			// reject rather than silently forwarding unscanned content.
+			if rawDesc, hasDesc := fn["description"]; hasDesc {
+				var desc string
+				if err := jsonx.Unmarshal(rawDesc, &desc); err != nil {
+					return nil, errors.New("pii: request body could not be processed for anonymization")
+				}
+				replaced, did, err := detect(desc)
+				if err != nil {
+					return nil, errors.New("pii: request body could not be processed for anonymization")
+				}
+				if did {
+					newJSON, err := jsonx.Marshal(replaced)
+					if err != nil {
+						return nil, errors.New("pii: request body could not be processed for anonymization")
+					}
+					fn["description"] = jsonx.RawMessage(newJSON)
+					fnTouched = true
+				}
+			}
+
+			// tools[].function.parameters: scan string leaf values only.
+			if rawParams, hasParams := fn["parameters"]; hasParams {
+				scanned, paramsTouched, err := scanStringLeaves(rawParams, detect)
+				if err != nil {
+					return nil, errors.New("pii: request body could not be processed for anonymization")
+				}
+				if paramsTouched {
+					fn["parameters"] = scanned
+					fnTouched = true
+				}
+			}
+
+			if fnTouched {
+				newFnJSON, err := jsonx.Marshal(fn)
+				if err != nil {
+					return nil, errors.New("pii: request body could not be processed for anonymization")
+				}
+				tool["function"] = jsonx.RawMessage(newFnJSON)
+				newToolJSON, err := jsonx.Marshal(tool)
+				if err != nil {
+					return nil, errors.New("pii: request body could not be processed for anonymization")
+				}
+				tools[i] = jsonx.RawMessage(newToolJSON)
+				toolsTouched = true
+			}
+		}
+		if toolsTouched {
+			newToolsJSON, err := jsonx.Marshal(tools)
+			if err != nil {
+				return nil, errors.New("pii: request body could not be processed for anonymization")
+			}
+			doc["tools"] = jsonx.RawMessage(newToolsJSON)
+			touched = true
+		}
+	}
+
+	// ── messages array ───────────────────────────────────────────────────────
+	rawMessages, hasMessages := doc["messages"]
+	if hasMessages {
+		var messages []jsonx.RawMessage
+		if err := jsonx.Unmarshal(rawMessages, &messages); err != nil {
+			return nil, errors.New("pii: request body could not be processed for anonymization")
+		}
+
+		for i, rawMsg := range messages {
+			var msg map[string]jsonx.RawMessage
+			if err := jsonx.Unmarshal(rawMsg, &msg); err != nil {
+				continue
+			}
+			msgTouched := false
+
+			// messages[].name
+			// Fail-closed: when "name" is present but is not a string, reject
+			// rather than silently forwarding unscanned content.
+			if rawName, ok := msg["name"]; ok {
+				var name string
+				if err := jsonx.Unmarshal(rawName, &name); err != nil {
+					return nil, errors.New("pii: request body could not be processed for anonymization")
+				}
+				replaced, did, err := detect(name)
+				if err != nil {
+					return nil, errors.New("pii: request body could not be processed for anonymization")
+				}
+				if did {
+					newJSON, err := jsonx.Marshal(replaced)
+					if err != nil {
+						return nil, errors.New("pii: request body could not be processed for anonymization")
+					}
+					msg["name"] = jsonx.RawMessage(newJSON)
+					msgTouched = true
+				}
+			}
+
+			// messages[].content (string or array-of-parts).
+			// Fail-closed: when "content" is present but is neither a string
+			// nor an array, the shape is unsupported for a covered field — reject.
+			if rawContent, ok := msg["content"]; ok {
+				var strContent string
+				if err := jsonx.Unmarshal(rawContent, &strContent); err == nil {
+					// String content path.
+					replaced, did, err := detect(strContent)
+					if err != nil {
+						return nil, errors.New("pii: request body could not be processed for anonymization")
+					}
+					if did {
+						newJSON, err := jsonx.Marshal(replaced)
+						if err != nil {
+							return nil, errors.New("pii: request body could not be processed for anonymization")
+						}
+						msg["content"] = jsonx.RawMessage(newJSON)
+						msgTouched = true
+					}
+				} else {
+					// Array content (multi-modal parts) path.
+					var parts []jsonx.RawMessage
+					if err := jsonx.Unmarshal(rawContent, &parts); err == nil {
+						partsTouched := false
+						for j, rawPart := range parts {
+							var part map[string]jsonx.RawMessage
+							if err := jsonx.Unmarshal(rawPart, &part); err != nil {
+								continue
+							}
+							var partType string
+							if rawType, hasType := part["type"]; hasType {
+								_ = jsonx.Unmarshal(rawType, &partType)
+							}
+							if partType != "text" {
+								continue
+							}
+							rawText, hasText := part["text"]
+							if !hasText {
+								continue
+							}
+							var textVal string
+							if err := jsonx.Unmarshal(rawText, &textVal); err != nil {
+								continue
+							}
+							replaced, did, err := detect(textVal)
+							if err != nil {
+								return nil, errors.New("pii: request body could not be processed for anonymization")
+							}
+							if did {
+								newJSON, err := jsonx.Marshal(replaced)
+								if err != nil {
+									return nil, errors.New("pii: request body could not be processed for anonymization")
+								}
+								part["text"] = jsonx.RawMessage(newJSON)
+								newPartJSON, err := jsonx.Marshal(part)
+								if err != nil {
+									return nil, errors.New("pii: request body could not be processed for anonymization")
+								}
+								parts[j] = jsonx.RawMessage(newPartJSON)
+								partsTouched = true
+							}
+						}
+						if partsTouched {
+							newPartsJSON, err := jsonx.Marshal(parts)
+							if err != nil {
+								return nil, errors.New("pii: request body could not be processed for anonymization")
+							}
+							msg["content"] = jsonx.RawMessage(newPartsJSON)
+							msgTouched = true
+						}
+					} else {
+						// "content" is present but is neither a string nor an array:
+						// unsupported shape for a covered field → fail-closed.
+						return nil, errors.New("pii: request body could not be processed for anonymization")
+					}
+				}
+			}
+
+			// messages[].function_call.arguments (legacy function call).
+			// Fail-closed: when "function_call" is present but not an object, or
+			// "arguments" is present but not a string → reject.
+			if rawFC, ok := msg["function_call"]; ok {
+				var fc map[string]jsonx.RawMessage
+				if err := jsonx.Unmarshal(rawFC, &fc); err != nil {
+					// "function_call" present but not an object: unsupported shape.
+					return nil, errors.New("pii: request body could not be processed for anonymization")
+				}
+				if rawArgs, ok := fc["arguments"]; ok {
+					var args string
+					if err := jsonx.Unmarshal(rawArgs, &args); err != nil {
+						// "arguments" present but not a string: unsupported shape.
+						return nil, errors.New("pii: request body could not be processed for anonymization")
+					}
+					replaced, did, err := detect(args)
+					if err != nil {
+						return nil, errors.New("pii: request body could not be processed for anonymization")
+					}
+					if did {
+						newJSON, err := jsonx.Marshal(replaced)
+						if err != nil {
+							return nil, errors.New("pii: request body could not be processed for anonymization")
+						}
+						fc["arguments"] = jsonx.RawMessage(newJSON)
+						newFCJSON, err := jsonx.Marshal(fc)
+						if err != nil {
+							return nil, errors.New("pii: request body could not be processed for anonymization")
+						}
+						msg["function_call"] = jsonx.RawMessage(newFCJSON)
+						msgTouched = true
+					}
+				}
+			}
+
+			// messages[].tool_calls[].function.arguments.
+			// Fail-closed: when "tool_calls" is present but not an array → reject.
+			// When "arguments" is present but not a string within a tool call → reject.
+			if rawTC, ok := msg["tool_calls"]; ok {
+				var toolCalls []jsonx.RawMessage
+				if err := jsonx.Unmarshal(rawTC, &toolCalls); err != nil {
+					// "tool_calls" present but not an array: unsupported shape.
+					return nil, errors.New("pii: request body could not be processed for anonymization")
+				}
+				tcTouched := false
+				for ti, rawCall := range toolCalls {
+					var call map[string]jsonx.RawMessage
+					if err := jsonx.Unmarshal(rawCall, &call); err != nil {
+						continue
+					}
+					rawCallFn, hasFn := call["function"]
+					if !hasFn {
+						continue
+					}
+					var callFn map[string]jsonx.RawMessage
+					if err := jsonx.Unmarshal(rawCallFn, &callFn); err != nil {
+						continue
+					}
+					rawArgs, hasArgs := callFn["arguments"]
+					if !hasArgs {
+						continue
+					}
+					var args string
+					if err := jsonx.Unmarshal(rawArgs, &args); err != nil {
+						// "arguments" present but not a string: unsupported shape.
+						return nil, errors.New("pii: request body could not be processed for anonymization")
+					}
+					replaced, did, err := detect(args)
+					if err != nil {
+						return nil, errors.New("pii: request body could not be processed for anonymization")
+					}
+					if did {
+						newJSON, err := jsonx.Marshal(replaced)
+						if err != nil {
+							return nil, errors.New("pii: request body could not be processed for anonymization")
+						}
+						callFn["arguments"] = jsonx.RawMessage(newJSON)
+						newCallFnJSON, err := jsonx.Marshal(callFn)
+						if err != nil {
+							return nil, errors.New("pii: request body could not be processed for anonymization")
+						}
+						call["function"] = jsonx.RawMessage(newCallFnJSON)
+						newCallJSON, err := jsonx.Marshal(call)
+						if err != nil {
+							return nil, errors.New("pii: request body could not be processed for anonymization")
+						}
+						toolCalls[ti] = jsonx.RawMessage(newCallJSON)
+						tcTouched = true
+					}
+				}
+				if tcTouched {
+					newTCJSON, err := jsonx.Marshal(toolCalls)
+					if err != nil {
+						return nil, errors.New("pii: request body could not be processed for anonymization")
+					}
+					msg["tool_calls"] = jsonx.RawMessage(newTCJSON)
+					msgTouched = true
+				}
+			}
+
+			if msgTouched {
+				newMsgJSON, err := jsonx.Marshal(msg)
+				if err != nil {
+					return nil, errors.New("pii: request body could not be processed for anonymization")
+				}
+				messages[i] = jsonx.RawMessage(newMsgJSON)
+				touched = true
+			}
+		}
+
+		if touched {
+			newMessagesJSON, err := jsonx.Marshal(messages)
+			if err != nil {
+				return nil, errors.New("pii: request body could not be processed for anonymization")
+			}
+			doc["messages"] = jsonx.RawMessage(newMessagesJSON)
+		}
+	}
+
+	if !touched {
+		// No modifications: return a fresh copy of the original (not the
+		// re-serialized doc) to preserve byte-for-byte fidelity and avoid
+		// a pointless round-trip.
+		out := make([]byte, len(body))
+		copy(out, body)
+		return out, nil
+	}
+
+	out, err := jsonx.Marshal(doc)
+	if err != nil {
+		return nil, errors.New("pii: request body could not be processed for anonymization")
+	}
+	return out, nil
+}
+
+// replaceSpansInText substitutes the given non-overlapping, Start-sorted
+// spans in text with pseudonyms returned by replace. A single left-to-right
+// pass over the sorted spans builds the result with a strings.Builder,
+// copying the unchanged gap between consecutive spans directly. This is O(n)
+// in the length of text with at most one allocation for the Builder's buffer.
+// Returns an error if replace returns an error for any span.
+func replaceSpansInText(text string, spans []Span, replace func(typ, value string) (string, error)) (string, bool, error) {
+	if len(spans) == 0 {
+		return text, false, nil
+	}
+	var b strings.Builder
+	b.Grow(len(text)) // pre-size: result length is close to input length
+	cursor := 0
+	for _, s := range spans {
+		// Copy the unchanged prefix between the previous span's end and this
+		// span's start. Spans are Start-sorted and non-overlapping, so cursor
+		// is always <= s.Start.
+		b.WriteString(text[cursor:s.Start])
+		orig := text[s.Start:s.End]
+		pseudo, err := replace(s.Type, orig)
+		if err != nil {
+			return "", false, err
+		}
+		b.WriteString(pseudo)
+		cursor = s.End
+	}
+	// Append any trailing text after the last span.
+	b.WriteString(text[cursor:])
+	return b.String(), true, nil
+}
+
+// deOverlap removes overlapping spans from a Start-ascending sorted slice,
+// keeping the leftmost span and discarding any that starts before the
+// previous span ends.
+func deOverlap(spans []Span) []Span {
+	if len(spans) == 0 {
+		return spans
+	}
+	result := spans[:1]
+	cursor := spans[0].End
+	for _, s := range spans[1:] {
+		if s.Start < cursor {
+			continue
+		}
+		result = append(result, s)
+		cursor = s.End
+	}
+	return result
+}
+
+// isTokenElement reports whether raw is a valid OpenAI token-ID element: either
+// a JSON number (single token ID) or a JSON array whose every element is itself
+// a valid token-ID element (int[][]). Objects, booleans, null, and strings are
+// not token IDs and cause the function to return false. This is used to validate
+// non-string elements in the "prompt" and "input" array fields before passing
+// them through unscanned, ensuring that unexpected shapes are rejected
+// (fail-closed) rather than silently forwarded.
+func isTokenElement(raw jsonx.RawMessage) bool {
+	// A number: valid single token ID. Try to unmarshal as int64 first (exact
+	// for token IDs), then float64 (handles any numeric JSON literal).
+	var n int64
+	if jsonx.Unmarshal(raw, &n) == nil {
+		return true
+	}
+	var f float64
+	if jsonx.Unmarshal(raw, &f) == nil {
+		return true
+	}
+
+	// An array: every element must itself be a valid token element (int[]).
+	var arr []jsonx.RawMessage
+	if jsonx.Unmarshal(raw, &arr) == nil {
+		for _, elem := range arr {
+			if !isTokenElement(elem) {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Anything else (object, bool, null, string) is not a token ID.
+	return false
+}
+
+// maxScanDepth is the maximum recursion depth for scanStringLeavesDepth.
+// A tools[].function.parameters JSON Schema is unlikely to exceed a handful of
+// nesting levels; 128 is a generous upper bound that still prevents a malicious
+// or pathologically nested schema from causing a goroutine stack overflow.
+const maxScanDepth = 128
+
+// scanStringLeaves recursively traverses a JSON value encoded as RawMessage
+// and applies detect to every string leaf it finds. Object keys are never
+// modified; only string values are scanned. Arrays of non-strings are
+// traversed recursively but non-string leaves are left untouched.
+//
+// This is used to scan tools[].function.parameters, which is a JSON Schema
+// object that may contain PII in string-valued fields (description, default,
+// enum strings, title, etc.) while its structure (object shape, key names)
+// must be preserved exactly.
+//
+// Recursion is bounded by maxScanDepth. A body whose parameters object is
+// nested beyond that limit is rejected (fail-closed) rather than traversed.
+//
+// Returns the (possibly modified) RawMessage, a bool indicating whether any
+// replacement was made, and any error from detect or re-serialization.
+func scanStringLeaves(raw jsonx.RawMessage, detect func(string) (string, bool, error)) (jsonx.RawMessage, bool, error) {
+	return scanStringLeavesDepth(raw, detect, 0)
+}
+
+// scanStringLeavesDepth is the depth-bounded implementation of scanStringLeaves.
+// depth is the current recursion depth; the initial caller passes 0.
+func scanStringLeavesDepth(raw jsonx.RawMessage, detect func(string) (string, bool, error), depth int) (jsonx.RawMessage, bool, error) {
+	if depth > maxScanDepth {
+		return nil, false, errors.New("pii: parameters schema exceeds maximum nesting depth")
+	}
+
+	// Try string first.
+	var s string
+	if err := jsonx.Unmarshal(raw, &s); err == nil {
+		replaced, did, err := detect(s)
+		if err != nil {
+			return nil, false, err
+		}
+		if !did {
+			return raw, false, nil
+		}
+		newJSON, err := jsonx.Marshal(replaced)
+		if err != nil {
+			return nil, false, err
+		}
+		return jsonx.RawMessage(newJSON), true, nil
+	}
+
+	// Try object: scan each key and each value recursively.
+	//
+	// Key scanning: object keys in a JSON Schema (tools[].function.parameters)
+	// are structural identifiers. Pseudonymizing a key would corrupt the schema
+	// (the upstream model expects the original field names). Therefore, if any
+	// key matches a PII pattern we fail-closed rather than forwarding unscanned
+	// or corrupted content.
+	var obj map[string]jsonx.RawMessage
+	if err := jsonx.Unmarshal(raw, &obj); err == nil {
+		objTouched := false
+		for k, v := range obj {
+			// Scan the key for PII. If the key contains PII, fail-closed:
+			// rewriting a structural key would corrupt the schema.
+			_, keyHasPII, err := detect(k)
+			if err != nil {
+				return nil, false, err
+			}
+			if keyHasPII {
+				return nil, false, errors.New("pii: parameters schema contains PII in an object key")
+			}
+			scanned, did, err := scanStringLeavesDepth(v, detect, depth+1)
+			if err != nil {
+				return nil, false, err
+			}
+			if did {
+				obj[k] = scanned
+				objTouched = true
+			}
+		}
+		if !objTouched {
+			return raw, false, nil
+		}
+		newJSON, err := jsonx.Marshal(obj)
+		if err != nil {
+			return nil, false, err
+		}
+		return jsonx.RawMessage(newJSON), true, nil
+	}
+
+	// Try array: scan each element recursively.
+	var arr []jsonx.RawMessage
+	if err := jsonx.Unmarshal(raw, &arr); err == nil {
+		arrTouched := false
+		for i, elem := range arr {
+			scanned, did, err := scanStringLeavesDepth(elem, detect, depth+1)
+			if err != nil {
+				return nil, false, err
+			}
+			if did {
+				arr[i] = scanned
+				arrTouched = true
+			}
+		}
+		if !arrTouched {
+			return raw, false, nil
+		}
+		newJSON, err := jsonx.Marshal(arr)
+		if err != nil {
+			return nil, false, err
+		}
+		return jsonx.RawMessage(newJSON), true, nil
+	}
+
+	// Scalar (number, bool, null): leave unchanged.
+	return raw, false, nil
+}

--- a/internal/pii/json.go
+++ b/internal/pii/json.go
@@ -1,12 +1,108 @@
 package pii
 
 import (
+	"encoding/json"
 	"errors"
 	"sort"
 	"strings"
 
 	"github.com/voidmind-io/voidllm/internal/jsonx"
 )
+
+// knownContentPartTypes is the set of non-text content-part type values that
+// carry no textual content and should be skipped (not scanned, not rejected).
+// Any type value NOT in this set and NOT "text" triggers fail-closed.
+var knownContentPartTypes = map[string]bool{
+	"image_url":   true,
+	"input_audio": true,
+	"input_image": true,
+	"file":        true,
+	"image":       true,
+	"audio":       true,
+	"document":    true,
+	"video":       true,
+}
+
+// hasDuplicateKeys reports whether body contains a JSON object (at any level of
+// nesting) that has at least one duplicated key. It uses encoding/json's
+// token-streaming decoder (stdlib, no CGO). Duplicate keys are rejected because
+// JSON decoders that retain the first value rather than the last (or vice-versa)
+// can disagree on the effective content, enabling smuggling attacks where PII
+// appears in a first-occurrence key that the map-based scanner does not see but
+// the upstream LLM does.
+//
+// Returns (true, nil) when a duplicate is found, (false, nil) on a clean
+// document, and (false, err) when the token stream is malformed (the caller
+// should treat this as fail-closed regardless).
+func hasDuplicateKeys(body []byte) (bool, error) {
+	dec := json.NewDecoder(strings.NewReader(string(body)))
+	return scanForDuplicateKeys(dec)
+}
+
+// scanForDuplicateKeys reads tokens from dec to walk a single JSON value and
+// returns true on the first duplicate object key found at any nesting depth.
+// It is called recursively for nested objects and array elements.
+func scanForDuplicateKeys(dec *json.Decoder) (bool, error) {
+	tok, err := dec.Token()
+	if err != nil {
+		return false, err
+	}
+
+	delim, ok := tok.(json.Delim)
+	if !ok {
+		// Scalar value (string, number, bool, null): no keys to check.
+		return false, nil
+	}
+
+	switch delim {
+	case '{':
+		seen := make(map[string]struct{})
+		for dec.More() {
+			// Read the key token.
+			keyTok, err := dec.Token()
+			if err != nil {
+				return false, err
+			}
+			key, ok := keyTok.(string)
+			if !ok {
+				return false, errors.New("expected string key in JSON object")
+			}
+			if _, exists := seen[key]; exists {
+				return true, nil
+			}
+			seen[key] = struct{}{}
+			// Recurse into the value.
+			dup, err := scanForDuplicateKeys(dec)
+			if err != nil {
+				return false, err
+			}
+			if dup {
+				return true, nil
+			}
+		}
+		// Consume the closing '}'.
+		if _, err := dec.Token(); err != nil {
+			return false, err
+		}
+
+	case '[':
+		for dec.More() {
+			dup, err := scanForDuplicateKeys(dec)
+			if err != nil {
+				return false, err
+			}
+			if dup {
+				return true, nil
+			}
+		}
+		// Consume the closing ']'.
+		if _, err := dec.Token(); err != nil {
+			return false, err
+		}
+	}
+
+	return false, nil
+}
 
 // anonymizeWithDetectors replaces PII in all PII-bearing string fields of an
 // OpenAI-shaped request body. It handles chat completion, legacy completion,
@@ -57,8 +153,21 @@ func anonymizeWithDetectors(body []byte, detectors []Detector, replace func(typ,
 		return out, touched, err
 	}
 
+	// Fix #3: reject any body that contains duplicate JSON object keys anywhere
+	// in the document (recursive, all nesting levels). A body with duplicate keys
+	// can be parsed differently by different JSON implementations — the map-based
+	// scan below sees only the last value for each key, while some upstream servers
+	// retain the first. This creates a smuggling window where PII appears in an
+	// earlier duplicate that the scanner does not see. Fail-closed here eliminates
+	// the window; the !touched original-return path is also safe because dup-key
+	// bodies are rejected before reaching it.
+	if dup, dupErr := hasDuplicateKeys(body); dupErr != nil || dup {
+		return nil, errors.New("pii: request body could not be processed for anonymization")
+	}
+
 	var doc map[string]jsonx.RawMessage
-	if err := jsonx.Unmarshal(body, &doc); err != nil {
+	if err := jsonx.Unmarshal(body, &doc); err != nil || doc == nil {
+		// A JSON null body or a non-object body cannot be scanned: fail-closed.
 		return nil, errors.New("pii: request body could not be processed for anonymization")
 	}
 
@@ -137,13 +246,13 @@ func anonymizeWithDetectors(body []byte, detectors []Detector, replace func(typ,
 						}
 						continue
 					}
-					// Not a string: must be a number or a number-array (token IDs).
-					// Validate the element is an integer or an array-of-integers so
-					// that objects, bools, and other unexpected types are rejected.
-					if !isTokenElement(elem) {
+					// Not a string: must be an integer or an array-of-integers (token IDs).
+					// Validate the element so that objects, bools, floats, and other
+					// unexpected types are rejected (fail-closed).
+					if !isTokenElement(elem, 0) {
 						return nil, errors.New("pii: request body could not be processed for anonymization")
 					}
-					// Valid token-ID element (number or int[]): leave unchanged.
+					// Valid token-ID element (integer or int[]): leave unchanged.
 				}
 				if arrTouched {
 					newJSON, err := jsonx.Marshal(promptArr)
@@ -192,7 +301,7 @@ func anonymizeWithDetectors(body []byte, detectors []Detector, replace func(typ,
 					// Each element may be a string or an integer array (token array,
 					// int[][]). Scan string elements; leave integer and integer-array
 					// elements untouched. Fail-closed on any other shape (object,
-					// bool, null) — those are not valid OpenAI input element types.
+					// bool, null, float) — those are not valid OpenAI input element types.
 					var s string
 					if err := jsonx.Unmarshal(elem, &s); err == nil {
 						replaced, did, err := detect(s)
@@ -209,10 +318,10 @@ func anonymizeWithDetectors(body []byte, detectors []Detector, replace func(typ,
 						}
 						continue
 					}
-					// Not a string: must be a number or a number-array (token IDs).
-					// Validate the element so that objects, bools, and other
+					// Not a string: must be an integer or array-of-integers (token IDs).
+					// Validate the element so that objects, bools, floats, and other
 					// unexpected types are rejected (fail-closed).
-					if !isTokenElement(elem) {
+					if !isTokenElement(elem, 0) {
 						return nil, errors.New("pii: request body could not be processed for anonymization")
 					}
 					// Valid token-ID element: leave unchanged.
@@ -240,23 +349,25 @@ func anonymizeWithDetectors(body []byte, detectors []Detector, replace func(typ,
 	// never modified. "tools" present but not an array → fail-closed.
 	if rawTools, ok := doc["tools"]; ok {
 		var tools []jsonx.RawMessage
-		if err := jsonx.Unmarshal(rawTools, &tools); err != nil {
-			// "tools" is present but not an array: unsupported shape.
+		if err := jsonx.Unmarshal(rawTools, &tools); err != nil || tools == nil {
+			// "tools" is present but not an array (or is JSON null): unsupported shape.
 			return nil, errors.New("pii: request body could not be processed for anonymization")
 		}
 		toolsTouched := false
 		for i, rawTool := range tools {
 			var tool map[string]jsonx.RawMessage
-			if err := jsonx.Unmarshal(rawTool, &tool); err != nil {
-				continue
+			if err := jsonx.Unmarshal(rawTool, &tool); err != nil || tool == nil {
+				// tools[] element is not a JSON object (or is JSON null): unsupported shape → fail-closed.
+				return nil, errors.New("pii: request body could not be processed for anonymization")
 			}
 			rawFn, hasFn := tool["function"]
 			if !hasFn {
 				continue
 			}
 			var fn map[string]jsonx.RawMessage
-			if err := jsonx.Unmarshal(rawFn, &fn); err != nil {
-				continue
+			if err := jsonx.Unmarshal(rawFn, &fn); err != nil || fn == nil {
+				// tools[].function is not a JSON object (or is JSON null): unsupported shape → fail-closed.
+				return nil, errors.New("pii: request body could not be processed for anonymization")
 			}
 			fnTouched := false
 
@@ -322,14 +433,16 @@ func anonymizeWithDetectors(body []byte, detectors []Detector, replace func(typ,
 	rawMessages, hasMessages := doc["messages"]
 	if hasMessages {
 		var messages []jsonx.RawMessage
-		if err := jsonx.Unmarshal(rawMessages, &messages); err != nil {
+		if err := jsonx.Unmarshal(rawMessages, &messages); err != nil || messages == nil {
+			// "messages" is present but not an array (or is JSON null): unsupported shape.
 			return nil, errors.New("pii: request body could not be processed for anonymization")
 		}
 
 		for i, rawMsg := range messages {
 			var msg map[string]jsonx.RawMessage
-			if err := jsonx.Unmarshal(rawMsg, &msg); err != nil {
-				continue
+			if err := jsonx.Unmarshal(rawMsg, &msg); err != nil || msg == nil {
+				// messages[] element is not a JSON object (or is JSON null): unsupported shape → fail-closed.
+				return nil, errors.New("pii: request body could not be processed for anonymization")
 			}
 			msgTouched := false
 
@@ -377,44 +490,62 @@ func anonymizeWithDetectors(body []byte, detectors []Detector, replace func(typ,
 				} else {
 					// Array content (multi-modal parts) path.
 					var parts []jsonx.RawMessage
-					if err := jsonx.Unmarshal(rawContent, &parts); err == nil {
+					if err := jsonx.Unmarshal(rawContent, &parts); err == nil && parts != nil {
 						partsTouched := false
 						for j, rawPart := range parts {
 							var part map[string]jsonx.RawMessage
-							if err := jsonx.Unmarshal(rawPart, &part); err != nil {
-								continue
-							}
-							var partType string
-							if rawType, hasType := part["type"]; hasType {
-								_ = jsonx.Unmarshal(rawType, &partType)
-							}
-							if partType != "text" {
-								continue
-							}
-							rawText, hasText := part["text"]
-							if !hasText {
-								continue
-							}
-							var textVal string
-							if err := jsonx.Unmarshal(rawText, &textVal); err != nil {
-								continue
-							}
-							replaced, did, err := detect(textVal)
-							if err != nil {
+							if err := jsonx.Unmarshal(rawPart, &part); err != nil || part == nil {
+								// content array element is not a JSON object (or is JSON null) → fail-closed.
 								return nil, errors.New("pii: request body could not be processed for anonymization")
 							}
-							if did {
-								newJSON, err := jsonx.Marshal(replaced)
+							rawType, hasType := part["type"]
+							if !hasType {
+								// content array element has no "type" field → fail-closed:
+								// we cannot determine whether it carries text that needs scanning.
+								return nil, errors.New("pii: request body could not be processed for anonymization")
+							}
+							var partType string
+							if err := jsonx.Unmarshal(rawType, &partType); err != nil {
+								// "type" field is not a string → fail-closed.
+								return nil, errors.New("pii: request body could not be processed for anonymization")
+							}
+							if partType == "text" {
+								// Text part: scan and replace PII in the "text" field.
+								rawText, hasText := part["text"]
+								if !hasText {
+									// text part without a "text" field — nothing to scan; skip.
+									continue
+								}
+								var textVal string
+								if err := jsonx.Unmarshal(rawText, &textVal); err != nil {
+									// "text" field is not a string → fail-closed.
+									return nil, errors.New("pii: request body could not be processed for anonymization")
+								}
+								replaced, did, err := detect(textVal)
 								if err != nil {
 									return nil, errors.New("pii: request body could not be processed for anonymization")
 								}
-								part["text"] = jsonx.RawMessage(newJSON)
-								newPartJSON, err := jsonx.Marshal(part)
-								if err != nil {
-									return nil, errors.New("pii: request body could not be processed for anonymization")
+								if did {
+									newJSON, err := jsonx.Marshal(replaced)
+									if err != nil {
+										return nil, errors.New("pii: request body could not be processed for anonymization")
+									}
+									part["text"] = jsonx.RawMessage(newJSON)
+									newPartJSON, err := jsonx.Marshal(part)
+									if err != nil {
+										return nil, errors.New("pii: request body could not be processed for anonymization")
+									}
+									parts[j] = jsonx.RawMessage(newPartJSON)
+									partsTouched = true
 								}
-								parts[j] = jsonx.RawMessage(newPartJSON)
-								partsTouched = true
+							} else if knownContentPartTypes[partType] {
+								// Known non-text part (image_url, input_audio, file, etc.):
+								// carries no scannable text, pass through unchanged.
+								continue
+							} else {
+								// Unknown type: we cannot determine whether this part carries
+								// text that needs scanning → fail-closed (conservative).
+								return nil, errors.New("pii: request body could not be processed for anonymization")
 							}
 						}
 						if partsTouched {
@@ -438,8 +569,8 @@ func anonymizeWithDetectors(body []byte, detectors []Detector, replace func(typ,
 			// "arguments" is present but not a string → reject.
 			if rawFC, ok := msg["function_call"]; ok {
 				var fc map[string]jsonx.RawMessage
-				if err := jsonx.Unmarshal(rawFC, &fc); err != nil {
-					// "function_call" present but not an object: unsupported shape.
+				if err := jsonx.Unmarshal(rawFC, &fc); err != nil || fc == nil {
+					// "function_call" present but not an object (or is JSON null): unsupported shape.
 					return nil, errors.New("pii: request body could not be processed for anonymization")
 				}
 				if rawArgs, ok := fc["arguments"]; ok {
@@ -470,26 +601,28 @@ func anonymizeWithDetectors(body []byte, detectors []Detector, replace func(typ,
 
 			// messages[].tool_calls[].function.arguments.
 			// Fail-closed: when "tool_calls" is present but not an array → reject.
-			// When "arguments" is present but not a string within a tool call → reject.
+			// When an element is not an object, or "arguments" is not a string → reject.
 			if rawTC, ok := msg["tool_calls"]; ok {
 				var toolCalls []jsonx.RawMessage
-				if err := jsonx.Unmarshal(rawTC, &toolCalls); err != nil {
-					// "tool_calls" present but not an array: unsupported shape.
+				if err := jsonx.Unmarshal(rawTC, &toolCalls); err != nil || toolCalls == nil {
+					// "tool_calls" present but not an array (or is JSON null): unsupported shape.
 					return nil, errors.New("pii: request body could not be processed for anonymization")
 				}
 				tcTouched := false
 				for ti, rawCall := range toolCalls {
 					var call map[string]jsonx.RawMessage
-					if err := jsonx.Unmarshal(rawCall, &call); err != nil {
-						continue
+					if err := jsonx.Unmarshal(rawCall, &call); err != nil || call == nil {
+						// tool_calls[] element is not a JSON object (or is JSON null) → fail-closed.
+						return nil, errors.New("pii: request body could not be processed for anonymization")
 					}
 					rawCallFn, hasFn := call["function"]
 					if !hasFn {
 						continue
 					}
 					var callFn map[string]jsonx.RawMessage
-					if err := jsonx.Unmarshal(rawCallFn, &callFn); err != nil {
-						continue
+					if err := jsonx.Unmarshal(rawCallFn, &callFn); err != nil || callFn == nil {
+						// tool_calls[].function is not a JSON object (or is JSON null) → fail-closed.
+						return nil, errors.New("pii: request body could not be processed for anonymization")
 					}
 					rawArgs, hasArgs := callFn["arguments"]
 					if !hasArgs {
@@ -619,21 +752,42 @@ func deOverlap(spans []Span) []Span {
 }
 
 // isTokenElement reports whether raw is a valid OpenAI token-ID element: either
-// a JSON number (single token ID) or a JSON array whose every element is itself
-// a valid token-ID element (int[][]). Objects, booleans, null, and strings are
-// not token IDs and cause the function to return false. This is used to validate
-// non-string elements in the "prompt" and "input" array fields before passing
-// them through unscanned, ensuring that unexpected shapes are rejected
-// (fail-closed) rather than silently forwarded.
-func isTokenElement(raw jsonx.RawMessage) bool {
-	// A number: valid single token ID. Try to unmarshal as int64 first (exact
-	// for token IDs), then float64 (handles any numeric JSON literal).
+// a JSON integer (single token ID) or a JSON array whose every element is itself
+// a valid token-ID element (int[][]). Floats, objects, booleans, null, and
+// strings are not token IDs and cause the function to return false.
+//
+// depth limits recursion to prevent a stack-exhaustion DoS via pathologically
+// nested arrays. When depth > maxScanDepth the function returns false, which
+// causes the caller to fail-closed on that element.
+//
+// This is used to validate non-string elements in the "prompt" and "input"
+// array fields before passing them through unscanned, ensuring that unexpected
+// shapes are rejected (fail-closed) rather than silently forwarded.
+func isTokenElement(raw jsonx.RawMessage, depth int) bool {
+	if depth > maxScanDepth {
+		// Reject pathologically deep arrays to prevent stack exhaustion.
+		return false
+	}
+
+	// A JSON integer: valid single token ID. We require an exact integer
+	// (int64 unmarshal succeeds without loss). Floats/decimals are rejected
+	// because token IDs are always whole numbers; accepting floats would
+	// allow unexpected numeric shapes to pass through unscanned.
+	//
+	// Strategy: unmarshal as int64. If that succeeds, it is an integer.
+	// If the raw bytes contain a decimal point or exponent indicating a
+	// non-integer float, int64 unmarshal will fail, so we check the raw
+	// bytes for those markers before concluding it is not an integer.
 	var n int64
 	if jsonx.Unmarshal(raw, &n) == nil {
-		return true
-	}
-	var f float64
-	if jsonx.Unmarshal(raw, &f) == nil {
+		// Verify raw bytes do not contain a decimal point or exponent —
+		// some JSON libraries round floats to integers on unmarshal.
+		rawStr := string(raw)
+		for _, ch := range rawStr {
+			if ch == '.' || ch == 'e' || ch == 'E' {
+				return false // float-shaped literal, not a token ID
+			}
+		}
 		return true
 	}
 
@@ -641,21 +795,22 @@ func isTokenElement(raw jsonx.RawMessage) bool {
 	var arr []jsonx.RawMessage
 	if jsonx.Unmarshal(raw, &arr) == nil {
 		for _, elem := range arr {
-			if !isTokenElement(elem) {
+			if !isTokenElement(elem, depth+1) {
 				return false
 			}
 		}
 		return true
 	}
 
-	// Anything else (object, bool, null, string) is not a token ID.
+	// Anything else (object, bool, null, string, float) is not a token ID.
 	return false
 }
 
-// maxScanDepth is the maximum recursion depth for scanStringLeavesDepth.
-// A tools[].function.parameters JSON Schema is unlikely to exceed a handful of
-// nesting levels; 128 is a generous upper bound that still prevents a malicious
-// or pathologically nested schema from causing a goroutine stack overflow.
+// maxScanDepth is the maximum recursion depth for scanStringLeavesDepth and
+// for isTokenElement. A tools[].function.parameters JSON Schema is unlikely to
+// exceed a handful of nesting levels; 128 is a generous upper bound that still
+// prevents a malicious or pathologically nested document from causing a
+// goroutine stack overflow.
 const maxScanDepth = 128
 
 // scanStringLeaves recursively traverses a JSON value encoded as RawMessage

--- a/internal/pii/pii.go
+++ b/internal/pii/pii.go
@@ -1,0 +1,212 @@
+// Package pii provides in-memory PII detection and pseudonymization for
+// LLM proxy requests. It intercepts outbound request bodies, replaces
+// personally-identifiable values with deterministic pseudonyms, and
+// restores the originals in the response — all without persisting or
+// logging any sensitive content.
+//
+// Zero-knowledge guarantee: no PII value, original or pseudonymized, is
+// ever written to logs, the database, or any usage event. The mapping
+// lives exclusively in the per-request Filter and is garbage-collected
+// when the request finishes.
+package pii
+
+import (
+	"errors"
+	"strings"
+)
+
+// maxPIIMappings is the maximum number of unique PII-to-pseudonym mappings
+// permitted within a single request. A request body of 20 MB could
+// theoretically contain up to ~1 million short values; bounding the map
+// prevents unbounded memory growth while still covering every realistic
+// document. When the cap is reached, AnonymizeJSON returns an error and
+// the proxy rejects the request (fail-closed).
+const maxPIIMappings = 10_000
+
+// Span describes a single PII match within a string. Start and End are
+// byte offsets (half-open interval [Start, End)) into the original text.
+// Type is the detector-assigned label (e.g. "EMAIL", "IBAN").
+type Span struct {
+	// Start is the inclusive start byte offset of the matched value.
+	Start int
+	// End is the exclusive end byte offset of the matched value.
+	End int
+	// Type is the PII category label assigned by the detector.
+	Type string
+}
+
+// Detector finds PII spans within a plain-text string. Implementations
+// must be safe for concurrent reuse across requests — they may not carry
+// per-request state. All expensive initialisation (regexp compilation,
+// model loading) must happen in the constructor, not in Find.
+type Detector interface {
+	// Find returns all non-overlapping PII spans found in text.
+	// The returned slice may be nil or empty when no PII is detected.
+	// Overlapping matches are resolved according to each implementation's
+	// documented policy (typically: longest match or leftmost wins).
+	Find(text string) []Span
+}
+
+// Engine is the shared, request-independent factory for PII filters. It
+// holds the compiled detectors and the per-installation pseudonym secret
+// derived from the main encryption key. Create one Engine at startup and
+// call NewFilter once per proxy request.
+//
+// Engine must not be used after Close has been called.
+type Engine struct {
+	secret    []byte
+	detectors []Detector
+}
+
+// NewEngine constructs an Engine from a pre-derived pseudonym secret and
+// a list of detectors. The secret should be derived from the installation
+// encryption key using HKDF with a stable info string so that the same
+// value always produces the same pseudonym across requests (within a
+// single installation lifetime). The caller owns the secret slice; Engine
+// makes an internal copy.
+func NewEngine(secret []byte, detectors []Detector) *Engine {
+	s := make([]byte, len(secret))
+	copy(s, secret)
+	return &Engine{
+		secret:    s,
+		detectors: detectors,
+	}
+}
+
+// NewFilter creates a fresh, empty Filter scoped to orgID for a single
+// proxy request. The orgID is incorporated into every pseudonym derivation
+// so that the same PII value maps to different tokens across organisations,
+// preventing cross-tenant correlation.
+//
+// The returned Filter is not safe for concurrent use; each request must
+// create its own instance via this method.
+func (e *Engine) NewFilter(orgID string) *Filter {
+	return &Filter{
+		secret:    e.secret,
+		orgID:     orgID,
+		detectors: e.detectors,
+		fwd:       make(map[string]string),
+		rev:       make(map[string]string),
+	}
+}
+
+// Close zeros the Engine's internal secret material. After Close,
+// NewFilter produces Filters whose pseudonyms are derived from a zeroed
+// key and will not match any previously issued pseudonyms. Call Close
+// exactly once at application shutdown, after all in-flight requests have
+// completed.
+func (e *Engine) Close() {
+	for i := range e.secret {
+		e.secret[i] = 0
+	}
+}
+
+// Filter is a per-request PII anonymization context. It holds the
+// forward map (original -> pseudonym) used to anonymize outbound content
+// and the reverse map (pseudonym -> original) used to restore values in
+// the response. A Filter must not be shared between goroutines or reused
+// across requests.
+type Filter struct {
+	secret    []byte
+	orgID     string
+	detectors []Detector
+	// fwd maps (type + NUL + NORMALIZED value) to their pseudonyms, ensuring
+	// that semantically equivalent values (e.g. email addresses differing only
+	// in case) always map to the same pseudonym. Using the normalized form as
+	// the key guarantees that "User@x.com" and "user@x.com" share one fwd entry
+	// and one rev entry. The rev entry is set to the FIRST-SEEN original form
+	// (see pseudonymFor) and is never overwritten, so restore always returns the
+	// original form as first encountered in the request.
+	fwd map[string]string
+	// rev maps pseudonyms back to the original values for response restore.
+	// Each pseudonym maps to the first-seen original form; subsequent occurrences
+	// of a semantically equivalent value (same type + normalized form) reuse the
+	// same fwd entry and do not overwrite rev.
+	rev map[string]string
+	// replacer is built lazily the first time Restore is called and cached
+	// for subsequent calls. Streaming restore calls Restore once per SSE
+	// chunk, so avoiding repeated construction matters on the hot path.
+	replacer *strings.Replacer
+}
+
+// AnonymizeJSON replaces PII found in PII-bearing fields of an
+// OpenAI-shaped request body with deterministic pseudonyms. The returned
+// slice is a new allocation; the input is never modified.
+//
+// Fail-closed: when the body cannot be parsed, reassembled, or when the
+// unique-mapping cap is exceeded, an error is returned. The caller must
+// reject the request rather than forward the original body, because a
+// later routing hop may be external and would receive raw PII.
+// Error messages never contain body content or PII values.
+func (f *Filter) AnonymizeJSON(body []byte) ([]byte, error) {
+	out, err := anonymizeWithDetectors(body, f.detectors, func(typ, value string) (string, error) {
+		return f.pseudonymFor(typ, value)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// Restore replaces all known pseudonyms in text with their original
+// values. It is safe to call on any byte slice, not just JSON — the
+// replacement is a plain string substitution over the raw bytes. When
+// nothing was anonymized (Touched returns false), Restore is a no-op and
+// returns the original slice without allocating.
+//
+// The internal strings.Replacer is built once on the first call and
+// cached for subsequent calls (relevant for streaming restore, where
+// Restore may be called once per SSE chunk).
+func (f *Filter) Restore(text []byte) []byte {
+	if len(f.rev) == 0 {
+		return text
+	}
+	if f.replacer == nil {
+		pairs := make([]string, 0, len(f.rev)*2)
+		for pseudo, orig := range f.rev {
+			pairs = append(pairs, pseudo, orig)
+		}
+		f.replacer = strings.NewReplacer(pairs...)
+	}
+	return []byte(f.replacer.Replace(string(text)))
+}
+
+// Touched reports whether any PII was detected and replaced during
+// AnonymizeJSON. Callers can skip the Restore step when this returns
+// false, avoiding an unnecessary allocation on the response path.
+func (f *Filter) Touched() bool {
+	return len(f.rev) > 0
+}
+
+// pseudonymFor returns the stable pseudonym for (typ, value), creating
+// and recording the mapping on first call. Subsequent calls with the same
+// arguments return the cached pseudonym so that repeated occurrences of
+// the same PII value are replaced consistently throughout the request.
+//
+// Case-normalization semantics: the fwd map is keyed on (type, normalizedValue)
+// so that semantically equivalent values map to the same pseudonym. For example,
+// "User@x.com" and "user@x.com" both normalize to "user@x.com" (EMAIL type),
+// share one fwd entry, and produce the same pseudonym. The rev entry maps the
+// pseudonym to the FIRST-SEEN original form and is never overwritten — restore
+// always returns the first form encountered in the request (deterministic,
+// no data loss). Subsequent case variants of the same canonical value use the
+// existing fwd entry and leave rev unchanged.
+//
+// Returns an error when the mapping cap (maxPIIMappings) would be exceeded.
+func (f *Filter) pseudonymFor(typ, value string) (string, error) {
+	// Key on the normalized form so that case variants share one mapping.
+	norm := normalizeValue(typ, value)
+	key := typ + "\x00" + norm
+	if p, ok := f.fwd[key]; ok {
+		return p, nil
+	}
+	if len(f.fwd) >= maxPIIMappings {
+		return "", errors.New("pii: request exceeds maximum unique PII mapping count")
+	}
+	p := pseudonym(f.secret, f.orgID, typ, value) // pseudonym also normalizes internally
+	f.fwd[key] = p
+	// Set rev only on first occurrence: subsequent case variants of the same
+	// canonical value reuse the fwd entry (above) and never reach here.
+	f.rev[p] = value
+	return p, nil
+}

--- a/internal/pii/pii_new_test.go
+++ b/internal/pii/pii_new_test.go
@@ -1,0 +1,888 @@
+package pii
+
+// pii_new_test.go covers the additional cases required by the feat/pii-anonymization-stage0a
+// test task:
+//
+//  1. embeddings "input" field: string, array-of-strings, array-of-ints, unexpected shape
+//  2. tools[].function.parameters string-leaf scanning and structure preservation
+//  3. nested fail-closed: every covered field present with an unexpected type
+//  4. case round-trip: mixed-case email variants → same pseudonym; first-seen restore
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// ── 1. embeddings "input" field ──────────────────────────────────────────────
+
+func TestAnonymizeJSON_EmbeddingsInput_String(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	body := []byte(`{"model":"text-embedding-3-small","input":"mail an max@example.com bitte"}`)
+	out, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: unexpected error: %v", err)
+	}
+	if strings.Contains(string(out), "max@example.com") {
+		t.Error("input string: PII email still present in anonymized body")
+	}
+	if !f.Touched() {
+		t.Error("Touched() = false after PII in input string, want true")
+	}
+	restored := f.Restore(out)
+	if !strings.Contains(string(restored), "max@example.com") {
+		t.Errorf("restore: original email missing; got: %s", restored)
+	}
+}
+
+func TestAnonymizeJSON_EmbeddingsInput_ArrayOfStrings(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	body := []byte(`{"model":"text-embedding-3-small","input":["hello world","write to alice@test.example"]}`)
+	out, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: unexpected error: %v", err)
+	}
+	if strings.Contains(string(out), "alice@test.example") {
+		t.Error("array input: PII email still present in anonymized body")
+	}
+	// First element (clean) must still be present.
+	if !strings.Contains(string(out), "hello world") {
+		t.Error("array input: clean first element was modified or dropped")
+	}
+	if !f.Touched() {
+		t.Error("Touched() = false after PII in array input, want true")
+	}
+	restored := f.Restore(out)
+	if !strings.Contains(string(restored), "alice@test.example") {
+		t.Errorf("restore: original email missing from array input; got: %s", restored)
+	}
+}
+
+func TestAnonymizeJSON_EmbeddingsInput_ArrayOfInts(t *testing.T) {
+	t.Parallel()
+
+	// Token-IDs: integers, must pass through unchanged.
+	f := newTestFilter(t)
+	body := []byte(`{"model":"text-embedding-3-small","input":[1,2,3,100,200]}`)
+	out, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: unexpected error for int-array input: %v", err)
+	}
+	// No PII touched.
+	if f.Touched() {
+		t.Error("Touched() = true for int-array input, want false")
+	}
+	// Output JSON must contain the integers untouched.
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	var arr []int
+	if err := json.Unmarshal(doc["input"], &arr); err != nil {
+		t.Fatalf("input field is not an int array: %v", err)
+	}
+	want := []int{1, 2, 3, 100, 200}
+	if len(arr) != len(want) {
+		t.Fatalf("input array length = %d, want %d", len(arr), len(want))
+	}
+	for i, v := range arr {
+		if v != want[i] {
+			t.Errorf("input[%d] = %d, want %d", i, v, want[i])
+		}
+	}
+}
+
+func TestAnonymizeJSON_EmbeddingsInput_UnexpectedShape_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	// "input" is an object: neither string nor array → fail-closed.
+	f := newTestFilter(t)
+	body := []byte(`{"model":"text-embedding-3-small","input":{"nested":"object"}}`)
+	_, err := f.AnonymizeJSON(body)
+	if err == nil {
+		t.Error("AnonymizeJSON: expected error for object-shaped input, got nil (should be fail-closed)")
+	}
+	// Error must be content-free.
+	if strings.Contains(err.Error(), "nested") || strings.Contains(err.Error(), "object") {
+		t.Errorf("error message leaks body content: %q", err.Error())
+	}
+}
+
+// ── 2. tools[].function.parameters string-leaf scanning ──────────────────────
+
+func TestAnonymizeJSON_Tools_Parameters_StringLeaves(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	// parameters contains a "description" string with PII and various non-string
+	// leaf values (integer default, boolean enum item, null default) that must
+	// remain untouched.
+	body := []byte(`{
+		"model":"gpt-4",
+		"messages":[{"role":"user","content":"hello"}],
+		"tools":[{
+			"type":"function",
+			"function":{
+				"name":"contact_user",
+				"description":"no pii here",
+				"parameters":{
+					"type":"object",
+					"properties":{
+						"email":{
+							"type":"string",
+							"description":"Send result to info@params.example",
+							"default":"none"
+						},
+						"count":{
+							"type":"integer",
+							"default":5
+						},
+						"flag":{
+							"type":"boolean",
+							"default":true
+						}
+					},
+					"required":["email"]
+				}
+			}
+		}]
+	}`)
+
+	out, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: unexpected error: %v", err)
+	}
+
+	// PII email in parameters.properties.email.description must be replaced.
+	if strings.Contains(string(out), "info@params.example") {
+		t.Error("PII email in parameters.properties.email.description still present")
+	}
+	if !f.Touched() {
+		t.Error("Touched() = false after PII in parameters description, want true")
+	}
+
+	// JSON structure must be preserved: parse and verify non-PII fields.
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	var tools []json.RawMessage
+	if err := json.Unmarshal(doc["tools"], &tools); err != nil {
+		t.Fatalf("tools is not a JSON array: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Fatalf("tools length = %d, want 1", len(tools))
+	}
+	// Verify integer and boolean defaults survive unchanged.
+	var tool struct {
+		Function struct {
+			Parameters struct {
+				Properties struct {
+					Count struct {
+						Default json.RawMessage `json:"default"`
+					} `json:"count"`
+					Flag struct {
+						Default json.RawMessage `json:"default"`
+					} `json:"flag"`
+				} `json:"properties"`
+			} `json:"parameters"`
+		} `json:"function"`
+	}
+	if err := json.Unmarshal(tools[0], &tool); err != nil {
+		t.Fatalf("cannot unmarshal tool: %v", err)
+	}
+	if string(tool.Function.Parameters.Properties.Count.Default) != "5" {
+		t.Errorf("integer default mutated: got %s, want 5",
+			tool.Function.Parameters.Properties.Count.Default)
+	}
+	if string(tool.Function.Parameters.Properties.Flag.Default) != "true" {
+		t.Errorf("boolean default mutated: got %s, want true",
+			tool.Function.Parameters.Properties.Flag.Default)
+	}
+
+	// Restore must recover the PII email.
+	restored := f.Restore(out)
+	if !strings.Contains(string(restored), "info@params.example") {
+		t.Errorf("restore: original email missing from parameters description; got: %s", restored)
+	}
+}
+
+func TestAnonymizeJSON_Tools_NotAnArray_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	// "tools" is present but is not an array → fail-closed.
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"tools":"not-an-array"}`)
+	_, err := f.AnonymizeJSON(body)
+	if err == nil {
+		t.Error("AnonymizeJSON: expected error for non-array tools, got nil (should be fail-closed)")
+	}
+	if strings.Contains(err.Error(), "not-an-array") {
+		t.Errorf("error message leaks body content: %q", err.Error())
+	}
+}
+
+// ── 3. nested fail-closed: unexpected shapes for every covered field ──────────
+//
+// Each sub-test provides a PRESENT field with an unexpected type. A MISSING field
+// must not produce an error (the implementation skips absent fields).
+
+func TestAnonymizeJSON_FailClosed_ContentNotStringNorArray(t *testing.T) {
+	t.Parallel()
+
+	// messages[].content is a number, not a string or array.
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":42}]}`)
+	_, err := f.AnonymizeJSON(body)
+	if err == nil {
+		t.Error("expected fail-closed error for numeric content, got nil")
+	}
+	if strings.Contains(err.Error(), "42") {
+		t.Errorf("error message leaks body content: %q", err.Error())
+	}
+}
+
+func TestAnonymizeJSON_FailClosed_FunctionCallNotObject(t *testing.T) {
+	t.Parallel()
+
+	// messages[].function_call is a string, not an object.
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"assistant","function_call":"not-an-object","content":"hi"}]}`)
+	_, err := f.AnonymizeJSON(body)
+	if err == nil {
+		t.Error("expected fail-closed error for non-object function_call, got nil")
+	}
+	if strings.Contains(err.Error(), "not-an-object") {
+		t.Errorf("error message leaks body content: %q", err.Error())
+	}
+}
+
+func TestAnonymizeJSON_FailClosed_FunctionCallArgumentsNotString(t *testing.T) {
+	t.Parallel()
+
+	// messages[].function_call.arguments is a number, not a string.
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"assistant","function_call":{"name":"fn","arguments":123}}]}`)
+	_, err := f.AnonymizeJSON(body)
+	if err == nil {
+		t.Error("expected fail-closed error for non-string function_call.arguments, got nil")
+	}
+	if strings.Contains(err.Error(), "123") {
+		t.Errorf("error message leaks body content: %q", err.Error())
+	}
+}
+
+func TestAnonymizeJSON_FailClosed_ToolCallsNotArray(t *testing.T) {
+	t.Parallel()
+
+	// messages[].tool_calls is a string, not an array.
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"assistant","tool_calls":"not-an-array","content":"hi"}]}`)
+	_, err := f.AnonymizeJSON(body)
+	if err == nil {
+		t.Error("expected fail-closed error for non-array tool_calls, got nil")
+	}
+	if strings.Contains(err.Error(), "not-an-array") {
+		t.Errorf("error message leaks body content: %q", err.Error())
+	}
+}
+
+func TestAnonymizeJSON_FailClosed_ToolCallArgumentsNotString(t *testing.T) {
+	t.Parallel()
+
+	// messages[].tool_calls[i].function.arguments is a number, not a string.
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"fn","arguments":{"key":"val"}}}]}]}`)
+	_, err := f.AnonymizeJSON(body)
+	if err == nil {
+		t.Error("expected fail-closed error for non-string tool_calls[].function.arguments, got nil")
+	}
+}
+
+func TestAnonymizeJSON_FailClosed_MessagesNotArray(t *testing.T) {
+	t.Parallel()
+
+	// "messages" is a string, not an array.
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":"not-an-array"}`)
+	_, err := f.AnonymizeJSON(body)
+	if err == nil {
+		t.Error("expected fail-closed error for non-array messages, got nil")
+	}
+	if strings.Contains(err.Error(), "not-an-array") {
+		t.Errorf("error message leaks body content: %q", err.Error())
+	}
+}
+
+// Missing fields must NOT produce errors (conservative pass-through).
+
+func TestAnonymizeJSON_NoError_MissingMessages(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4"}`)
+	_, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Errorf("AnonymizeJSON with no messages field: unexpected error: %v", err)
+	}
+}
+
+func TestAnonymizeJSON_NoError_MissingFunctionCall(t *testing.T) {
+	t.Parallel()
+
+	// Message with no function_call field at all: no error.
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}`)
+	_, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Errorf("AnonymizeJSON with no function_call: unexpected error: %v", err)
+	}
+}
+
+func TestAnonymizeJSON_NoError_MissingToolCalls(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"assistant","content":"ok"}]}`)
+	_, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Errorf("AnonymizeJSON with no tool_calls: unexpected error: %v", err)
+	}
+}
+
+func TestAnonymizeJSON_NoError_MissingInput(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`)
+	_, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Errorf("AnonymizeJSON with no input field: unexpected error: %v", err)
+	}
+}
+
+// Error messages must never contain PII/body content.
+
+func TestAnonymizeJSON_FailClosed_ErrorMessageContentFree(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "object input",
+			body: []byte(`{"model":"x","input":{"pii":"secret@example.com"}}`),
+		},
+		{
+			name: "non-array messages",
+			body: []byte(`{"model":"x","messages":"secret@example.com"}`),
+		},
+		{
+			name: "non-array tools",
+			body: []byte(`{"model":"x","tools":"secret@example.com","messages":[]}`),
+		},
+		{
+			name: "non-object function_call",
+			body: []byte(`{"model":"x","messages":[{"role":"a","function_call":"secret@example.com","content":"hi"}]}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFilter(t)
+			_, err := f.AnonymizeJSON(tc.body)
+			if err == nil {
+				t.Errorf("[%s] expected fail-closed error, got nil", tc.name)
+				return
+			}
+			// The error message must not contain any content from the body.
+			if strings.Contains(err.Error(), "secret@example.com") {
+				t.Errorf("[%s] error message leaks PII: %q", tc.name, err.Error())
+			}
+			// A generic check: no raw JSON fragments from the body.
+			if strings.Contains(err.Error(), "{") || strings.Contains(err.Error(), "}") {
+				t.Errorf("[%s] error message appears to contain JSON fragments: %q", tc.name, err.Error())
+			}
+		})
+	}
+}
+
+// ── 4. case round-trip ─────────────────────────────────────────────────────────
+
+// TestFilter_CaseRoundtrip verifies that mixed-case variants of the same email
+// produce a single pseudonym and that restore always returns the FIRST-SEEN
+// original form, as documented in pseudonymFor.
+//
+// The semantics implemented: both "User@Example.com" and "user@example.com"
+// normalize to the same key, share one fwd entry, and one rev entry.
+// The rev entry is set to the FIRST-SEEN original form and never overwritten.
+// After restore, the client receives the original form as first encountered
+// in the body.
+func TestFilter_CaseRoundtrip_MixedCaseEmailSamePseudonym(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	// Both email variants appear in a single content string.
+	// "User@Example.com" is first (position-wise in the message).
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"User@Example.com and user@example.com are the same person"}]}`)
+	out, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: unexpected error: %v", err)
+	}
+
+	// Neither variant of the email must be visible in the anonymized body.
+	if strings.Contains(string(out), "@Example.com") || strings.Contains(string(out), "@example.com") {
+		t.Error("anonymized body still contains the email in some case variant")
+	}
+	if !f.Touched() {
+		t.Error("Touched() = false; expected PII to be detected")
+	}
+
+	// Both occurrences must be replaced by the SAME pseudonym (not two different ones).
+	// Count how many distinct PII_EM_ tokens appear.
+	outStr := string(out)
+	firstPseudo := ""
+	for p := range f.rev {
+		firstPseudo = p
+		break
+	}
+	if firstPseudo == "" {
+		t.Fatal("rev map is empty; no pseudonym was recorded")
+	}
+	// The pseudonym must appear twice in the output (one per original occurrence).
+	count := strings.Count(outStr, firstPseudo)
+	if count != 2 {
+		t.Errorf("expected pseudonym to appear 2 times, got %d; out: %s", count, outStr)
+	}
+
+	// Restore must map the pseudonym back to the FIRST-SEEN original form.
+	// The first occurrence in the body is "User@Example.com" (capital U and E).
+	restored := f.Restore(out)
+	restoredStr := string(restored)
+
+	// The pseudonym must not be visible after restore.
+	if strings.Contains(restoredStr, firstPseudo) {
+		t.Errorf("pseudonym still visible after restore: %s", restoredStr)
+	}
+
+	// Verify the rev map holds the first-seen form. The key point is that
+	// rev[pseudo] is set once (first occurrence) and never overwritten.
+	firstSeen, ok := f.rev[firstPseudo]
+	if !ok {
+		t.Fatalf("pseudonym %q not found in rev map", firstPseudo)
+	}
+	// After restore, exactly one of the two original forms must appear.
+	// Which form was "first seen" depends on left-to-right scan order in the
+	// text: "User@Example.com" appears earlier, so it must be first-seen.
+	// The rev entry must equal the first encountered form.
+	if firstSeen != "User@Example.com" && firstSeen != "user@example.com" {
+		t.Errorf("rev[pseudo] = %q is neither case variant", firstSeen)
+	}
+	// The restored output must contain the first-seen form exactly where the
+	// pseudonym was, and there must be NO residual pseudonym.
+	if !strings.Contains(restoredStr, firstSeen) {
+		t.Errorf("restored body does not contain first-seen original form %q; got: %s", firstSeen, restoredStr)
+	}
+	// No data loss: the restored content must contain the original value twice
+	// (once per pseudonym occurrence), all replaced with the single rev entry.
+	if strings.Count(restoredStr, firstSeen) != 2 {
+		t.Errorf("expected restored form to appear 2 times, got %d; out: %s",
+			strings.Count(restoredStr, firstSeen), restoredStr)
+	}
+}
+
+// TestFilter_CaseRoundtrip_NoCrash verifies there is no crash or panic
+// when the same canonical value is submitted many times with alternating case.
+func TestFilter_CaseRoundtrip_NoCrash(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	// Build a large body with 50 alternating-case occurrences of the same email.
+	var sb strings.Builder
+	sb.WriteString(`{"model":"gpt-4","messages":[{"role":"user","content":"`)
+	for i := 0; i < 50; i++ {
+		if i%2 == 0 {
+			sb.WriteString("Upper@CASE.example ")
+		} else {
+			sb.WriteString("upper@case.example ")
+		}
+	}
+	sb.WriteString(`"}]}`)
+
+	out, err := f.AnonymizeJSON([]byte(sb.String()))
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: unexpected error on repeated case variants: %v", err)
+	}
+	if !f.Touched() {
+		t.Error("Touched() = false; expected email to be detected")
+	}
+	// Only ONE rev entry must exist.
+	if len(f.rev) != 1 {
+		t.Errorf("expected exactly 1 rev entry (all variants normalize to the same key), got %d", len(f.rev))
+	}
+	// Restore must not panic and must not contain the pseudonym.
+	restored := f.Restore(out)
+	pseudo := ""
+	for p := range f.rev {
+		pseudo = p
+	}
+	if strings.Contains(string(restored), pseudo) {
+		t.Errorf("pseudonym still visible after restore: %s", restored)
+	}
+
+	// No data loss: the restored output must not be empty.
+	if len(restored) == 0 {
+		t.Error("restore returned empty output")
+	}
+}
+
+// TestFilter_CaseRoundtrip_RevNotOverwritten verifies the explicit contract:
+// when the same canonical value appears in both its original and a case-variant
+// form, the rev entry is set once (first occurrence) and never overwritten.
+// We verify this directly on the internal rev map, which pii_test.go uses freely
+// (white-box test, same package).
+func TestFilter_CaseRoundtrip_RevNotOverwritten(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	// Submit two-message body: first message has lowercase, second has uppercase.
+	// The lowercase variant arrives at AnonymizeJSON first (left-to-right scan).
+	body := []byte(`{"model":"gpt-4","messages":[` +
+		`{"role":"user","content":"first: lower@rev.example"},` +
+		`{"role":"assistant","content":"second: LOWER@REV.EXAMPLE"}` +
+		`]}`)
+
+	_, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: unexpected error: %v", err)
+	}
+	if !f.Touched() {
+		t.Error("Touched() = false; expected email to be detected")
+	}
+
+	// Verify only one rev entry exists.
+	if len(f.rev) != 1 {
+		t.Errorf("expected 1 rev entry, got %d; rev: %v", len(f.rev), f.rev)
+	}
+
+	// The first-seen form is "lower@rev.example" (appears in messages[0] which
+	// is processed before messages[1]).
+	var pseudo, orig string
+	for p, o := range f.rev {
+		pseudo = p
+		orig = o
+		break
+	}
+	if orig != "lower@rev.example" {
+		// If the implementation processes messages in a different order this
+		// assertion may need adjustment, but left-to-right scan is documented.
+		t.Errorf("rev[%q] = %q, want %q (first-seen form)", pseudo, orig, "lower@rev.example")
+	}
+}
+
+// TestAnonymizeJSON_Tools_NoArrayElements_NoError verifies that an empty tools
+// array does not cause an error (conservative edge case).
+func TestAnonymizeJSON_Tools_EmptyArray_NoError(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hello"}],"tools":[]}`)
+	_, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Errorf("AnonymizeJSON with empty tools array: unexpected error: %v", err)
+	}
+}
+
+// TestAnonymizeJSON_EmbeddingsInput_ArrayMixed verifies that a mixed array
+// (strings interspersed with integers) anonymizes only string elements and
+// leaves integer elements untouched. This exercises the per-element type
+// check in the array code path.
+func TestAnonymizeJSON_EmbeddingsInput_ArrayMixed(t *testing.T) {
+	t.Parallel()
+
+	// Arrays of integers in the embeddings API encode token IDs; if the
+	// API allows arrays of arrays (each being a token array), those are also
+	// left untouched. Here we test a flat array where some elements are
+	// strings containing PII and others are integers.
+	f := newTestFilter(t)
+	// Note: while mixing strings and ints in one array is unusual in the
+	// real OpenAI API, the code handles it element-by-element.
+	body := []byte(`{"model":"text-embedding-3-small","input":["send to bob@mixed.example",42,"also cc@mixed.example"]}`)
+	out, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: unexpected error: %v", err)
+	}
+	if strings.Contains(string(out), "bob@mixed.example") {
+		t.Error("first string element still contains PII email")
+	}
+	if strings.Contains(string(out), "cc@mixed.example") {
+		t.Error("third string element still contains PII email")
+	}
+	if !f.Touched() {
+		t.Error("Touched() = false after PII in mixed array, want true")
+	}
+
+	// Integer element must survive the round-trip.
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	var arr []json.RawMessage
+	if err := json.Unmarshal(doc["input"], &arr); err != nil {
+		t.Fatalf("input is not an array: %v", err)
+	}
+	if len(arr) != 3 {
+		t.Fatalf("input array length = %d, want 3", len(arr))
+	}
+	// Second element must still be integer 42.
+	var v int
+	if err := json.Unmarshal(arr[1], &v); err != nil {
+		t.Fatalf("arr[1] is not an integer after round-trip: %v (raw: %s)", err, arr[1])
+	}
+	if v != 42 {
+		t.Errorf("arr[1] = %d, want 42", v)
+	}
+}
+
+// ── Error sentinel test ───────────────────────────────────────────────────────
+
+// TestAnonymizeJSON_FailClosed_ErrorIsSentinel verifies that all fail-closed
+// paths return a non-nil error (no panic, no nil) for every covered field
+// with an unexpected shape. Uses errors.Is with a nil target as a "any error"
+// check.
+func TestAnonymizeJSON_FailClosed_AllShapes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"content is number", `{"model":"gpt-4","messages":[{"role":"user","content":42}]}`},
+		{"content is bool", `{"model":"gpt-4","messages":[{"role":"user","content":true}]}`},
+		{"function_call is array", `{"model":"gpt-4","messages":[{"role":"a","function_call":[],"content":"hi"}]}`},
+		{"function_call.arguments is object", `{"model":"gpt-4","messages":[{"role":"a","function_call":{"name":"f","arguments":{"x":1}}}]}`},
+		{"tool_calls is object", `{"model":"gpt-4","messages":[{"role":"a","tool_calls":{"a":1},"content":"hi"}]}`},
+		{"tool_calls[i].function.arguments is array", `{"model":"gpt-4","messages":[{"role":"a","tool_calls":[{"id":"c1","type":"function","function":{"name":"f","arguments":[]}}]}]}`},
+		{"messages is number", `{"model":"gpt-4","messages":123}`},
+		{"input is null-shaped object", `{"model":"x","input":{"nested":true}}`},
+		{"tools is string", `{"model":"x","tools":"bad","messages":[]}`},
+		// FIX 1: simple-string fields must fail-closed when present but not a string.
+		{"user is object", `{"model":"gpt-4","user":{"id":1},"messages":[]}`},
+		{"user is array", `{"model":"gpt-4","user":[1,2],"messages":[]}`},
+		{"user is number", `{"model":"gpt-4","user":42,"messages":[]}`},
+		{"messages[].name is object", `{"model":"gpt-4","messages":[{"role":"user","name":{},"content":"hi"}]}`},
+		{"messages[].name is number", `{"model":"gpt-4","messages":[{"role":"user","name":99,"content":"hi"}]}`},
+		{"tools[].function.description is number", `{"model":"gpt-4","messages":[],"tools":[{"type":"function","function":{"name":"f","description":42}}]}`},
+		{"tools[].function.description is object", `{"model":"gpt-4","messages":[],"tools":[{"type":"function","function":{"name":"f","description":{"x":1}}}]}`},
+		// FIX 1b: prompt/input array elements — non-string, non-number shapes.
+		{"prompt array element is object", `{"model":"gpt-3.5","prompt":[{"key":"val"}]}`},
+		{"prompt array element is bool", `{"model":"gpt-3.5","prompt":[true]}`},
+		{"input array element is object", `{"model":"text-emb","input":[{"key":"val"}]}`},
+		{"input array element is bool", `{"model":"text-emb","input":[false]}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFilter(t)
+			_, err := f.AnonymizeJSON([]byte(tc.body))
+			if err == nil {
+				t.Errorf("[%s] expected fail-closed error, got nil", tc.name)
+				return
+			}
+			// Verify the error is non-nil (errors.Is(err, nil) == false).
+			if errors.Is(err, nil) {
+				t.Errorf("[%s] errors.Is(err, nil) is true; expected a real error", tc.name)
+			}
+		})
+	}
+}
+
+// ── FIX 1: token-array passthrough ───────────────────────────────────────────
+
+// TestAnonymizeJSON_PromptTokenArraysPassThrough verifies that valid token-ID
+// arrays (int[], int[][]) in the "prompt" field pass through without error and
+// without modification, while object and bool elements are rejected.
+func TestAnonymizeJSON_PromptTokenArraysPassThrough(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{
+			name:    "int[] token array",
+			body:    `{"model":"gpt-3.5","prompt":[100,200,300]}`,
+			wantErr: false,
+		},
+		{
+			name:    "int[][] token array",
+			body:    `{"model":"gpt-3.5","prompt":[[1,2,3],[4,5,6]]}`,
+			wantErr: false,
+		},
+		{
+			name:    "mixed string and int",
+			body:    `{"model":"gpt-3.5","prompt":["hello",42]}`,
+			wantErr: false,
+		},
+		{
+			name:    "object element",
+			body:    `{"model":"gpt-3.5","prompt":[{"key":"val"}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "bool element",
+			body:    `{"model":"gpt-3.5","prompt":[true]}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFilter(t)
+			_, err := f.AnonymizeJSON([]byte(tc.body))
+			if tc.wantErr && err == nil {
+				t.Errorf("[%s] expected error, got nil", tc.name)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("[%s] unexpected error: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestAnonymizeJSON_InputTokenArraysPassThrough verifies the same for "input".
+func TestAnonymizeJSON_InputTokenArraysPassThrough(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{
+			name:    "int[] token array",
+			body:    `{"model":"text-emb","input":[1,2,3,100]}`,
+			wantErr: false,
+		},
+		{
+			name:    "int[][] token array",
+			body:    `{"model":"text-emb","input":[[1,2],[3,4]]}`,
+			wantErr: false,
+		},
+		{
+			name:    "object element",
+			body:    `{"model":"text-emb","input":[{"x":1}]}`,
+			wantErr: true,
+		},
+		{
+			name:    "bool element",
+			body:    `{"model":"text-emb","input":[false]}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFilter(t)
+			_, err := f.AnonymizeJSON([]byte(tc.body))
+			if tc.wantErr && err == nil {
+				t.Errorf("[%s] expected error, got nil", tc.name)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("[%s] unexpected error: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// ── FIX 2: object keys in parameters schema ───────────────────────────────────
+
+// TestAnonymizeJSON_Tools_Parameters_PIIInKey_FailClosed verifies that when a
+// key inside tools[].function.parameters contains PII (e.g. an email address
+// used as a property name), the request is rejected rather than forwarded with
+// the key intact. Rewriting a structural key would corrupt the schema, so
+// fail-closed is the only safe response.
+func TestAnonymizeJSON_Tools_Parameters_PIIInKey_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	// A schema where one property key IS a PII email address.
+	// This is pathological but must be rejected, not silently passed through.
+	body := []byte(`{
+		"model":"gpt-4",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{
+			"type":"function",
+			"function":{
+				"name":"fn",
+				"parameters":{
+					"type":"object",
+					"properties":{
+						"user@example.com":{
+							"type":"string"
+						}
+					}
+				}
+			}
+		}]
+	}`)
+
+	f := newTestFilter(t)
+	_, err := f.AnonymizeJSON(body)
+	if err == nil {
+		t.Error("expected fail-closed error when parameters key contains PII, got nil")
+	}
+	// Error must be content-free.
+	if strings.Contains(err.Error(), "user@example.com") {
+		t.Errorf("error message leaks PII key: %q", err.Error())
+	}
+}
+
+// TestAnonymizeJSON_Tools_Parameters_CleanKeys_Passthrough verifies that clean
+// (non-PII) property keys in parameters are never rejected. Only keys that
+// match a PII detector pattern trigger fail-closed.
+func TestAnonymizeJSON_Tools_Parameters_CleanKeys_Passthrough(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"model":"gpt-4",
+		"messages":[{"role":"user","content":"hi"}],
+		"tools":[{
+			"type":"function",
+			"function":{
+				"name":"fn",
+				"parameters":{
+					"type":"object",
+					"properties":{
+						"email_address":{"type":"string"},
+						"phone_number":{"type":"string"},
+						"count":{"type":"integer"}
+					}
+				}
+			}
+		}]
+	}`)
+
+	f := newTestFilter(t)
+	_, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Errorf("clean parameter keys should not cause error: %v", err)
+	}
+}

--- a/internal/pii/pii_stage0a_test.go
+++ b/internal/pii/pii_stage0a_test.go
@@ -1,0 +1,822 @@
+package pii
+
+// pii_stage0a_test.go covers the hardened paths introduced in
+// feat/pii-anonymization-stage0a:
+//
+//  1. Duplicate-key fail-closed (#3): top-level, nested, and deep duplicate keys.
+//  2. Token-element validation (#6): float rejection, pathological depth, valid int/int[][].
+//  3. Malformed array-element fail-closed (#2): messages/tools/tool_calls/content-parts.
+//
+// All tests use synthetic, non-real PII.  The package-level test helpers
+// (newTestFilter, newTestEngine, etc.) are defined in pii_test.go (same package).
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/voidmind-io/voidllm/internal/jsonx"
+)
+
+// ── 1. Duplicate-key fail-closed (#3) ─────────────────────────────────────────
+
+// TestHasDuplicateKeys_TopLevel verifies that a top-level duplicate key is
+// detected and returned as (true, nil).
+func TestHasDuplicateKeys_TopLevel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		body    []byte
+		wantDup bool
+	}{
+		{
+			name:    "top-level duplicate messages key",
+			body:    []byte(`{"messages":[{"role":"user","content":"a"}],"messages":[{"role":"user","content":"b"}]}`),
+			wantDup: true,
+		},
+		{
+			name:    "top-level duplicate user key",
+			body:    []byte(`{"user":"alice","user":"bob"}`),
+			wantDup: true,
+		},
+		{
+			name:    "top-level no duplicate",
+			body:    []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}`),
+			wantDup: false,
+		},
+		{
+			name:    "empty object",
+			body:    []byte(`{}`),
+			wantDup: false,
+		},
+		{
+			name:    "single key no duplicate",
+			body:    []byte(`{"model":"gpt-4"}`),
+			wantDup: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := hasDuplicateKeys(tc.body)
+			if err != nil {
+				t.Fatalf("hasDuplicateKeys(%q): unexpected error: %v", tc.body, err)
+			}
+			if got != tc.wantDup {
+				t.Errorf("hasDuplicateKeys(%q) = %v, want %v", tc.body, got, tc.wantDup)
+			}
+		})
+	}
+}
+
+// TestHasDuplicateKeys_Nested verifies that duplicate keys nested inside
+// array elements or object values are detected.
+func TestHasDuplicateKeys_Nested(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		body    []byte
+		wantDup bool
+	}{
+		{
+			name:    "duplicate in message object",
+			body:    []byte(`{"messages":[{"role":"user","content":"x","content":"y"}]}`),
+			wantDup: true,
+		},
+		{
+			name:    "duplicate deep in tools.function.parameters",
+			body:    []byte(`{"tools":[{"type":"function","function":{"name":"fn","parameters":{"type":"object","type":"array"}}}]}`),
+			wantDup: true,
+		},
+		{
+			name:    "clean body with nesting",
+			body:    []byte(`{"messages":[{"role":"user","content":[{"type":"text","text":"hi"}]}],"tools":[]}`),
+			wantDup: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := hasDuplicateKeys(tc.body)
+			if err != nil {
+				t.Fatalf("hasDuplicateKeys: unexpected error: %v", err)
+			}
+			if got != tc.wantDup {
+				t.Errorf("hasDuplicateKeys = %v, want %v; body: %s", got, tc.wantDup, tc.body)
+			}
+		})
+	}
+}
+
+// TestAnonymizeJSON_DuplicateKey_FailClosed verifies that AnonymizeJSON
+// rejects bodies with duplicate keys at any nesting level. The error must
+// be non-nil and must not contain body content.
+func TestAnonymizeJSON_DuplicateKey_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "top-level duplicate messages key",
+			body: []byte(`{"messages":[{"role":"user","content":"a"}],"messages":[{"role":"user","content":"b"}]}`),
+		},
+		{
+			name: "top-level duplicate user key",
+			body: []byte(`{"user":"alice","user":"bob"}`),
+		},
+		{
+			name: "nested duplicate in message element",
+			body: []byte(`{"messages":[{"role":"user","content":"x","content":"y"}]}`),
+		},
+		{
+			name: "deep duplicate in tools parameters",
+			body: []byte(`{"tools":[{"type":"function","function":{"name":"fn","parameters":{"type":"object","type":"array"}}}]}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFilter(t)
+			_, err := f.AnonymizeJSON(tc.body)
+			if err == nil {
+				t.Errorf("[%s] expected fail-closed error for duplicate key, got nil", tc.name)
+				return
+			}
+			// Error message must be content-free: must not contain any of the
+			// string values from the body.
+			for _, leak := range []string{"alice", "bob", "messages", "content", "object", "array"} {
+				if strings.Contains(err.Error(), leak) {
+					t.Errorf("[%s] error message leaks body content %q: %s", tc.name, leak, err.Error())
+				}
+			}
+		})
+	}
+}
+
+// TestAnonymizeJSON_NoDuplicateKey_Passthrough verifies that a clean body
+// (no duplicate keys, no PII) passes through without error and is returned
+// byte-for-byte identical to the original.
+func TestAnonymizeJSON_NoDuplicateKey_Passthrough(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hello world"}]}`)
+	f := newTestFilter(t)
+	out, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON(clean body): unexpected error: %v", err)
+	}
+	if string(out) != string(body) {
+		t.Errorf("AnonymizeJSON(clean body): body mutated:\n got: %s\nwant: %s", out, body)
+	}
+	if f.Touched() {
+		t.Error("Touched() = true for clean body with no PII, want false")
+	}
+}
+
+// ── 2. Token-element validation (#6) ──────────────────────────────────────────
+
+// TestIsTokenElement_FloatRejected verifies that float-shaped JSON values are
+// not considered valid token elements and cause fail-closed behavior.
+func TestIsTokenElement_FloatRejected(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "simple float 1.5", raw: "1.5"},
+		{name: "zero-decimal 1.0", raw: "1.0"},
+		{name: "negative float", raw: "-3.14"},
+		{name: "scientific notation", raw: "1e5"},
+		{name: "scientific notation uppercase", raw: "2E3"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isTokenElement(jsonx.RawMessage(tc.raw), 0)
+			if got {
+				t.Errorf("isTokenElement(%q) = true, want false (floats must be rejected)", tc.raw)
+			}
+		})
+	}
+}
+
+// TestAnonymizeJSON_FloatInPromptArray_FailClosed verifies that a float element
+// in the "prompt" array causes AnonymizeJSON to fail-closed.
+func TestAnonymizeJSON_FloatInPromptArray_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "float 1.5 in prompt array",
+			body: []byte(`{"model":"gpt-3.5","prompt":[1.5]}`),
+		},
+		{
+			name: "float 1.0 in prompt array",
+			body: []byte(`{"model":"gpt-3.5","prompt":[1.0]}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFilter(t)
+			_, err := f.AnonymizeJSON(tc.body)
+			if err == nil {
+				t.Errorf("[%s] expected fail-closed error for float in prompt array, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// TestAnonymizeJSON_FloatInInputArray_FailClosed verifies that a float element
+// in the "input" array causes AnonymizeJSON to fail-closed.
+func TestAnonymizeJSON_FloatInInputArray_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "float 1.5 in input array",
+			body: []byte(`{"model":"text-emb","input":[1.5]}`),
+		},
+		{
+			name: "float 1.0 in input array",
+			body: []byte(`{"model":"text-emb","input":[1.0]}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFilter(t)
+			_, err := f.AnonymizeJSON(tc.body)
+			if err == nil {
+				t.Errorf("[%s] expected fail-closed error for float in input array, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// TestIsTokenElement_PathologicalDepth verifies that isTokenElement does not
+// stack-overflow on a deeply nested array and instead returns false (which
+// causes the caller to fail-closed) once the depth limit is exceeded.
+func TestIsTokenElement_PathologicalDepth(t *testing.T) {
+	t.Parallel()
+
+	// Build a 200-level deep array: [[[...[1]...]]] with 200 opening brackets.
+	// This exceeds maxScanDepth (128), so isTokenElement must return false
+	// rather than recursing into a stack overflow.
+	const depth = 200
+	var sb strings.Builder
+	for i := 0; i < depth; i++ {
+		sb.WriteByte('[')
+	}
+	sb.WriteByte('1')
+	for i := 0; i < depth; i++ {
+		sb.WriteByte(']')
+	}
+	deepArray := jsonx.RawMessage(sb.String())
+
+	// isTokenElement must return false (reject) rather than crash.
+	got := isTokenElement(deepArray, 0)
+	if got {
+		t.Error("isTokenElement(200-deep array) = true, want false (must reject beyond maxScanDepth)")
+	}
+}
+
+// TestAnonymizeJSON_PathologicalDepth_NoStackOverflow verifies that
+// AnonymizeJSON does not panic or stack-overflow on a pathologically deep
+// array in the "input" field. It must either return an error (fail-closed)
+// or succeed — but must never crash.
+func TestAnonymizeJSON_PathologicalDepth_NoStackOverflow(t *testing.T) {
+	t.Parallel()
+
+	// 200-level nested array of 1 in the "input" field.
+	const depth = 200
+	var sb strings.Builder
+	sb.WriteString(`{"model":"text-emb","input":`)
+	for i := 0; i < depth; i++ {
+		sb.WriteByte('[')
+	}
+	sb.WriteByte('1')
+	for i := 0; i < depth; i++ {
+		sb.WriteByte(']')
+	}
+	sb.WriteByte('}')
+
+	f := newTestFilter(t)
+	// Must not panic. Depending on depth vs. maxScanDepth, this may return
+	// an error (fail-closed) or succeed. Either is acceptable; what is NOT
+	// acceptable is a crash.
+	_, _ = f.AnonymizeJSON([]byte(sb.String()))
+}
+
+// TestIsTokenElement_ValidIntegers verifies that valid JSON integers are
+// accepted as token elements.
+func TestIsTokenElement_ValidIntegers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "zero", raw: "0"},
+		{name: "positive", raw: "42"},
+		{name: "large", raw: "100000"},
+		{name: "negative", raw: "-1"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := isTokenElement(jsonx.RawMessage(tc.raw), 0)
+			if !got {
+				t.Errorf("isTokenElement(%q) = false, want true (valid integer token ID)", tc.raw)
+			}
+		})
+	}
+}
+
+// TestAnonymizeJSON_IntTokenArrays_Passthrough verifies that int[] and int[][]
+// token arrays in prompt and input are accepted without error and returned unchanged.
+func TestAnonymizeJSON_IntTokenArrays_Passthrough(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "prompt int[] flat",
+			body: `{"model":"gpt-3.5","prompt":[1,2,3]}`,
+		},
+		{
+			name: "prompt int[][] nested",
+			body: `{"model":"gpt-3.5","prompt":[[1,2],[3,4]]}`,
+		},
+		{
+			name: "input int[] flat",
+			body: `{"model":"text-emb","input":[1,2,3,100,200]}`,
+		},
+		{
+			name: "input int[][] nested",
+			body: `{"model":"text-emb","input":[[1,2],[3,4]]}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFilter(t)
+			out, err := f.AnonymizeJSON([]byte(tc.body))
+			if err != nil {
+				t.Errorf("[%s] unexpected error for int token array: %v", tc.name, err)
+				return
+			}
+			if f.Touched() {
+				t.Errorf("[%s] Touched() = true for int token array, want false", tc.name)
+			}
+			// The output must be identical to the input (no-op round-trip).
+			if string(out) != tc.body {
+				t.Errorf("[%s] body was mutated:\n got: %s\nwant: %s", tc.name, out, tc.body)
+			}
+		})
+	}
+}
+
+// ── 3. Malformed array-element fail-closed (#2) ───────────────────────────────
+
+// TestAnonymizeJSON_MessagesNonObjectElement_FailClosed verifies that a
+// messages array containing a non-object element (including JSON null) triggers
+// fail-closed. json.Unmarshal of JSON null into a map returns (nil, nil), so
+// the nil-map check is required in addition to the error check.
+func TestAnonymizeJSON_MessagesNonObjectElement_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "string element in messages",
+			body: []byte(`{"model":"gpt-4","messages":["just a string"]}`),
+		},
+		{
+			name: "integer element in messages",
+			body: []byte(`{"model":"gpt-4","messages":[42]}`),
+		},
+		{
+			name: "array element in messages",
+			body: []byte(`{"model":"gpt-4","messages":[[1,2,3]]}`),
+		},
+		{
+			name: "null element in messages",
+			body: []byte(`{"model":"gpt-4","messages":[null]}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFilter(t)
+			_, err := f.AnonymizeJSON(tc.body)
+			if err == nil {
+				t.Errorf("[%s] expected fail-closed error for non-object message element, got nil", tc.name)
+				return
+			}
+			// Error must be content-free.
+			if strings.Contains(err.Error(), "just a string") {
+				t.Errorf("[%s] error leaks body content: %s", tc.name, err.Error())
+			}
+		})
+	}
+}
+
+// TestAnonymizeJSON_ToolCallsNonObjectElement_FailClosed verifies that a
+// tool_calls array containing a non-object element triggers fail-closed.
+func TestAnonymizeJSON_ToolCallsNonObjectElement_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "string element in tool_calls",
+			body: []byte(`{"model":"gpt-4","messages":[{"role":"assistant","tool_calls":["not-an-object"]}]}`),
+		},
+		{
+			name: "integer element in tool_calls",
+			body: []byte(`{"model":"gpt-4","messages":[{"role":"assistant","tool_calls":[99]}]}`),
+		},
+		{
+			name: "array element in tool_calls",
+			body: []byte(`{"model":"gpt-4","messages":[{"role":"assistant","tool_calls":[[1,2]]}]}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFilter(t)
+			_, err := f.AnonymizeJSON(tc.body)
+			if err == nil {
+				t.Errorf("[%s] expected fail-closed error for non-object tool_calls element, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// TestAnonymizeJSON_ToolsNonObjectElement_FailClosed verifies that a
+// top-level tools array containing a non-object element (including JSON null)
+// triggers fail-closed. The null case requires a nil-map check in addition to
+// the unmarshal error check.
+func TestAnonymizeJSON_ToolsNonObjectElement_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "string element in tools",
+			body: []byte(`{"model":"gpt-4","messages":[],"tools":["not-an-object"]}`),
+		},
+		{
+			name: "integer element in tools",
+			body: []byte(`{"model":"gpt-4","messages":[],"tools":[42]}`),
+		},
+		{
+			name: "null element in tools",
+			body: []byte(`{"model":"gpt-4","messages":[],"tools":[null]}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFilter(t)
+			_, err := f.AnonymizeJSON(tc.body)
+			if err == nil {
+				t.Errorf("[%s] expected fail-closed error for non-object tools element, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// TestAnonymizeJSON_NullArrayFields_FailClosed verifies that covered array
+// fields present with value JSON null are rejected fail-closed. A null JSON
+// value unmarshalled into a slice produces (nil, nil), so a nil-slice check is
+// required alongside the unmarshal error check.
+func TestAnonymizeJSON_NullArrayFields_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "messages field is JSON null",
+			body: []byte(`{"model":"gpt-4","messages":null}`),
+		},
+		{
+			name: "tools field is JSON null",
+			body: []byte(`{"model":"gpt-4","messages":[],"tools":null}`),
+		},
+		{
+			name: "tool_calls field is JSON null",
+			body: []byte(`{"model":"gpt-4","messages":[{"role":"assistant","tool_calls":null,"content":"hi"}]}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFilter(t)
+			_, err := f.AnonymizeJSON(tc.body)
+			if err == nil {
+				t.Errorf("[%s] expected fail-closed error for JSON null array field, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// TestAnonymizeJSON_NullObjectFields_FailClosed verifies that covered object
+// fields present with value JSON null are rejected fail-closed. A null JSON
+// value unmarshalled into a map produces (nil, nil), so a nil-map check is
+// required alongside the unmarshal error check.
+func TestAnonymizeJSON_NullObjectFields_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "function_call field is JSON null",
+			body: []byte(`{"model":"gpt-4","messages":[{"role":"assistant","function_call":null,"content":"hi"}]}`),
+		},
+		{
+			name: "tool_calls element is JSON null",
+			body: []byte(`{"model":"gpt-4","messages":[{"role":"assistant","tool_calls":[null]}]}`),
+		},
+		{
+			name: "tool_calls[].function is JSON null",
+			body: []byte(`{"model":"gpt-4","messages":[{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":null}]}]}`),
+		},
+		{
+			name: "tools[].function is JSON null",
+			body: []byte(`{"model":"gpt-4","messages":[],"tools":[{"type":"function","function":null}]}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFilter(t)
+			_, err := f.AnonymizeJSON(tc.body)
+			if err == nil {
+				t.Errorf("[%s] expected fail-closed error for JSON null object field, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// TestAnonymizeJSON_ContentPartNonObject_FailClosed verifies that a content
+// array containing a non-object element triggers fail-closed.
+func TestAnonymizeJSON_ContentPartNonObject_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "string element in content array",
+			body: []byte(`{"model":"gpt-4","messages":[{"role":"user","content":["just a string"]}]}`),
+		},
+		{
+			name: "integer element in content array",
+			body: []byte(`{"model":"gpt-4","messages":[{"role":"user","content":[42]}]}`),
+		},
+		{
+			name: "null element in content array",
+			body: []byte(`{"model":"gpt-4","messages":[{"role":"user","content":[null]}]}`),
+		},
+		{
+			name: "boolean element in content array",
+			body: []byte(`{"model":"gpt-4","messages":[{"role":"user","content":[true]}]}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFilter(t)
+			_, err := f.AnonymizeJSON(tc.body)
+			if err == nil {
+				t.Errorf("[%s] expected fail-closed error for non-object content part, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// TestAnonymizeJSON_ContentPartNoType_FailClosed verifies that a content-part
+// object without a "type" field triggers fail-closed.
+func TestAnonymizeJSON_ContentPartNoType_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":[{"text":"hello synthetic@test.invalid"}]}]}`)
+	f := newTestFilter(t)
+	_, err := f.AnonymizeJSON(body)
+	if err == nil {
+		t.Error("expected fail-closed error for content part without type field, got nil")
+	}
+	if strings.Contains(err.Error(), "synthetic@test.invalid") {
+		t.Errorf("error leaks body content: %s", err.Error())
+	}
+}
+
+// TestAnonymizeJSON_ContentPartUnknownType_FailClosed verifies that a
+// content-part with an unknown "type" value triggers fail-closed.
+func TestAnonymizeJSON_ContentPartUnknownType_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body []byte
+	}{
+		{
+			name: "type weird",
+			body: []byte(`{"model":"gpt-4","messages":[{"role":"user","content":[{"type":"weird","text":"synthetic@test.invalid"}]}]}`),
+		},
+		{
+			name: "type custom_blob",
+			body: []byte(`{"model":"gpt-4","messages":[{"role":"user","content":[{"type":"custom_blob","data":"base64stuff"}]}]}`),
+		},
+		{
+			name: "type empty string",
+			body: []byte(`{"model":"gpt-4","messages":[{"role":"user","content":[{"type":"","text":"something"}]}]}`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFilter(t)
+			_, err := f.AnonymizeJSON(tc.body)
+			if err == nil {
+				t.Errorf("[%s] expected fail-closed error for unknown content part type, got nil", tc.name)
+				return
+			}
+			// Error must not contain body values.
+			if strings.Contains(err.Error(), "synthetic@test.invalid") || strings.Contains(err.Error(), "base64stuff") {
+				t.Errorf("[%s] error leaks body content: %s", tc.name, err.Error())
+			}
+		})
+	}
+}
+
+// TestAnonymizeJSON_ContentPartImageURL_ValidSkipped verifies that a
+// content-part with type "image_url" is accepted without error and is passed
+// through unchanged (URLs are not PII-scanned).
+func TestAnonymizeJSON_ContentPartImageURL_ValidSkipped(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"model":"gpt-4-vision","messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"https://example.test/synth.png"}}]}]}`)
+	f := newTestFilter(t)
+	out, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON(image_url part): unexpected error: %v", err)
+	}
+	// URL must be preserved verbatim.
+	if !strings.Contains(string(out), "https://example.test/synth.png") {
+		t.Errorf("image_url was modified or removed; got: %s", out)
+	}
+	if f.Touched() {
+		t.Error("Touched() = true for image_url-only content, want false")
+	}
+}
+
+// TestAnonymizeJSON_KnownNonTextParts_ValidSkipped covers all entries in
+// knownContentPartTypes to ensure each is accepted without error and that
+// the part is passed through unchanged.
+func TestAnonymizeJSON_KnownNonTextParts_ValidSkipped(t *testing.T) {
+	t.Parallel()
+
+	knownTypes := []string{
+		"image_url",
+		"input_audio",
+		"input_image",
+		"file",
+		"image",
+		"audio",
+		"document",
+		"video",
+	}
+
+	for _, partType := range knownTypes {
+		partType := partType
+		t.Run("type_"+partType, func(t *testing.T) {
+			t.Parallel()
+
+			body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":[{"type":"` + partType + `","data":"sentinel-value"}]}]}`)
+			f := newTestFilter(t)
+			out, err := f.AnonymizeJSON(body)
+			if err != nil {
+				t.Fatalf("AnonymizeJSON(type=%q): unexpected error: %v", partType, err)
+			}
+			if !strings.Contains(string(out), "sentinel-value") {
+				t.Errorf("type=%q: non-text part was modified or removed; got: %s", partType, out)
+			}
+			if f.Touched() {
+				t.Errorf("type=%q: Touched() = true, want false", partType)
+			}
+		})
+	}
+}
+
+// TestAnonymizeJSON_ContentPartText_PIIScanned verifies that a content-part
+// with type "text" has its "text" field scanned and PII replaced.
+func TestAnonymizeJSON_ContentPartText_PIIScanned(t *testing.T) {
+	t.Parallel()
+
+	// Use a synthetic email that will be caught by the regex detector.
+	const pii = "notify@synthetic-test.example"
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":[{"type":"text","text":"send to ` + pii + `"}]}]}`)
+
+	f := newTestFilter(t)
+	out, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON(text part): unexpected error: %v", err)
+	}
+	if strings.Contains(string(out), pii) {
+		t.Errorf("content-part text still contains original PII; got: %s", out)
+	}
+	if !f.Touched() {
+		t.Error("Touched() = false after PII in text part, want true")
+	}
+	// Restore must recover the original.
+	restored := f.Restore(out)
+	if !strings.Contains(string(restored), pii) {
+		t.Errorf("restore did not recover original PII; got: %s", restored)
+	}
+}
+
+// TestAnonymizeJSON_MixedParts_PIIInTextOnly verifies that a content array
+// containing both a "text" part (with PII) and an "image_url" part correctly
+// anonymizes only the text part.
+func TestAnonymizeJSON_MixedParts_PIIInTextOnly(t *testing.T) {
+	t.Parallel()
+
+	const pii = "contact@synthetic-mix.example"
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":[` +
+		`{"type":"text","text":"reach out to ` + pii + `"},` +
+		`{"type":"image_url","image_url":{"url":"https://synth.test/pic.jpg"}}` +
+		`]}]}`)
+
+	f := newTestFilter(t)
+	out, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON(mixed parts): unexpected error: %v", err)
+	}
+	// PII in text part must be replaced.
+	if strings.Contains(string(out), pii) {
+		t.Errorf("text part still contains PII; got: %s", out)
+	}
+	// image_url part must pass through unchanged.
+	if !strings.Contains(string(out), "https://synth.test/pic.jpg") {
+		t.Errorf("image URL was removed or modified; got: %s", out)
+	}
+	if !f.Touched() {
+		t.Error("Touched() = false after PII in mixed text part, want true")
+	}
+}

--- a/internal/pii/pii_test.go
+++ b/internal/pii/pii_test.go
@@ -1,0 +1,1048 @@
+package pii
+
+// pii_test.go is in package pii (white-box) so it can reach unexported
+// helpers: pseudonym, normalizeValue, typeAbbrev, replaceSpansInText, deOverlap.
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// testSecret is a fixed 32-byte secret used by all pseudonym tests. It must
+// not be a real installation secret — it exists only to make tests
+// deterministic.
+var testSecret = []byte("test-secret-32-bytes-0000000000!")
+
+// testOrgID is the fixed organisation ID used in tests.
+const testOrgID = "org-test-001"
+
+// newTestEngine creates an Engine backed by the DefaultPatterns detector.
+func newTestEngine(t *testing.T) *Engine {
+	t.Helper()
+	d, err := NewRegexDetector(DefaultPatterns())
+	if err != nil {
+		t.Fatalf("NewRegexDetector(DefaultPatterns()): %v", err)
+	}
+	return NewEngine(testSecret, []Detector{d})
+}
+
+// newTestFilter is shorthand for engine.NewFilter in tests.
+func newTestFilter(t *testing.T) *Filter {
+	t.Helper()
+	return newTestEngine(t).NewFilter(testOrgID)
+}
+
+// mustAnonymize calls AnonymizeJSON and fails the test on error.
+func mustAnonymize(t *testing.T, f *Filter, body []byte) []byte {
+	t.Helper()
+	out, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: unexpected error: %v", err)
+	}
+	return out
+}
+
+// ── RegexDetector / DefaultPatterns ──────────────────────────────────────────
+
+func TestRegexDetector_DefaultPatterns_Recognition(t *testing.T) {
+	t.Parallel()
+
+	d, err := NewRegexDetector(DefaultPatterns())
+	if err != nil {
+		t.Fatalf("NewRegexDetector: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		text      string
+		wantType  string
+		wantStart int
+		wantEnd   int
+	}{
+		{
+			name:      "german iban",
+			text:      "IBAN: DE12345678901234567890",
+			wantType:  "IBAN",
+			wantStart: 6,
+			wantEnd:   28,
+		},
+		{
+			name:      "email address",
+			text:      "contact max.mustermann+test@example.de please",
+			wantType:  "EMAIL",
+			wantStart: 8,
+			wantEnd:   38,
+		},
+		{
+			// "+4915112345678" is 14 characters starting at offset 5 → end is 19.
+			name:      "german phone +49 prefix",
+			text:      "call +4915112345678 now",
+			wantType:  "PHONE",
+			wantStart: 5,
+			wantEnd:   19,
+		},
+		{
+			name:      "credit card number",
+			text:      "card 4111111111111111 expired",
+			wantType:  "CREDIT_CARD",
+			wantStart: 5,
+			wantEnd:   21,
+		},
+		{
+			name:      "german tax id",
+			text:      "steuer-id: 12345678901 fertig",
+			wantType:  "TAX_ID",
+			wantStart: 11,
+			wantEnd:   22,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			spans := d.Find(tc.text)
+			if len(spans) == 0 {
+				t.Fatalf("Find(%q): no spans, want at least one", tc.text)
+			}
+			// Find the expected span.
+			found := false
+			for _, s := range spans {
+				if s.Type == tc.wantType && s.Start == tc.wantStart && s.End == tc.wantEnd {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("Find(%q) = %+v, want span {Type:%q, Start:%d, End:%d}",
+					tc.text, spans, tc.wantType, tc.wantStart, tc.wantEnd)
+			}
+		})
+	}
+}
+
+func TestRegexDetector_NoMatchInCleanText(t *testing.T) {
+	t.Parallel()
+
+	d, err := NewRegexDetector(DefaultPatterns())
+	if err != nil {
+		t.Fatalf("NewRegexDetector: %v", err)
+	}
+
+	text := "the quick brown fox jumps over the lazy dog"
+	spans := d.Find(text)
+	if len(spans) != 0 {
+		t.Errorf("Find(%q) = %+v, want no spans", text, spans)
+	}
+}
+
+func TestRegexDetector_NonOverlappingSpans(t *testing.T) {
+	t.Parallel()
+
+	// Use a single custom pattern to generate two adjacent matches.
+	d, err := NewRegexDetector([]Pattern{
+		{Type: "EMAIL", Regexp: `\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b`},
+	})
+	if err != nil {
+		t.Fatalf("NewRegexDetector: %v", err)
+	}
+
+	text := "send to alice@example.com and bob@example.com today"
+	spans := d.Find(text)
+	if len(spans) != 2 {
+		t.Fatalf("Find(%q) = %+v, want 2 non-overlapping spans", text, spans)
+	}
+	// Verify no overlaps.
+	for i := 1; i < len(spans); i++ {
+		if spans[i].Start < spans[i-1].End {
+			t.Errorf("span[%d] (start=%d) overlaps span[%d] (end=%d)",
+				i, spans[i].Start, i-1, spans[i-1].End)
+		}
+	}
+	// Verify correct positions.
+	if spans[0].Start != strings.Index(text, "alice@example.com") {
+		t.Errorf("span[0].Start = %d, want %d", spans[0].Start, strings.Index(text, "alice@example.com"))
+	}
+	if spans[1].Start != strings.Index(text, "bob@example.com") {
+		t.Errorf("span[1].Start = %d, want %d", spans[1].Start, strings.Index(text, "bob@example.com"))
+	}
+}
+
+func TestNewRegexDetector_InvalidRegexp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		patterns []Pattern
+	}{
+		{
+			name: "empty type returns error",
+			patterns: []Pattern{
+				{Type: "", Regexp: `\d+`},
+			},
+		},
+		{
+			name: "empty regexp returns error",
+			patterns: []Pattern{
+				{Type: "CUSTOM", Regexp: ""},
+			},
+		},
+		{
+			name: "invalid regexp syntax returns error",
+			patterns: []Pattern{
+				{Type: "CUSTOM", Regexp: `[invalid`},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := NewRegexDetector(tc.patterns)
+			if err == nil {
+				t.Errorf("NewRegexDetector(%v): expected error, got nil", tc.patterns)
+			}
+		})
+	}
+}
+
+// ── pseudonym ────────────────────────────────────────────────────────────────
+
+func TestPseudonym_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	secret := testSecret
+	typ := "EMAIL"
+	value := "alice@example.com"
+
+	first := pseudonym(secret, testOrgID, typ, value)
+	second := pseudonym(secret, testOrgID, typ, value)
+	third := pseudonym(secret, testOrgID, typ, value)
+
+	if first != second || second != third {
+		t.Errorf("pseudonym is not deterministic: %q, %q, %q", first, second, third)
+	}
+}
+
+func TestPseudonym_DifferentValues(t *testing.T) {
+	t.Parallel()
+
+	secret := testSecret
+	typ := "EMAIL"
+
+	p1 := pseudonym(secret, testOrgID, typ, "alice@example.com")
+	p2 := pseudonym(secret, testOrgID, typ, "bob@example.com")
+
+	if p1 == p2 {
+		t.Errorf("different values produced the same pseudonym %q", p1)
+	}
+}
+
+func TestPseudonym_DifferentSecrets(t *testing.T) {
+	t.Parallel()
+
+	value := "alice@example.com"
+	typ := "EMAIL"
+
+	secret1 := []byte("secret-aaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	secret2 := []byte("secret-bbbbbbbbbbbbbbbbbbbbbbbbbbb")
+
+	p1 := pseudonym(secret1, testOrgID, typ, value)
+	p2 := pseudonym(secret2, testOrgID, typ, value)
+
+	if p1 == p2 {
+		t.Errorf("different secrets produced the same pseudonym %q", p1)
+	}
+}
+
+func TestPseudonym_DifferentOrgs(t *testing.T) {
+	t.Parallel()
+
+	// Same secret + type + value but different org → different pseudonym.
+	// This prevents cross-tenant correlation.
+	value := "alice@example.com"
+	typ := "EMAIL"
+
+	p1 := pseudonym(testSecret, "org-a", typ, value)
+	p2 := pseudonym(testSecret, "org-b", typ, value)
+
+	if p1 == p2 {
+		t.Errorf("different orgs produced the same pseudonym %q; cross-tenant isolation broken", p1)
+	}
+}
+
+func TestPseudonym_DifferentTypes(t *testing.T) {
+	t.Parallel()
+
+	// Same value under two types must produce different pseudonyms.
+	// Prevents cross-type correlation for values that match multiple patterns.
+	value := "12345678901"
+
+	p1 := pseudonym(testSecret, testOrgID, "TAX_ID", value)
+	p2 := pseudonym(testSecret, testOrgID, "PHONE", value)
+
+	if p1 == p2 {
+		t.Errorf("different types produced the same pseudonym %q; cross-type isolation broken", p1)
+	}
+}
+
+func TestPseudonym_FixedLengthPerType(t *testing.T) {
+	t.Parallel()
+
+	// All pseudonyms for a given type must have the same length.
+	// Format: "PII_<2-char abbr>_<24 hex chars>" = 4 + 2 + 1 + 24 = 31 chars.
+	expectedLen := len("PII_EM_") + 24 // 31 total
+
+	types := []struct {
+		typ    string
+		values []string
+	}{
+		{"EMAIL", []string{"a@b.com", "test.user+alias@domain.co.uk", "x@y.z"}},
+		{"IBAN", []string{"DE12345678901234567890", "DE00000000000000000000"}},
+		{"PHONE", []string{"+4915112345678", "030123456", "0800123456"}},
+		{"CREDIT_CARD", []string{"4111111111111111", "5500005555555559"}},
+		{"TAX_ID", []string{"12345678901", "99999999999"}},
+	}
+
+	for _, tc := range types {
+		t.Run(tc.typ, func(t *testing.T) {
+			t.Parallel()
+
+			var lengths []int
+			for _, v := range tc.values {
+				p := pseudonym(testSecret, testOrgID, tc.typ, v)
+				lengths = append(lengths, len(p))
+			}
+			for i, l := range lengths {
+				if l != expectedLen {
+					t.Errorf("pseudonym(%q, %q): len = %d, want %d",
+						tc.typ, tc.values[i], l, expectedLen)
+				}
+			}
+			// All same type must have the same length.
+			for i := 1; i < len(lengths); i++ {
+				if lengths[i] != lengths[0] {
+					t.Errorf("pseudonym length inconsistency for type %q: %d != %d",
+						tc.typ, lengths[i], lengths[0])
+				}
+			}
+		})
+	}
+}
+
+func TestPseudonym_AlphanumericFormat(t *testing.T) {
+	t.Parallel()
+
+	// Pseudonyms must only contain [A-Za-z0-9_] characters.
+	validChars := regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+
+	types := []string{"EMAIL", "IBAN", "PHONE", "CREDIT_CARD", "TAX_ID", "UNKNOWN"}
+	values := []string{"test@example.com", "DE12345678901234567890", "+4915112345678", "4111111111111111", "12345678901", "anything"}
+
+	for i, typ := range types {
+		p := pseudonym(testSecret, testOrgID, typ, values[i])
+		if !validChars.MatchString(p) {
+			t.Errorf("pseudonym(%q, %q) = %q contains characters outside [A-Za-z0-9_]", typ, values[i], p)
+		}
+	}
+}
+
+func TestPseudonym_EmailNormalization(t *testing.T) {
+	t.Parallel()
+
+	// EMAIL normalization: lowercase + trim. Same canonical form → same pseudonym.
+	tests := []struct {
+		a, b string
+		same bool
+	}{
+		// These normalize to the same value.
+		{"Max@Example.COM", "max@example.com", true},
+		{"  alice@test.org  ", "alice@test.org", true},
+		{"User+Tag@DOMAIN.NET", "user+tag@domain.net", true},
+		// These normalize to different values.
+		{"alice@example.com", "bob@example.com", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.a+"_vs_"+tc.b, func(t *testing.T) {
+			t.Parallel()
+
+			pA := pseudonym(testSecret, testOrgID, "EMAIL", tc.a)
+			pB := pseudonym(testSecret, testOrgID, "EMAIL", tc.b)
+
+			if tc.same && pA != pB {
+				t.Errorf("pseudonym(EMAIL, %q) = %q, pseudonym(EMAIL, %q) = %q, want equal",
+					tc.a, pA, tc.b, pB)
+			}
+			if !tc.same && pA == pB {
+				t.Errorf("pseudonym(EMAIL, %q) = pseudonym(EMAIL, %q) = %q, want different",
+					tc.a, tc.b, pA)
+			}
+		})
+	}
+}
+
+func TestNormalizeValue_NonEmailTrimOnly(t *testing.T) {
+	t.Parallel()
+
+	// Non-EMAIL types: only whitespace trimming, no case folding.
+	tests := []struct {
+		typ   string
+		input string
+		want  string
+	}{
+		{"IBAN", "  DE12345678901234567890  ", "DE12345678901234567890"},
+		{"IBAN", "DE12345678901234567890", "DE12345678901234567890"},
+		{"PHONE", " +4915112345678 ", "+4915112345678"},
+		// Case is preserved for non-EMAIL types.
+		{"CUSTOM", "UPPERCASE-VALUE", "UPPERCASE-VALUE"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.typ+"_"+tc.input, func(t *testing.T) {
+			t.Parallel()
+
+			got := normalizeValue(tc.typ, tc.input)
+			if got != tc.want {
+				t.Errorf("normalizeValue(%q, %q) = %q, want %q", tc.typ, tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// ── Filter: AnonymizeJSON / Restore round-trip ────────────────────────────────
+
+func TestFilter_RoundTrip_StringContent(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"Please contact max.mustermann@example.com about IBAN DE12345678901234567890."}]}`)
+	anonBody := mustAnonymize(t, f, body)
+
+	// Anonymized body must not contain the original PII.
+	if strings.Contains(string(anonBody), "max.mustermann@example.com") {
+		t.Error("anonymized body still contains original email")
+	}
+	if strings.Contains(string(anonBody), "DE12345678901234567890") {
+		t.Error("anonymized body still contains original IBAN")
+	}
+
+	// Restore must recover original PII.
+	restored := f.Restore(anonBody)
+	if !strings.Contains(string(restored), "max.mustermann@example.com") {
+		t.Errorf("restored body does not contain original email; got: %s", restored)
+	}
+	if !strings.Contains(string(restored), "DE12345678901234567890") {
+		t.Errorf("restored body does not contain original IBAN; got: %s", restored)
+	}
+}
+
+func TestFilter_NonContentFieldsUntouched(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	// Put a PII-like value in a non-covered field (here: model name).
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"user","content":"hello world"}]}`)
+	anonBody := mustAnonymize(t, f, body)
+
+	// The model field must remain unchanged.
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(anonBody, &doc); err != nil {
+		t.Fatalf("anonBody is not valid JSON: %v\nbody: %s", err, anonBody)
+	}
+	var model string
+	if err := json.Unmarshal(doc["model"], &model); err != nil {
+		t.Fatalf("cannot unmarshal model field: %v", err)
+	}
+	if model != "gpt-4o" {
+		t.Errorf("model field = %q, want %q", model, "gpt-4o")
+	}
+
+	// Content was PII-free, so structure stays valid and touched is false.
+	if f.Touched() {
+		t.Error("Touched() = true, want false (no PII in content)")
+	}
+}
+
+func TestFilter_JSONStructureIntact(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"system","content":"You are helpful."},{"role":"user","content":"My email is user@example.com."}]}`)
+	anonBody := mustAnonymize(t, f, body)
+
+	// Result must be valid JSON.
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(anonBody, &doc); err != nil {
+		t.Fatalf("anonBody is not valid JSON: %v\nbody: %s", err, anonBody)
+	}
+
+	// Messages array must be parseable.
+	var messages []map[string]json.RawMessage
+	if err := json.Unmarshal(doc["messages"], &messages); err != nil {
+		t.Fatalf("messages is not valid JSON array: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("messages length = %d, want 2", len(messages))
+	}
+
+	// role fields must be intact.
+	var role0, role1 string
+	_ = json.Unmarshal(messages[0]["role"], &role0)
+	_ = json.Unmarshal(messages[1]["role"], &role1)
+	if role0 != "system" {
+		t.Errorf("messages[0].role = %q, want %q", role0, "system")
+	}
+	if role1 != "user" {
+		t.Errorf("messages[1].role = %q, want %q", role1, "user")
+	}
+}
+
+func TestFilter_ArrayContentParts(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	body := []byte(`{"model":"gpt-4-vision","messages":[{"role":"user","content":[{"type":"text","text":"send to alice@example.com"},{"type":"image_url","image_url":{"url":"https://example.com/img.png"}}]}]}`)
+	anonBody := mustAnonymize(t, f, body)
+
+	// The text part must have been anonymized.
+	if strings.Contains(string(anonBody), "alice@example.com") {
+		t.Error("anonymized body still contains original email in text part")
+	}
+
+	// The image_url part must be structurally unchanged (URL is not PII-scanned).
+	if !strings.Contains(string(anonBody), "image_url") {
+		t.Error("image_url part was removed from array content")
+	}
+	if !strings.Contains(string(anonBody), "https://example.com/img.png") {
+		t.Error("image URL was modified or removed")
+	}
+
+	// Restore must put the email back.
+	restored := f.Restore(anonBody)
+	if !strings.Contains(string(restored), "alice@example.com") {
+		t.Errorf("restored body does not contain original email; got: %s", restored)
+	}
+}
+
+func TestFilter_Touched_FalseWhenNoPII(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"What is the capital of France?"}]}`)
+	_ = mustAnonymize(t, f, body)
+
+	if f.Touched() {
+		t.Error("Touched() = true, want false when content contains no PII")
+	}
+}
+
+func TestFilter_Touched_TrueWhenPIIReplaced(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"My email is anon@example.com."}]}`)
+	_ = mustAnonymize(t, f, body)
+
+	if !f.Touched() {
+		t.Error("Touched() = false, want true when email PII was detected")
+	}
+}
+
+func TestFilter_ConsistencyWithinRequest(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	// Same email appears twice: must get the same pseudonym both times.
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"First: alice@example.com. Second: alice@example.com."}]}`)
+	anonBody := mustAnonymize(t, f, body)
+
+	// Count how many distinct PII_ tokens appear.
+	content := string(anonBody)
+	// Find all PII_EM_ tokens (24 hex chars now).
+	re := regexp.MustCompile(`PII_EM_[0-9a-f]{24}`)
+	matches := re.FindAllString(content, -1)
+	if len(matches) < 2 {
+		t.Fatalf("expected at least 2 pseudonym occurrences, got: %v\nbody: %s", matches, content)
+	}
+	// All must be identical.
+	for i, m := range matches {
+		if m != matches[0] {
+			t.Errorf("match[%d] = %q, want same as match[0] = %q", i, m, matches[0])
+		}
+	}
+}
+
+func TestFilter_FailClosed_UnparseableBody(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	body := []byte(`not json at all { broken`)
+	_, err := f.AnonymizeJSON(body)
+
+	// Must return an error (fail-closed), not the original body.
+	if err == nil {
+		t.Error("AnonymizeJSON(invalid JSON) returned nil error; expected fail-closed error")
+	}
+	// Error message must be content-free.
+	if strings.Contains(err.Error(), "not json") || strings.Contains(err.Error(), "broken") {
+		t.Errorf("error message contains body content: %q", err.Error())
+	}
+
+	if f.Touched() {
+		t.Error("Touched() = true after fail-closed path, want false")
+	}
+}
+
+func TestFilter_AnonymizeJSON_NoMessagesKey(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	// Valid JSON but no "messages" key — treated as completion-style body.
+	// The body contains no covered fields with PII, so it should succeed
+	// and return a copy of the original.
+	body := []byte(`{"model":"gpt-4","other":"hello"}`)
+	out, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON(no messages key): unexpected error: %v", err)
+	}
+	if string(out) != string(body) {
+		t.Errorf("AnonymizeJSON(no PII) returned different body: %q vs %q", out, body)
+	}
+	if f.Touched() {
+		t.Error("Touched() = true, want false when no PII fields present")
+	}
+}
+
+func TestFilter_AnonymizeJSON_CompletionPromptString(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	body := []byte(`{"model":"gpt-3.5-turbo-instruct","prompt":"My email is alice@example.com"}`)
+	anonBody, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	if strings.Contains(string(anonBody), "alice@example.com") {
+		t.Error("anonymized body still contains original email in prompt string")
+	}
+	if !f.Touched() {
+		t.Error("Touched() = false after PII in prompt, want true")
+	}
+	restored := f.Restore(anonBody)
+	if !strings.Contains(string(restored), "alice@example.com") {
+		t.Errorf("restored body missing original email: %s", restored)
+	}
+}
+
+func TestFilter_AnonymizeJSON_CompletionPromptArray(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	body := []byte(`{"model":"gpt-3.5-turbo-instruct","prompt":["Hello","My IBAN is DE12345678901234567890"]}`)
+	anonBody, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	if strings.Contains(string(anonBody), "DE12345678901234567890") {
+		t.Error("anonymized body still contains IBAN in prompt array")
+	}
+	if !f.Touched() {
+		t.Error("Touched() = false after PII in prompt array, want true")
+	}
+}
+
+// TestFilter_AnonymizeJSON_CompletionPromptTokenArray verifies that integer
+// token arrays in the "prompt" field are passed through unchanged. Token IDs
+// are PII-free by definition and must never be rejected or modified.
+func TestFilter_AnonymizeJSON_CompletionPromptTokenArray(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	// int[] prompt — a flat token-ID array.
+	body := []byte(`{"model":"gpt-3.5-turbo-instruct","prompt":[1234,5678,91011]}`)
+	anonBody, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON(int[] prompt): unexpected error: %v", err)
+	}
+	if string(anonBody) != string(body) {
+		t.Errorf("AnonymizeJSON(int[] prompt) mutated body: got %q, want %q", anonBody, body)
+	}
+	if f.Touched() {
+		t.Error("Touched() = true after int[] prompt, want false")
+	}
+
+	f2 := newTestFilter(t)
+
+	// Mixed prompt: string elements are scanned, int elements pass through.
+	mixed := []byte(`{"model":"gpt-3.5-turbo-instruct","prompt":["hello alice@example.com",42,99]}`)
+	anonMixed, err := f2.AnonymizeJSON(mixed)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON(mixed prompt): unexpected error: %v", err)
+	}
+	if strings.Contains(string(anonMixed), "alice@example.com") {
+		t.Error("AnonymizeJSON(mixed prompt): string element still contains PII")
+	}
+	// Integer elements must be preserved verbatim.
+	if !strings.Contains(string(anonMixed), "42") || !strings.Contains(string(anonMixed), "99") {
+		t.Errorf("AnonymizeJSON(mixed prompt): integer elements missing: %s", anonMixed)
+	}
+	if !f2.Touched() {
+		t.Error("Touched() = false after PII in mixed prompt string element, want true")
+	}
+}
+
+func TestFilter_AnonymizeJSON_UserField(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hello"}],"user":"alice@example.com"}`)
+	anonBody, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	if strings.Contains(string(anonBody), "alice@example.com") {
+		t.Error("anonymized body still contains original email in user field")
+	}
+	if !f.Touched() {
+		t.Error("Touched() = false after PII in user field, want true")
+	}
+}
+
+func TestFilter_AnonymizeJSON_MessageName(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","name":"alice@example.com","content":"hello"}]}`)
+	anonBody, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	if strings.Contains(string(anonBody), "alice@example.com") {
+		t.Error("anonymized body still contains original email in messages[].name")
+	}
+}
+
+func TestFilter_AnonymizeJSON_ToolCallArguments(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{"name":"send_email","arguments":"{\"to\":\"alice@example.com\",\"body\":\"hello\"}"}}]}]}`)
+	anonBody, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	if strings.Contains(string(anonBody), "alice@example.com") {
+		t.Error("anonymized body still contains original email in tool_calls[].function.arguments")
+	}
+	if !f.Touched() {
+		t.Error("Touched() = false after PII in tool_calls arguments, want true")
+	}
+}
+
+func TestFilter_AnonymizeJSON_ToolDescription(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function","function":{"name":"contact","description":"Send email to alice@example.com"}}]}`)
+	anonBody, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	if strings.Contains(string(anonBody), "alice@example.com") {
+		t.Error("anonymized body still contains original email in tools[].function.description")
+	}
+	if !f.Touched() {
+		t.Error("Touched() = false after PII in tool description, want true")
+	}
+}
+
+func TestFilter_Restore_UnknownPseudonymUnchanged(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	// Call AnonymizeJSON on PII-free content so rev map remains empty.
+	_ = mustAnonymize(t, f, []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}`))
+
+	// A pseudonym-shaped string that was NOT produced by this filter.
+	foreign := []byte(`response containing PII_EM_aabbccddeeff001122334455 which is unknown`)
+	result := f.Restore(foreign)
+
+	if string(result) != string(foreign) {
+		t.Errorf("Restore() modified an unknown pseudonym: got %q, want %q", result, foreign)
+	}
+}
+
+func TestFilter_Restore_NoopWhenNotTouched(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	// No AnonymizeJSON call at all — rev map is empty.
+	text := []byte("some response with no pseudonyms")
+	result := f.Restore(text)
+
+	// When rev map is empty, Restore returns the original slice without allocation.
+	if string(result) != string(text) {
+		t.Errorf("Restore() changed content unexpectedly: %q", result)
+	}
+}
+
+func TestFilter_Restore_CachesReplacer(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"email: x@example.com"}]}`)
+	anonBody := mustAnonymize(t, f, body)
+	if !f.Touched() {
+		t.Skip("no PII detected, cannot test replacer caching")
+	}
+
+	// Call Restore twice with the same filter: second call should reuse the
+	// cached replacer and produce the same output.
+	first := f.Restore(anonBody)
+	second := f.Restore(anonBody)
+	if string(first) != string(second) {
+		t.Errorf("Restore() produced different results on repeated calls: %q vs %q", first, second)
+	}
+}
+
+func TestFilter_MappingCapExceeded(t *testing.T) {
+	t.Parallel()
+
+	eng := newTestEngine(t)
+	f := eng.NewFilter(testOrgID)
+
+	// Fill the mapping table to exactly maxPIIMappings entries by calling
+	// pseudonymFor directly with unique synthetic values. Using fmt.Sprintf
+	// would pull in an extra import; instead we build unique keys via the
+	// lookup key format the filter itself uses (type+NUL+value). We bypass
+	// the detector here because we are testing the cap logic in pseudonymFor,
+	// not the detection path.
+	for i := 0; i < maxPIIMappings; i++ {
+		// Generate a unique value string that looks like "value-0000000001",
+		// "value-0000000002", etc. We zero-pad so that short integers do not
+		// accidentally alias each other through normalization.
+		val := "value-" + strings.Repeat("0", 10-len(itoa(i))) + itoa(i)
+		_, err := f.pseudonymFor("EMAIL", val)
+		if err != nil {
+			t.Fatalf("unexpected error at mapping %d (before cap of %d): %v", i, maxPIIMappings, err)
+		}
+	}
+	// The next new unique value must exceed the cap.
+	_, err := f.pseudonymFor("EMAIL", "cap-exceeded-sentinel")
+	if err == nil {
+		t.Error("pseudonymFor returned nil error when mapping cap was exceeded; expected fail-closed error")
+	}
+	// Error message must never contain the PII value.
+	if strings.Contains(err.Error(), "cap-exceeded-sentinel") {
+		t.Errorf("error message leaks PII value: %q", err.Error())
+	}
+}
+
+// itoa is a minimal int-to-string helper for test use only (avoids importing strconv).
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := make([]byte, 0, 10)
+	for n > 0 {
+		digits = append(digits, byte('0'+n%10))
+		n /= 10
+	}
+	// Reverse.
+	for i, j := 0, len(digits)-1; i < j; i, j = i+1, j-1 {
+		digits[i], digits[j] = digits[j], digits[i]
+	}
+	return string(digits)
+}
+
+// ── Engine / NewFilter ────────────────────────────────────────────────────────
+
+func TestEngine_NewFilterIsolation(t *testing.T) {
+	t.Parallel()
+
+	eng := newTestEngine(t)
+
+	f1 := eng.NewFilter(testOrgID)
+	f2 := eng.NewFilter(testOrgID)
+
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"email: x@example.com"}]}`)
+	_ = mustAnonymize(t, f1, body)
+
+	// f2 must have its own clean state — Touched must be false.
+	if f2.Touched() {
+		t.Error("f2.Touched() = true after f1 anonymized; filters must be independent")
+	}
+}
+
+func TestEngine_SecretIsCopied(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("mutable-secret-32-bytes-00000000")
+
+	// Build a detector so the engine can actually find PII.
+	d, err := NewRegexDetector(DefaultPatterns())
+	if err != nil {
+		t.Fatalf("NewRegexDetector: %v", err)
+	}
+	eng := NewEngine(secret, []Detector{d})
+
+	// Compute the expected pseudonym BEFORE mutating the secret slice.
+	origSecret := []byte("mutable-secret-32-bytes-00000000")
+	want := pseudonym(origSecret, testOrgID, "EMAIL", "test@example.com")
+
+	// Mutate the caller's slice — the engine must have taken a copy.
+	secret[0] = 'X'
+
+	f := eng.NewFilter(testOrgID)
+	// Trigger pseudonymFor via AnonymizeJSON on a body with that email.
+	anonBody := mustAnonymize(t, f, []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"test@example.com"}]}`))
+
+	re := regexp.MustCompile(`PII_EM_[0-9a-f]{24}`)
+	got := re.FindString(string(anonBody))
+	if got != want {
+		t.Errorf("pseudonym after secret mutation = %q, want %q (engine should hold a copy of secret)", got, want)
+	}
+}
+
+func TestEngine_Close_ZerosSecret(t *testing.T) {
+	t.Parallel()
+
+	d, err := NewRegexDetector(DefaultPatterns())
+	if err != nil {
+		t.Fatalf("NewRegexDetector: %v", err)
+	}
+	eng := NewEngine(testSecret, []Detector{d})
+
+	// Compute a pseudonym before Close.
+	before := pseudonym(eng.secret, testOrgID, "EMAIL", "test@example.com")
+
+	eng.Close()
+
+	// After Close the internal secret slice must be all zeros.
+	for i, b := range eng.secret {
+		if b != 0 {
+			t.Errorf("secret[%d] = %d after Close, want 0", i, b)
+		}
+	}
+
+	// A filter created after Close will derive pseudonyms from an all-zero
+	// key, which will differ from pre-Close pseudonyms.
+	after := pseudonym(eng.secret, testOrgID, "EMAIL", "test@example.com")
+	if before == after && len(testSecret) > 0 {
+		t.Error("pseudonym after Close equals pre-Close pseudonym; secret was not zeroed")
+	}
+}
+
+// ── typeAbbrev ────────────────────────────────────────────────────────────────
+
+func TestTypeAbbrev(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		typ  string
+		want string
+	}{
+		{"EMAIL", "EM"},
+		{"IBAN", "IB"},
+		{"PHONE", "PH"},
+		{"CREDIT_CARD", "CC"},
+		{"TAX_ID", "TX"},
+		{"UNKNOWN_TYPE", "XX"},
+		{"", "XX"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.typ, func(t *testing.T) {
+			t.Parallel()
+
+			got := typeAbbrev(tc.typ)
+			if got != tc.want {
+				t.Errorf("typeAbbrev(%q) = %q, want %q", tc.typ, got, tc.want)
+			}
+		})
+	}
+}
+
+// ── replaceSpansInText / deOverlap (package-level helpers) ───────────────────
+
+func TestReplaceSpansInText_Empty(t *testing.T) {
+	t.Parallel()
+
+	text, touched, err := replaceSpansInText("hello world", nil, func(_, v string) (string, error) { return v, nil })
+	if err != nil {
+		t.Fatalf("replaceSpansInText with nil spans: unexpected error: %v", err)
+	}
+	if touched {
+		t.Error("replaceSpansInText with nil spans: touched = true, want false")
+	}
+	if text != "hello world" {
+		t.Errorf("replaceSpansInText with nil spans: text = %q, want %q", text, "hello world")
+	}
+}
+
+func TestReplaceSpansInText_Substitution(t *testing.T) {
+	t.Parallel()
+
+	text := "call 123 or 456"
+	spans := []Span{
+		{Start: 5, End: 8, Type: "NUM"},
+		{Start: 12, End: 15, Type: "NUM"},
+	}
+	replace := func(_, v string) (string, error) { return "[" + v + "]", nil }
+
+	got, touched, err := replaceSpansInText(text, spans, replace)
+	if err != nil {
+		t.Fatalf("replaceSpansInText: unexpected error: %v", err)
+	}
+	if !touched {
+		t.Error("touched = false, want true")
+	}
+	want := "call [123] or [456]"
+	if got != want {
+		t.Errorf("replaceSpansInText = %q, want %q", got, want)
+	}
+}
+
+func TestDeOverlap(t *testing.T) {
+	t.Parallel()
+
+	spans := []Span{
+		{Start: 0, End: 10, Type: "A"},
+		{Start: 5, End: 15, Type: "B"},  // overlaps A
+		{Start: 15, End: 20, Type: "C"}, // non-overlapping
+	}
+	result := deOverlap(spans)
+	if len(result) != 2 {
+		t.Fatalf("deOverlap: got %d spans, want 2: %+v", len(result), result)
+	}
+	if result[0] != spans[0] {
+		t.Errorf("result[0] = %+v, want %+v", result[0], spans[0])
+	}
+	if result[1] != spans[2] {
+		t.Errorf("result[1] = %+v, want %+v", result[1], spans[2])
+	}
+}

--- a/internal/pii/pseudonym.go
+++ b/internal/pii/pseudonym.go
@@ -1,0 +1,111 @@
+package pii
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// pseudonym derives a deterministic, fixed-length replacement token for a
+// PII value scoped to a specific organisation. The token format is:
+//
+//	PII_<TY>_<24 hex chars>
+//
+// where <TY> is a two-character uppercase abbreviation for the PII type
+// and <24 hex chars> is the first 24 hex digits (12 bytes) of
+// HMAC-SHA256(secret, orgID || 0x00 || type || 0x00 || normalize(value)).
+//
+// Design rationale:
+//
+//   - Per-org scope: including orgID in the HMAC input ensures that the same
+//     PII value maps to a different pseudonym in each organisation. This
+//     prevents cross-tenant correlation when the same real value (e.g. a
+//     shared email address) appears in multiple orgs' requests.
+//
+//   - Type-binding: including the type with a NUL separator prevents
+//     cross-type collisions where a value that happens to match two
+//     different detector patterns (e.g. a 16-digit credit card that also
+//     matches the TAX_ID pattern) would otherwise produce the same pseudonym
+//     under different type labels.
+//
+//   - Collision probability: 12 bytes (96 bits) → ~1 in 2^96 per pair.
+//     With up to 10,000 mappings per request (maxPIIMappings) the birthday
+//     probability is negligible. A collision would cause rev[p] to be
+//     overwritten, mapping the pseudonym to the wrong original value. The
+//     96-bit tail makes this astronomically unlikely in practice.
+//
+//   - Fixed length per type: every EMAIL token is exactly 27 characters
+//     (PII_EM_xxxxxxxxxxxxxxxxxxxxxxxxxxxx). This property is preserved for
+//     Stage 0b's rolling-buffer streaming restore, where the buffer must
+//     know the exact byte length of each token to detect chunk-split
+//     boundaries.
+//
+//   - [A-Za-z0-9_] alphabet only: no special characters that JSON
+//     serializers, HTML escapers, or LLM tokenizers might alter. The token
+//     passes through round-trips (JSON encode → LLM → JSON decode)
+//     unchanged.
+//
+//   - Virtually zero natural collision: the PII_ prefix and type suffix
+//     make accidental occurrence in real text extremely unlikely.
+//
+//   - Deterministic within (orgID, type, value): the same triple always
+//     produces the same token. This guarantees cross-message consistency
+//     within a request and, for the same installation, stable pseudonyms
+//     across requests for the same org (though the current single-request
+//     scope only requires within-request consistency).
+//
+// normalize applies type-specific normalization before hashing:
+//   - EMAIL: trim whitespace, lowercase (case-insensitive identifier)
+//   - all other types: trim whitespace only
+//
+// This means "User@Example.com" and "user@example.com" produce the same
+// pseudonym, which is correct for identifiers whose canonical form is
+// case-insensitive.
+func pseudonym(secret []byte, orgID, typ, value string) string {
+	norm := normalizeValue(typ, value)
+	mac := hmac.New(sha256.New, secret)
+	// HMAC input: orgID || NUL || type || NUL || normalized-value.
+	// NUL separators prevent concatenation ambiguity between fields
+	// (e.g. orgID="ab", type="cd" vs orgID="a", type="bcd").
+	mac.Write([]byte(orgID))
+	mac.Write([]byte{0x00})
+	mac.Write([]byte(typ))
+	mac.Write([]byte{0x00})
+	mac.Write([]byte(norm))
+	sum := mac.Sum(nil)
+	abbr := typeAbbrev(typ)
+	// 12 bytes → 24 hex characters → 96 bits of collision resistance.
+	return "PII_" + abbr + "_" + hex.EncodeToString(sum[:12])
+}
+
+// normalizeValue produces a canonical form of value for the given PII type.
+// Normalization is applied before hashing so that semantically equivalent
+// values map to the same pseudonym.
+func normalizeValue(typ, value string) string {
+	v := strings.TrimSpace(value)
+	if typ == "EMAIL" {
+		v = strings.ToLower(v)
+	}
+	return v
+}
+
+// typeAbbrev maps a PII type name to a stable two-character uppercase
+// abbreviation used in the token format. Unknown types fall back to "XX"
+// so that new detector types do not break the token format.
+func typeAbbrev(typ string) string {
+	switch typ {
+	case "EMAIL":
+		return "EM"
+	case "IBAN":
+		return "IB"
+	case "PHONE":
+		return "PH"
+	case "CREDIT_CARD":
+		return "CC"
+	case "TAX_ID":
+		return "TX"
+	default:
+		return "XX"
+	}
+}

--- a/internal/pii/regex.go
+++ b/internal/pii/regex.go
@@ -1,0 +1,148 @@
+package pii
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+)
+
+// Pattern associates a PII type label with a regular expression string.
+// Both fields are required; an empty Regexp causes NewRegexDetector to
+// return an error.
+type Pattern struct {
+	// Type is the PII category label (e.g. "EMAIL", "IBAN"). It must be
+	// non-empty and is used verbatim in the Span.Type field and in the
+	// pseudonym token abbreviation.
+	Type string
+	// Regexp is the Go regular expression that matches a single PII value.
+	// The expression is compiled once in NewRegexDetector and reused for
+	// the lifetime of the detector. Named capture groups are ignored;
+	// only the full match (group 0) is used.
+	Regexp string
+}
+
+// RegexDetector finds PII spans using a set of compiled regular expressions.
+// It is safe for concurrent use across goroutines; all state is read-only
+// after construction.
+type RegexDetector struct {
+	compiled []*compiledPattern
+}
+
+// compiledPattern pairs a ready-to-use regexp with its PII type label.
+type compiledPattern struct {
+	typ string
+	re  *regexp.Regexp
+}
+
+// NewRegexDetector compiles each pattern's Regexp exactly once and returns
+// a RegexDetector ready for use. It returns an error if any pattern has an
+// empty Type, an empty Regexp, or a Regexp that cannot be compiled.
+func NewRegexDetector(patterns []Pattern) (*RegexDetector, error) {
+	compiled := make([]*compiledPattern, 0, len(patterns))
+	for i, p := range patterns {
+		if p.Type == "" {
+			return nil, fmt.Errorf("pii: pattern[%d]: Type must not be empty", i)
+		}
+		if p.Regexp == "" {
+			return nil, fmt.Errorf("pii: pattern[%d] (%s): Regexp must not be empty", i, p.Type)
+		}
+		re, err := regexp.Compile(p.Regexp)
+		if err != nil {
+			return nil, fmt.Errorf("pii: pattern[%d] (%s): compile regexp: %w", i, p.Type, err)
+		}
+		compiled = append(compiled, &compiledPattern{typ: p.Type, re: re})
+	}
+	return &RegexDetector{compiled: compiled}, nil
+}
+
+// Find returns all non-overlapping PII spans in text. When multiple
+// patterns match overlapping byte ranges, the leftmost match takes
+// priority; among matches starting at the same position, the longest
+// match wins. This policy is equivalent to scanning the text left-to-right
+// and advancing past each accepted match.
+func (d *RegexDetector) Find(text string) []Span {
+	// Collect all raw matches from every pattern.
+	var raw []Span
+	for _, cp := range d.compiled {
+		locs := cp.re.FindAllStringIndex(text, -1)
+		for _, loc := range locs {
+			raw = append(raw, Span{Start: loc[0], End: loc[1], Type: cp.typ})
+		}
+	}
+	if len(raw) == 0 {
+		return nil
+	}
+
+	// Sort: leftmost first; on tie, longest first (largest End first).
+	sort.Slice(raw, func(i, j int) bool {
+		if raw[i].Start != raw[j].Start {
+			return raw[i].Start < raw[j].Start
+		}
+		return raw[i].End > raw[j].End
+	})
+
+	// Greedy non-overlapping selection: advance cursor past each accepted span.
+	result := make([]Span, 0, len(raw))
+	cursor := 0
+	for _, s := range raw {
+		if s.Start < cursor {
+			continue // overlaps with a previously accepted span
+		}
+		result = append(result, s)
+		cursor = s.End
+	}
+	return result
+}
+
+// DefaultPatterns returns the built-in set of conservative PII detection
+// patterns tuned for European (particularly German) contexts. The list is
+// intentionally small and precise — false positives in an LLM proxy are
+// more disruptive than false negatives, because they corrupt legitimate
+// text that happens to match a pattern.
+//
+// Included patterns:
+//   - IBAN: German IBANs (DE + 20 digits, word-boundary anchored)
+//   - EMAIL: RFC 5321-compatible local part and domain
+//   - PHONE: German mobile and landline numbers (+49 or 0xx prefix)
+//   - CREDIT_CARD: 13-19 contiguous digit groups (catches most major schemes)
+//   - TAX_ID: German Steueridentifikationsnummer (11 digits, not starting with 0)
+func DefaultPatterns() []Pattern {
+	return []Pattern{
+		{
+			Type: "IBAN",
+			// German IBAN: DE followed by exactly 20 digits.
+			// Word-boundary anchors prevent matching inside longer digit strings.
+			Regexp: `\bDE\d{20}\b`,
+		},
+		{
+			Type: "EMAIL",
+			// Standard email: local@domain.tld. Allows +addressing and subdomains.
+			// Does not match bare domain names or addresses without a TLD.
+			Regexp: `\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b`,
+		},
+		{
+			Type: "PHONE",
+			// German phone numbers in three common formats:
+			//   +49 (prefix) followed by digits and optional spaces/hyphens
+			//   0800 / 0900 service numbers
+			//   0xx local landline with area code
+			// The pattern requires at least 7 digits total to reduce false positives.
+			Regexp: `(?:\+49|0)[0-9][0-9 \-]{5,14}[0-9]`,
+		},
+		{
+			Type: "CREDIT_CARD",
+			// 13-19 consecutive digits (no separators). Catches Visa (16),
+			// Mastercard (16), Amex (15), Discover (16), and others.
+			// Luhn validation is omitted intentionally: it adds CPU cost and
+			// the false-positive risk from 13-19 digit sequences in normal
+			// text is low enough with word-boundary anchors.
+			Regexp: `\b[0-9]{13,19}\b`,
+		},
+		{
+			Type: "TAX_ID",
+			// German Steueridentifikationsnummer: 11 digits, first digit 1-9.
+			// Word boundaries prevent matching inside longer digit sequences.
+			Regexp: `\b[1-9][0-9]{10}\b`,
+		},
+	}
+}

--- a/internal/pii/stream.go
+++ b/internal/pii/stream.go
@@ -1,0 +1,354 @@
+package pii
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/voidmind-io/voidllm/internal/jsonx"
+)
+
+// dataLinePrefix is the SSE field prefix per RFC 6202 §4.2. A "data" field
+// line MUST begin with "data:" — the space after the colon is optional.
+var dataLinePrefix = []byte("data:")
+
+// errUnparseableSSE is returned by RestoreSSEStream when a data: line carries
+// JSON that cannot be parsed for content-aware restore. The caller must treat
+// this as fail-closed and must not forward un-restored content to the client.
+var errUnparseableSSE = errors.New("pii: sse stream structure could not be parsed for content-aware restore")
+
+// choiceBuf accumulates per-choice streaming content across SSE events.
+type choiceBuf struct {
+	content      bytes.Buffer
+	finishReason string // empty = none seen
+	role         string // preserved from delta.role, first occurrence only
+}
+
+// RestoreSSEStream performs content-aware PII restore over a buffered set of
+// raw SSE lines. It is the correct fix for the Stage-0a raw-byte-join bug:
+// a pseudonym split across two SSE events by the LLM tokenizer never appears
+// as a contiguous byte sequence in the raw-joined buffer, so strings.Replacer
+// cannot find and replace it. This function instead extracts the content string
+// from each event's JSON payload, concatenates per choice index, applies
+// restore over the assembled string (where the pseudonym is always contiguous),
+// and re-emits a valid SSE response.
+//
+// Input contract: sseLines is the complete set of raw lines read from the
+// upstream SSE body (one element per scanner.Scan() call, without trailing \n).
+// The restore function is Filter.Restore — it is applied to the assembled
+// content bytes for each choice and returns the restored bytes.
+//
+// Output: a new slice of raw SSE lines (without trailing \n) ready to be
+// written to the client. nil elements in the output represent blank separator
+// lines between events.
+//
+// Fail-closed contract:
+//   - Any data: line whose payload is not [DONE] and not valid JSON → error.
+//   - Any choice that carries tool_calls deltas → error (cannot safely
+//     reassemble split tool-call argument JSON strings across events).
+//   - On any error, the caller must not emit any content to the client.
+//
+// Belt-and-suspenders restore: after synthesizing all output lines, restore is
+// applied a final time to every emitted byte. This ensures that pseudonyms
+// echo-ed by the upstream in envelope fields (id, model, system_fingerprint),
+// SSE comment lines, or any other non-content field are removed even if they
+// were not captured during the content-assembly phase. restore is idempotent:
+// it only substitutes known pseudonyms and never rewrites already-restored
+// content.
+//
+// Stage 0b note: the restored content is emitted as a single delta chunk per
+// choice (no incremental token streaming for PII-hit requests). This is
+// correct and leak-free. Stage 0b would implement a cross-event rolling buffer
+// that delivers restored content incrementally; that is a performance
+// optimisation, not a correctness fix.
+//
+// n>1 choices: each choice index is handled independently. The output emits
+// all choices in index order.
+func RestoreSSEStream(sseLines [][]byte, restore func([]byte) []byte) ([][]byte, error) {
+	donePayload := []byte("[DONE]")
+
+	// nonDataLines collects lines that are not data: JSON events (blank lines,
+	// SSE comment lines, event:/id:/retry: lines). They are emitted verbatim
+	// at the start of the output, before synthesized content chunks.
+	var nonDataLines [][]byte
+
+	// envelope holds the top-level SSE chunk fields (id, object, created,
+	// model, system_fingerprint) captured from the first parseable data chunk.
+	var envelope map[string]jsonx.RawMessage
+
+	// choicesByIndex accumulates content and metadata per OpenAI choice index.
+	choicesByIndex := make(map[int]*choiceBuf)
+
+	var hasToolCalls bool
+
+	for _, line := range sseLines {
+		// Per SSE spec (RFC 6202 §4.2): a "data" field line begins with "data:"
+		// followed by an optional single space. We must check for the bare
+		// "data:" prefix (no space) to avoid silently emitting content-carrying
+		// lines that don't have the conventional space.
+		if !bytes.HasPrefix(line, dataLinePrefix) {
+			// Not a data: line. Lines starting with "event:", "id:", "retry:",
+			// or ":" (comment) carry no content and are safe to pass through.
+			nonDataLines = append(nonDataLines, line)
+			continue
+		}
+
+		// Strip "data:" and then an optional single leading space per SSE spec.
+		payload := line[len(dataLinePrefix):]
+		if len(payload) > 0 && payload[0] == ' ' {
+			payload = payload[1:]
+		}
+
+		// [DONE] sentinel: not JSON, skip; re-emitted at end of output.
+		if bytes.Equal(payload, donePayload) {
+			continue
+		}
+
+		// Any data: line whose payload is not [DONE] and not valid JSON is a
+		// protocol violation that we cannot safely process. Fail-closed: return
+		// an error rather than emitting un-restored content.
+		// (The JSON parse below covers this; this comment documents intent.)
+
+		// Parse the raw document to capture envelope fields.
+		var rawDoc map[string]jsonx.RawMessage
+		if err := jsonx.Unmarshal(payload, &rawDoc); err != nil {
+			return nil, errUnparseableSSE
+		}
+
+		// Capture envelope fields from the first data chunk that has them.
+		if envelope == nil {
+			envelope = make(map[string]jsonx.RawMessage)
+			for _, field := range []string{"id", "object", "created", "model", "system_fingerprint"} {
+				if v, ok := rawDoc[field]; ok {
+					envelope[field] = v
+				}
+			}
+		}
+
+		// Chunks without "choices" carry auxiliary data (e.g. usage with
+		// stream_options.include_usage=true). Skip content accumulation.
+		rawChoicesJSON, hasChoices := rawDoc["choices"]
+		if !hasChoices {
+			continue
+		}
+
+		// Parse choices as a typed slice for safe field extraction.
+		var rawChoices []struct {
+			Index        int     `json:"index"`
+			FinishReason *string `json:"finish_reason"`
+			Delta        struct {
+				Role      string             `json:"role"`
+				Content   *string            `json:"content"`
+				ToolCalls []jsonx.RawMessage `json:"tool_calls,omitempty"`
+			} `json:"delta"`
+			// Completions streaming uses "text" at the choice level instead of delta.
+			Text *string `json:"text"`
+		}
+		if err := jsonx.Unmarshal(rawChoicesJSON, &rawChoices); err != nil {
+			return nil, errUnparseableSSE
+		}
+
+		for _, ch := range rawChoices {
+			// Fail-closed: tool_calls deltas span multiple chunks and their
+			// function.arguments JSON string may be split. Reassembling them
+			// safely is not implemented in Stage 0a/0b.
+			if len(ch.Delta.ToolCalls) > 0 {
+				hasToolCalls = true
+			}
+
+			cb, exists := choicesByIndex[ch.Index]
+			if !exists {
+				cb = &choiceBuf{}
+				choicesByIndex[ch.Index] = cb
+			}
+
+			if ch.Delta.Role != "" && cb.role == "" {
+				cb.role = ch.Delta.Role
+			}
+			if ch.Delta.Content != nil {
+				cb.content.WriteString(*ch.Delta.Content)
+			}
+			if ch.Text != nil {
+				cb.content.WriteString(*ch.Text)
+			}
+			if ch.FinishReason != nil && *ch.FinishReason != "" {
+				cb.finishReason = *ch.FinishReason
+			}
+		}
+	}
+
+	if hasToolCalls {
+		// Fail-closed: cannot safely restore split tool-call argument content.
+		return nil, errUnparseableSSE
+	}
+
+	// Build output SSE lines.
+	// Capacity estimate: non-data lines + 2 lines per choice (content + finish)
+	// + 2 for [DONE] + separator blanks.
+	out := make([][]byte, 0, len(nonDataLines)+len(choicesByIndex)*4+2)
+
+	// Preserve non-data lines at the top, applying restore to each so that
+	// pseudonyms echo-ed in SSE comment or event: lines are removed.
+	for _, ndl := range nonDataLines {
+		if len(ndl) > 0 {
+			out = append(out, restore(ndl))
+		} else {
+			out = append(out, ndl)
+		}
+	}
+
+	if envelope == nil {
+		// Stream had no parseable data chunks at all; emit a minimal envelope.
+		envelope = map[string]jsonx.RawMessage{
+			"object": jsonx.RawMessage(`"chat.completion.chunk"`),
+		}
+	}
+
+	// Sort choice indices for deterministic output order.
+	indices := sortedKeys(choicesByIndex)
+
+	for _, idx := range indices {
+		cb := choicesByIndex[idx]
+
+		// Apply restore to the assembled content for this choice.
+		restoredBytes := restore(cb.content.Bytes())
+
+		// Emit content delta chunk.
+		contentLine, err := buildContentChunk(envelope, idx, cb.role, string(restoredBytes))
+		if err != nil {
+			return nil, errUnparseableSSE
+		}
+		out = append(out, contentLine)
+		out = append(out, nil) // blank SSE event separator
+
+		// Emit finish_reason chunk when one was seen during accumulation.
+		if cb.finishReason != "" {
+			frLine, err := buildFinishChunk(envelope, idx, cb.finishReason)
+			if err != nil {
+				return nil, errUnparseableSSE
+			}
+			out = append(out, frLine)
+			out = append(out, nil) // blank SSE event separator
+		}
+	}
+
+	// Always close with [DONE].
+	out = append(out, []byte("data: [DONE]"))
+	out = append(out, nil) // blank SSE event separator
+
+	// Belt-and-suspenders final pass: apply restore to every non-nil output
+	// line. This catches any pseudonym that may have been embedded in envelope
+	// fields (id, model, system_fingerprint) during JSON serialization of the
+	// synthesized chunks. restore is idempotent — already-restored content is
+	// never modified because restored original values never match the
+	// PII_<TY>_<hex> pseudonym format.
+	for i, line := range out {
+		if line != nil {
+			out[i] = restore(line)
+		}
+	}
+
+	return out, nil
+}
+
+// sseDelta is the typed representation of an SSE delta object within a choice.
+// Role is omitted when empty to match the provider wire format on non-first chunks.
+type sseDelta struct {
+	Role    string `json:"role,omitempty"`
+	Content string `json:"content"`
+}
+
+// sseDeltaEmpty is the typed representation of an empty delta used in
+// finish_reason chunks (empty content, no role).
+type sseDeltaEmpty struct{}
+
+// sseContentChoice is a typed SSE choice carrying a delta.content payload.
+// FinishReason is always null for content chunks.
+type sseContentChoice struct {
+	Index        int      `json:"index"`
+	Delta        sseDelta `json:"delta"`
+	FinishReason *string  `json:"finish_reason"`
+}
+
+// sseFinishChoice is a typed SSE choice carrying a finish_reason payload.
+// Delta is empty (no role, no content) per the OpenAI SSE wire format.
+type sseFinishChoice struct {
+	Index        int           `json:"index"`
+	Delta        sseDeltaEmpty `json:"delta"`
+	FinishReason string        `json:"finish_reason"`
+}
+
+// buildContentChunk serializes a data: line carrying a delta.content SSE
+// chunk. Envelope fields (id, object, created, model, system_fingerprint) are
+// embedded verbatim from the captured first chunk so the synthesized response
+// is structurally identical to a real provider response.
+func buildContentChunk(envelope map[string]jsonx.RawMessage, choiceIdx int, role, content string) ([]byte, error) {
+	doc := make(map[string]jsonx.RawMessage, len(envelope)+1)
+	for k, v := range envelope {
+		doc[k] = v
+	}
+
+	choice := sseContentChoice{
+		Index:        choiceIdx,
+		Delta:        sseDelta{Role: role, Content: content},
+		FinishReason: nil,
+	}
+
+	choicesJSON, err := jsonx.Marshal([]sseContentChoice{choice})
+	if err != nil {
+		return nil, err
+	}
+	doc["choices"] = jsonx.RawMessage(choicesJSON)
+
+	payload, err := jsonx.Marshal(doc)
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte("data: "), payload...), nil
+}
+
+// buildFinishChunk serializes a data: line carrying a finish_reason SSE chunk
+// (empty delta, non-null finish_reason) for the given choice index.
+func buildFinishChunk(envelope map[string]jsonx.RawMessage, choiceIdx int, finishReason string) ([]byte, error) {
+	doc := make(map[string]jsonx.RawMessage, len(envelope)+1)
+	for k, v := range envelope {
+		doc[k] = v
+	}
+
+	choice := sseFinishChoice{
+		Index:        choiceIdx,
+		Delta:        sseDeltaEmpty{},
+		FinishReason: finishReason,
+	}
+
+	choicesJSON, err := jsonx.Marshal([]sseFinishChoice{choice})
+	if err != nil {
+		return nil, err
+	}
+	doc["choices"] = jsonx.RawMessage(choicesJSON)
+
+	payload, err := jsonx.Marshal(doc)
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte("data: "), payload...), nil
+}
+
+// sortedKeys returns the keys of m sorted in ascending order.
+// Used to produce deterministic choice ordering in the output SSE stream.
+// Insertion sort is appropriate here: choice counts are always small (1-8).
+func sortedKeys(m map[int]*choiceBuf) []int {
+	keys := make([]int, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	for i := 1; i < len(keys); i++ {
+		key := keys[i]
+		j := i - 1
+		for j >= 0 && keys[j] > key {
+			keys[j+1] = keys[j]
+			j--
+		}
+		keys[j+1] = key
+	}
+	return keys
+}

--- a/internal/pii/stream_new_test.go
+++ b/internal/pii/stream_new_test.go
@@ -1,0 +1,365 @@
+package pii
+
+// stream_new_test.go covers the additional SSE parsing cases required by the
+// feat/pii-anonymization-stage0a test task:
+//
+//  5. SSE "data:" without space (bare colon) is parsed correctly; mixed with/without
+//  6. Unparseable data line → fail-closed
+
+import (
+	"strings"
+	"testing"
+)
+
+// ── 5. SSE "data:" without space ──────────────────────────────────────────────
+
+// TestRestoreSSEStream_DataPrefixNoSpace verifies that a data: line without
+// the optional space (i.e., "data:{...}" rather than "data: {...}") is parsed
+// and restored correctly, not passed through verbatim.
+//
+// Per RFC 6202 §4.2, the space after "data:" is optional. The stream.go
+// implementation explicitly strips the optional space via:
+//
+//	payload := line[len(dataLinePrefix):]
+//	if len(payload) > 0 && payload[0] == ' ' { payload = payload[1:] }
+//
+// A line that begins with "data:" (no space) must be treated as a data line,
+// not a non-data line.
+func TestRestoreSSEStream_DataPrefixNoSpace(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"email: nospace@example.com"}]}`)
+	_, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	if !f.Touched() {
+		t.Fatal("Touched() = false; expected email to be detected")
+	}
+
+	pseudo := ""
+	for p, o := range f.rev {
+		if o == "nospace@example.com" {
+			pseudo = p
+			break
+		}
+	}
+	if pseudo == "" {
+		t.Fatal("pseudonym not found in rev map")
+	}
+
+	// Construct a data: line WITHOUT the space after the colon.
+	// The payload is a valid JSON SSE chunk with the pseudonym in delta.content.
+	eventNoSpace := `data:{"id":"ns1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"` + pseudo + `"},"finish_reason":null}]}`
+
+	lines := makeSSELines(eventNoSpace, "", "data: [DONE]", "")
+
+	out, err := RestoreSSEStream(lines, f.Restore)
+	if err != nil {
+		t.Fatalf("RestoreSSEStream: unexpected error: %v", err)
+	}
+
+	output := outputStr(out)
+
+	// The pseudonym must NOT appear in the output (it was restored).
+	if strings.Contains(output, pseudo) {
+		t.Errorf("pseudonym %q still visible in output; expected it to be restored\noutput:\n%s", pseudo, output)
+	}
+
+	// The original email must appear in the output.
+	if !strings.Contains(output, "nospace@example.com") {
+		t.Errorf("original email missing from output\noutput:\n%s", output)
+	}
+
+	// Output must contain valid SSE structure.
+	if !strings.Contains(output, "data: ") {
+		t.Errorf("output missing data: prefix\noutput:\n%s", output)
+	}
+	if !strings.Contains(output, "[DONE]") {
+		t.Errorf("output missing [DONE]\noutput:\n%s", output)
+	}
+}
+
+// TestRestoreSSEStream_MixedDataPrefixSpacing verifies that a stream containing
+// a mix of "data: " (with space) and "data:" (without space) lines is processed
+// correctly. Each data line must be parsed as a data event regardless of whether
+// the optional space is present.
+func TestRestoreSSEStream_MixedDataPrefixSpacing(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"contact mix@example.com"}]}`)
+	_, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	if !f.Touched() {
+		t.Fatal("Touched() = false; expected email to be detected")
+	}
+
+	pseudo := ""
+	origEmail := ""
+	for p, o := range f.rev {
+		pseudo = p
+		origEmail = o
+		break
+	}
+	if pseudo == "" {
+		t.Fatal("no pseudonym found")
+	}
+
+	// Build a stream where the pseudonym is split across two chunks:
+	// one emitted with "data: " (with space) and one with "data:" (no space).
+	// This exercises the path where both variants coexist and must both be
+	// parsed correctly for the assembled-content restore to succeed.
+	mid := len(pseudo) / 2
+	part1 := pseudo[:mid]
+	part2 := pseudo[mid:]
+
+	// Chunk 1: "data: " with space (standard).
+	eventWithSpace := `data: {"id":"mix1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"` + part1 + `"},"finish_reason":null}]}`
+	// Chunk 2: "data:" without space.
+	eventNoSpace := `data:{"id":"mix1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"` + part2 + `"},"finish_reason":null}]}`
+	done := `data: [DONE]`
+
+	lines := makeSSELines(eventWithSpace, "", eventNoSpace, "", done, "")
+
+	out, err := RestoreSSEStream(lines, f.Restore)
+	if err != nil {
+		t.Fatalf("RestoreSSEStream: unexpected error on mixed-spacing stream: %v", err)
+	}
+
+	output := outputStr(out)
+
+	// The original email must appear in the output.
+	if !strings.Contains(output, origEmail) {
+		t.Errorf("original email %q missing from mixed-spacing output\noutput:\n%s", origEmail, output)
+	}
+
+	// Neither the full pseudonym nor either fragment must remain.
+	if strings.Contains(output, pseudo) {
+		t.Errorf("full pseudonym still visible\noutput:\n%s", output)
+	}
+	if strings.Contains(output, part1) || strings.Contains(output, part2) {
+		t.Errorf("pseudonym fragment still visible\noutput:\n%s", output)
+	}
+}
+
+// ── 6. Unparseable data line → fail-closed ────────────────────────────────────
+
+// TestRestoreSSEStream_UnparseableDataLine_FailClosed verifies that a data: line
+// whose payload is not [DONE] and not valid JSON causes RestoreSSEStream to
+// return an error rather than emitting any content to the client.
+//
+// This covers the "fail-closed on unparseable data" contract described in the
+// RestoreSSEStream documentation.
+func TestRestoreSSEStream_UnparseableDataLine_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	tests := []struct {
+		name string
+		line string
+	}{
+		{
+			name: "broken json with space prefix",
+			line: `data: {broken json`,
+		},
+		{
+			name: "broken json without space prefix",
+			line: `data:{broken json`,
+		},
+		{
+			name: "data line is plain text not json",
+			line: `data: this is not json at all`,
+		},
+		{
+			name: "data line is empty object fragment",
+			line: `data: {`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			lines := makeSSELines(tc.line, "")
+			_, err := RestoreSSEStream(lines, f.Restore)
+			if err == nil {
+				t.Errorf("[%s] expected fail-closed error for unparseable data line, got nil", tc.name)
+			}
+		})
+	}
+}
+
+// TestRestoreSSEStream_UnparseableDataLine_NoContentEmitted verifies that when
+// RestoreSSEStream returns an error due to an unparseable line, no content is
+// returned in the output slice (the returned slice should be nil/empty).
+func TestRestoreSSEStream_UnparseableDataLine_NoContentEmitted(t *testing.T) {
+	t.Parallel()
+
+	// A stream with a valid first chunk followed by a broken chunk.
+	// The broken chunk must cause the entire stream processing to fail.
+	f2 := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"email: fail@closed.example"}]}`)
+	_, err := f2.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	pseudo := ""
+	for p := range f2.rev {
+		pseudo = p
+		break
+	}
+
+	// Valid JSON chunk, then broken chunk.
+	validLine := `data: {"id":"fc1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"` + pseudo + `"},"finish_reason":null}]}`
+	brokenLine := `data: {not json`
+
+	lines := makeSSELines(validLine, "", brokenLine, "")
+	result, err := RestoreSSEStream(lines, f2.Restore)
+	if err == nil {
+		t.Error("expected fail-closed error when stream contains broken JSON, got nil")
+	}
+	// When err != nil, result must be nil (no partial content emitted).
+	if result != nil {
+		t.Errorf("result must be nil when err != nil; got %d lines", len(result))
+	}
+}
+
+// TestRestoreSSEStream_DataNoSpaceOnlyDone verifies that a minimal stream
+// containing only a "data:[DONE]" sentinel (no space) is handled gracefully
+// and the [DONE] sentinel is preserved in the output.
+func TestRestoreSSEStream_DataNoSpaceOnlyDone(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	// "data:[DONE]" without space — the payload is "[DONE]".
+	// This must be treated as the stream sentinel, not as broken JSON.
+	lines := [][]byte{[]byte("data:[DONE]"), {}}
+
+	out, err := RestoreSSEStream(lines, f.Restore)
+	if err != nil {
+		t.Fatalf("RestoreSSEStream: unexpected error on bare data:[DONE]: %v", err)
+	}
+	output := outputStr(out)
+	if !strings.Contains(output, "[DONE]") {
+		t.Errorf("output missing [DONE] sentinel\noutput:\n%s", output)
+	}
+}
+
+// ── FIX 3: envelope and non-data lines restored ───────────────────────────────
+
+// TestRestoreSSEStream_PseudonymInEnvelopeField verifies that a pseudonym
+// echo-ed by the upstream in an envelope field (e.g. "model" or
+// "system_fingerprint") is removed from the synthesized output. This covers the
+// belt-and-suspenders final restore pass added to RestoreSSEStream.
+func TestRestoreSSEStream_PseudonymInEnvelopeField(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	// Anonymize a body to get a deterministic pseudonym for an email.
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"id: env@example.com"}]}`)
+	_, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	if !f.Touched() {
+		t.Fatal("Touched() = false; expected email to be detected")
+	}
+
+	pseudo := ""
+	origEmail := ""
+	for p, o := range f.rev {
+		pseudo = p
+		origEmail = o
+		break
+	}
+	if pseudo == "" {
+		t.Fatal("no pseudonym found")
+	}
+
+	// Upstream echoes the pseudonym in the "model" envelope field.
+	// The content delta carries clean text (no pseudonym in content).
+	eventWithPseudoInModel := `data: {"id":"ep1","object":"chat.completion.chunk","model":"` + pseudo + `","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}`
+
+	lines := makeSSELines(eventWithPseudoInModel, "", "data: [DONE]", "")
+
+	out, err := RestoreSSEStream(lines, f.Restore)
+	if err != nil {
+		t.Fatalf("RestoreSSEStream: unexpected error: %v", err)
+	}
+
+	output := outputStr(out)
+
+	// The raw pseudonym must NOT appear anywhere in the output (belt-and-suspenders).
+	if strings.Contains(output, pseudo) {
+		t.Errorf("FIX 3: pseudonym %q still visible in output after envelope restore\noutput:\n%s",
+			pseudo, output)
+	}
+
+	// The original email must appear in the output (restored from envelope).
+	if !strings.Contains(output, origEmail) {
+		t.Errorf("FIX 3: original email %q missing from output\noutput:\n%s", origEmail, output)
+	}
+
+	// The clean content must still be present.
+	if !strings.Contains(output, "hello") {
+		t.Errorf("FIX 3: clean content 'hello' missing from output\noutput:\n%s", output)
+	}
+}
+
+// TestRestoreSSEStream_PseudonymInNonDataLine verifies that a pseudonym in a
+// non-data SSE line (e.g. an SSE comment line starting with ":") is removed
+// from the output by the restore pass applied to non-data lines.
+func TestRestoreSSEStream_PseudonymInNonDataLine(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"id: nd@example.com"}]}`)
+	_, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	if !f.Touched() {
+		t.Fatal("Touched() = false")
+	}
+
+	pseudo := ""
+	origEmail := ""
+	for p, o := range f.rev {
+		pseudo = p
+		origEmail = o
+		break
+	}
+	if pseudo == "" {
+		t.Fatal("no pseudonym found")
+	}
+
+	// An SSE comment line carrying the pseudonym (e.g. upstream debug info).
+	commentLine := ": debug " + pseudo
+	contentEvent := `data: {"id":"nd1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}`
+
+	lines := makeSSELines(commentLine, contentEvent, "", "data: [DONE]", "")
+
+	out, err := RestoreSSEStream(lines, f.Restore)
+	if err != nil {
+		t.Fatalf("RestoreSSEStream: unexpected error: %v", err)
+	}
+
+	output := outputStr(out)
+
+	// Pseudonym must not appear anywhere in the output.
+	if strings.Contains(output, pseudo) {
+		t.Errorf("FIX 3: pseudonym %q still visible in non-data line output\noutput:\n%s",
+			pseudo, output)
+	}
+
+	// Original email must appear (restored from the comment line).
+	if !strings.Contains(output, origEmail) {
+		t.Errorf("FIX 3: original email %q missing from output\noutput:\n%s", origEmail, output)
+	}
+}

--- a/internal/pii/stream_test.go
+++ b/internal/pii/stream_test.go
@@ -1,0 +1,494 @@
+package pii
+
+// stream_test.go is in package pii (white-box) so it can construct a *Filter
+// directly via newTestFilter and call RestoreSSEStream with filter.Restore.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// sseLines converts a variadic list of raw SSE line strings into the [][]byte
+// slice expected by RestoreSSEStream. Blank separator lines are represented as
+// empty strings and converted to nil (matching the output convention of
+// RestoreSSEStream but accepting them as input too — RestoreSSEStream treats
+// non-data: lines as nonDataLines).
+func makeSSELines(lines ...string) [][]byte {
+	out := make([][]byte, 0, len(lines))
+	for _, l := range lines {
+		if l == "" {
+			out = append(out, []byte{}) // blank line (non-data)
+		} else {
+			out = append(out, []byte(l))
+		}
+	}
+	return out
+}
+
+// outputStr joins the output lines of RestoreSSEStream into a single string
+// for assertion. nil elements (blank separators) become a bare newline.
+func outputStr(lines [][]byte) string {
+	var b strings.Builder
+	for _, l := range lines {
+		if l == nil {
+			b.WriteByte('\n')
+		} else {
+			b.Write(l)
+			b.WriteByte('\n')
+		}
+	}
+	return b.String()
+}
+
+// ── Core bug: split pseudonym across two SSE events ──────────────────────────
+
+// TestRestoreSSEStream_SplitPseudonym is the principal regression test for the
+// streaming-leak bug described in the issue. It constructs an upstream SSE
+// response in which a deterministic pseudonym (produced by the same filter used
+// on the request) has been split across two consecutive SSE events by the LLM
+// tokenizer. The first event carries the first half as delta.content and the
+// second event carries the second half.
+//
+// The Stage-0a raw-byte-join approach fails here: when the two JSON objects are
+// concatenated as raw bytes the pseudonym appears as
+//
+//	...{"content":"PII_EM_1bd7"}...{"content":"5caa..."}...
+//
+// which never contains the full token as a contiguous substring, so
+// strings.Replacer cannot find it.
+//
+// RestoreSSEStream must reassemble the content per choice index before calling
+// Restore, at which point the complete pseudonym appears as a contiguous string
+// and the replacement succeeds.
+func TestRestoreSSEStream_SplitPseudonym(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+
+	// Anonymize a body containing a known email so we can derive the pseudonym.
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"email: test@split.example"}]}`)
+	anonBody, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	if !f.Touched() {
+		t.Fatal("Touched() = false; filter did not detect PII in test body")
+	}
+
+	// Extract the pseudonym that was assigned to the email.
+	pseudo := ""
+	for p, orig := range f.rev {
+		if orig == "test@split.example" {
+			pseudo = p
+			break
+		}
+	}
+	if pseudo == "" {
+		t.Fatalf("could not find pseudonym in filter rev map; anonBody: %s", anonBody)
+	}
+
+	// Verify the pseudonym is at least two characters so we can split it.
+	if len(pseudo) < 2 {
+		t.Fatalf("pseudonym too short to split: %q", pseudo)
+	}
+
+	// Split the pseudonym at the midpoint.
+	mid := len(pseudo) / 2
+	part1 := pseudo[:mid]
+	part2 := pseudo[mid:]
+
+	// Build upstream SSE lines: the pseudonym is split across event 1 and event 2.
+	// This exactly reproduces the bug: the LLM tokenizes the pseudonym token and
+	// emits the first half in one chunk and the second half in the next.
+	event1 := `data: {"id":"chatcmpl-x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"` + part1 + `"},"finish_reason":null}]}`
+	event2 := `data: {"id":"chatcmpl-x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"` + part2 + `"},"finish_reason":null}]}`
+	eventDone := `data: {"id":"chatcmpl-x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`
+
+	sseInput := makeSSELines(event1, "", event2, "", eventDone, "", "data: [DONE]", "")
+
+	restoredLines, err := RestoreSSEStream(sseInput, f.Restore)
+	if err != nil {
+		t.Fatalf("RestoreSSEStream: unexpected error: %v", err)
+	}
+
+	output := outputStr(restoredLines)
+
+	// Assert 1: the output contains the original email (pseudonym was restored).
+	if !strings.Contains(output, "test@split.example") {
+		t.Errorf("split-pseudonym restore failed: output does not contain original email %q\noutput:\n%s", "test@split.example", output)
+	}
+
+	// Assert 2: the output does NOT contain the raw pseudonym or either half.
+	if strings.Contains(output, pseudo) {
+		t.Errorf("output still contains full raw pseudonym %q (should have been restored)\noutput:\n%s", pseudo, output)
+	}
+	if strings.Contains(output, part1) || strings.Contains(output, part2) {
+		t.Errorf("output still contains pseudonym fragment (part1=%q part2=%q)\noutput:\n%s", part1, part2, output)
+	}
+
+	// Assert 3: output is valid SSE (contains data: and [DONE]).
+	if !strings.Contains(output, "data: ") {
+		t.Errorf("output missing SSE data: prefix\noutput:\n%s", output)
+	}
+	if !strings.Contains(output, "[DONE]") {
+		t.Errorf("output missing [DONE] sentinel\noutput:\n%s", output)
+	}
+}
+
+// TestRestoreSSEStream_SingleChunkPseudonym verifies the straightforward case
+// where the pseudonym appears in a single SSE event (no split). RestoreSSEStream
+// must restore it correctly in the output.
+func TestRestoreSSEStream_SingleChunkPseudonym(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"IBAN DE12345678901234567890"}]}`)
+	_, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	if !f.Touched() {
+		t.Fatal("Touched() = false; expected IBAN to be detected")
+	}
+
+	pseudo := ""
+	orig := ""
+	for p, o := range f.rev {
+		pseudo = p
+		orig = o
+		break
+	}
+
+	event := `data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Your IBAN is ` + pseudo + ` confirmed"},"finish_reason":null}]}`
+	done := `data: [DONE]`
+
+	lines := makeSSELines(event, "", done, "")
+
+	out, err := RestoreSSEStream(lines, f.Restore)
+	if err != nil {
+		t.Fatalf("RestoreSSEStream: %v", err)
+	}
+
+	output := outputStr(out)
+
+	if !strings.Contains(output, orig) {
+		t.Errorf("output missing original value %q\noutput:\n%s", orig, output)
+	}
+	if strings.Contains(output, pseudo) {
+		t.Errorf("output still contains pseudonym %q\noutput:\n%s", pseudo, output)
+	}
+}
+
+// TestRestoreSSEStream_NoPII verifies that when filter.Restore is a no-op
+// (no PII was anonymized), RestoreSSEStream returns valid SSE output with the
+// original content unchanged.
+func TestRestoreSSEStream_NoPII(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	// No AnonymizeJSON call — rev map is empty; Restore is a no-op.
+
+	event := `data: {"id":"y","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hello world"},"finish_reason":null}]}`
+	done := `data: [DONE]`
+
+	lines := makeSSELines(event, "", done, "")
+
+	out, err := RestoreSSEStream(lines, f.Restore)
+	if err != nil {
+		t.Fatalf("RestoreSSEStream: %v", err)
+	}
+
+	output := outputStr(out)
+
+	if !strings.Contains(output, "hello world") {
+		t.Errorf("content missing from output\noutput:\n%s", output)
+	}
+	if !strings.Contains(output, "[DONE]") {
+		t.Errorf("missing [DONE]\noutput:\n%s", output)
+	}
+}
+
+// TestRestoreSSEStream_MultipleChoices verifies that n>1 choices are each
+// restored independently. Each choice's content is assembled separately and
+// restore is applied per-choice.
+func TestRestoreSSEStream_MultipleChoices(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"contact alice@example.com and bob@example.com"}]}`)
+	_, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	if !f.Touched() {
+		t.Fatal("Touched() = false")
+	}
+
+	// Find the pseudonyms for alice and bob.
+	alicePseudo := ""
+	bobPseudo := ""
+	for p, o := range f.rev {
+		if o == "alice@example.com" {
+			alicePseudo = p
+		}
+		if o == "bob@example.com" {
+			bobPseudo = p
+		}
+	}
+	if alicePseudo == "" || bobPseudo == "" {
+		t.Fatalf("pseudonyms not found: alice=%q bob=%q", alicePseudo, bobPseudo)
+	}
+
+	// Two choices in the same SSE event, each with a different pseudonym.
+	event := `data: {"id":"z","object":"chat.completion.chunk","choices":[` +
+		`{"index":0,"delta":{"content":"` + alicePseudo + `"},"finish_reason":null},` +
+		`{"index":1,"delta":{"content":"` + bobPseudo + `"},"finish_reason":null}]}`
+
+	lines := makeSSELines(event, "", "data: [DONE]", "")
+
+	out, err := RestoreSSEStream(lines, f.Restore)
+	if err != nil {
+		t.Fatalf("RestoreSSEStream: %v", err)
+	}
+
+	output := outputStr(out)
+
+	if !strings.Contains(output, "alice@example.com") {
+		t.Errorf("output missing alice@example.com\noutput:\n%s", output)
+	}
+	if !strings.Contains(output, "bob@example.com") {
+		t.Errorf("output missing bob@example.com\noutput:\n%s", output)
+	}
+	if strings.Contains(output, alicePseudo) {
+		t.Errorf("output still contains alice pseudonym %q\noutput:\n%s", alicePseudo, output)
+	}
+	if strings.Contains(output, bobPseudo) {
+		t.Errorf("output still contains bob pseudonym %q\noutput:\n%s", bobPseudo, output)
+	}
+}
+
+// TestRestoreSSEStream_ToolCallsFailClosed verifies the fail-closed contract
+// for tool_calls streaming: if any choice carries tool_calls deltas,
+// RestoreSSEStream must return an error rather than risk leaking un-restored
+// content (split tool-call argument JSON cannot be safely reassembled).
+func TestRestoreSSEStream_ToolCallsFailClosed(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	// No PII setup needed — we're testing structural fail-closed behaviour.
+
+	event := `data: {"id":"tc1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function","function":{"name":"search","arguments":""}}]},"finish_reason":null}]}`
+
+	lines := makeSSELines(event, "", "data: [DONE]", "")
+
+	_, err := RestoreSSEStream(lines, f.Restore)
+	if err == nil {
+		t.Error("RestoreSSEStream returned nil error for tool_calls stream; expected fail-closed error")
+	}
+}
+
+// TestRestoreSSEStream_InvalidJSON verifies fail-closed behaviour when a data:
+// line carries a non-[DONE] payload that is not valid JSON.
+func TestRestoreSSEStream_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	lines := makeSSELines(`data: {broken json`, "")
+
+	_, err := RestoreSSEStream(lines, f.Restore)
+	if err == nil {
+		t.Error("RestoreSSEStream returned nil error for invalid JSON payload; expected fail-closed error")
+	}
+}
+
+// TestRestoreSSEStream_EmptyStream verifies that an SSE stream with no data
+// chunks (only a [DONE] line) is handled gracefully and emits a valid [DONE].
+func TestRestoreSSEStream_EmptyStream(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	lines := makeSSELines("data: [DONE]", "")
+
+	out, err := RestoreSSEStream(lines, f.Restore)
+	if err != nil {
+		t.Fatalf("RestoreSSEStream: %v", err)
+	}
+
+	output := outputStr(out)
+	if !strings.Contains(output, "[DONE]") {
+		t.Errorf("output missing [DONE]\noutput:\n%s", output)
+	}
+}
+
+// TestRestoreSSEStream_FinishReasonPreserved verifies that the finish_reason
+// field seen in the upstream stream is preserved in the synthesized output.
+func TestRestoreSSEStream_FinishReasonPreserved(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	// Minimal setup: no PII, just checking finish_reason is forwarded.
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"email: x@example.com"}]}`)
+	_, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+
+	pseudo := ""
+	for p := range f.rev {
+		pseudo = p
+		break
+	}
+	if pseudo == "" {
+		t.Fatal("no pseudonym found")
+	}
+
+	contentEvent := `data: {"id":"fr1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"` + pseudo + `"},"finish_reason":null}]}`
+	stopEvent := `data: {"id":"fr1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`
+
+	lines := makeSSELines(contentEvent, "", stopEvent, "", "data: [DONE]", "")
+
+	out, err := RestoreSSEStream(lines, f.Restore)
+	if err != nil {
+		t.Fatalf("RestoreSSEStream: %v", err)
+	}
+
+	output := outputStr(out)
+
+	if !strings.Contains(output, `"finish_reason":"stop"`) {
+		t.Errorf("finish_reason:stop missing from output\noutput:\n%s", output)
+	}
+}
+
+// TestRestoreSSEStream_SplitPseudonymRawJoinFails demonstrates WHY the old
+// raw-byte-join approach fails on a split pseudonym. This test runs the old
+// approach and asserts that it produces incorrect output (raw pseudonym fragments
+// visible), confirming the bug that RestoreSSEStream fixes. If this test ever
+// starts passing it means the old approach happened to work by accident (e.g.
+// because the pseudonym was emitted whole) — in that case the test conditions
+// must be re-verified.
+func TestRestoreSSEStream_SplitPseudonymRawJoinFails(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"email: raw@joinbug.example"}]}`)
+	_, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	if !f.Touched() {
+		t.Fatal("Touched() = false")
+	}
+
+	pseudo := ""
+	for p, o := range f.rev {
+		if o == "raw@joinbug.example" {
+			pseudo = p
+			break
+		}
+	}
+	if pseudo == "" {
+		t.Fatal("no pseudonym found")
+	}
+	if len(pseudo) < 2 {
+		t.Skipf("pseudonym too short to split: %q", pseudo)
+	}
+
+	mid := len(pseudo) / 2
+	part1 := pseudo[:mid]
+	part2 := pseudo[mid:]
+
+	event1 := `data: {"choices":[{"index":0,"delta":{"content":"` + part1 + `"}}]}`
+	event2 := `data: {"choices":[{"index":0,"delta":{"content":"` + part2 + `"}}]}`
+
+	lines := [][]byte{[]byte(event1), []byte(event2)}
+
+	// Simulate the old raw-byte-join approach.
+	var joined []byte
+	for _, l := range lines {
+		joined = append(joined, l...)
+		joined = append(joined, '\n')
+	}
+	rawRestored := f.Restore(joined)
+
+	// The old approach FAILS: the full pseudonym never appears as a contiguous
+	// substring in the joined buffer (it is interrupted by JSON field closing
+	// and opening), so Restore cannot find it, and fragments remain.
+	//
+	// If this assertion fails it means the pseudonym happened to survive the
+	// join intact (e.g. the test data changed) — re-split more carefully.
+	if !bytes.Contains(rawRestored, []byte(part1)) && !bytes.Contains(rawRestored, []byte(part2)) {
+		t.Skip("raw-join happened to restore correctly for this pseudonym; test conditions need re-verification")
+	}
+	// At least one fragment must remain visible, OR the full pseudonym must
+	// still be present (not replaced), demonstrating the limitation.
+	if !bytes.Contains(rawRestored, []byte(pseudo)) &&
+		!bytes.Contains(rawRestored, []byte(part1)) &&
+		!bytes.Contains(rawRestored, []byte(part2)) {
+		t.Skip("no fragment found; raw-join may have accidentally succeeded")
+	}
+
+	// Now confirm RestoreSSEStream correctly restores the split pseudonym.
+	sseInput := makeSSELines(event1, "", event2, "", "data: [DONE]", "")
+	out, err := RestoreSSEStream(sseInput, f.Restore)
+	if err != nil {
+		t.Fatalf("RestoreSSEStream: %v", err)
+	}
+	output := outputStr(out)
+
+	if !strings.Contains(output, "raw@joinbug.example") {
+		t.Errorf("RestoreSSEStream did not restore split pseudonym; output:\n%s", output)
+	}
+	if strings.Contains(output, pseudo) || strings.Contains(output, part1) || strings.Contains(output, part2) {
+		t.Errorf("RestoreSSEStream output still contains pseudonym or fragment\noutput:\n%s", output)
+	}
+}
+
+// TestRestoreSSEStream_CompletionsTextField verifies that the legacy completions
+// streaming format (choices[i].text instead of choices[i].delta.content) is
+// handled correctly.
+func TestRestoreSSEStream_CompletionsTextField(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-3.5-turbo-instruct","prompt":"email: comp@example.com"}`)
+	_, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	if !f.Touched() {
+		t.Fatal("Touched() = false")
+	}
+
+	pseudo := ""
+	for p, o := range f.rev {
+		if o == "comp@example.com" {
+			pseudo = p
+			break
+		}
+	}
+	if pseudo == "" {
+		t.Fatal("no pseudonym found")
+	}
+
+	// Completions streaming: text at choice level, not inside delta.
+	event := `data: {"id":"comp1","object":"text_completion.chunk","choices":[{"index":0,"text":"` + pseudo + `","finish_reason":null}]}`
+
+	lines := makeSSELines(event, "", "data: [DONE]", "")
+
+	out, err := RestoreSSEStream(lines, f.Restore)
+	if err != nil {
+		t.Fatalf("RestoreSSEStream: %v", err)
+	}
+
+	output := outputStr(out)
+
+	if !strings.Contains(output, "comp@example.com") {
+		t.Errorf("output missing restored email\noutput:\n%s", output)
+	}
+	if strings.Contains(output, pseudo) {
+		t.Errorf("output still contains pseudonym %q\noutput:\n%s", pseudo, output)
+	}
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,0 +1,34 @@
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/voidmind-io/voidllm/internal/provider"
+)
+
+func TestNames_ReturnsSortedSlice(t *testing.T) {
+	t.Parallel()
+
+	names := provider.Names()
+	if len(names) == 0 {
+		t.Fatal("Names() returned empty slice")
+	}
+
+	// Must be sorted.
+	for i := 1; i < len(names); i++ {
+		if names[i] < names[i-1] {
+			t.Errorf("Names() not sorted at index %d: %q < %q", i, names[i], names[i-1])
+		}
+	}
+
+	// Must contain all providers from ValidProviders.
+	nameSet := make(map[string]bool, len(names))
+	for _, n := range names {
+		nameSet[n] = true
+	}
+	for p := range provider.ValidProviders {
+		if !nameSet[p] {
+			t.Errorf("Names() missing provider %q from ValidProviders", p)
+		}
+	}
+}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/voidmind-io/voidllm/internal/circuitbreaker"
 	"github.com/voidmind-io/voidllm/internal/jsonx"
 	"github.com/voidmind-io/voidllm/internal/metrics"
+	"github.com/voidmind-io/voidllm/internal/pii"
 	"github.com/voidmind-io/voidllm/internal/ratelimit"
 	"github.com/voidmind-io/voidllm/internal/shutdown"
 	"github.com/voidmind-io/voidllm/internal/usage"
@@ -62,6 +63,10 @@ type ProxyHandler struct {
 	// request. Zero or negative disables fallback chaining entirely.
 	// Set from config.SettingsConfig.FallbackMaxDepth at startup.
 	FallbackMaxDepth int
+	// PIIEngine performs in-memory PII anonymization on outbound request
+	// bodies and restores original values in responses. A nil value
+	// disables PII anonymization entirely with zero overhead on the hot path.
+	PIIEngine *pii.Engine
 }
 
 // NewProxyHandler constructs a ProxyHandler with a pre-configured HTTP client.
@@ -181,12 +186,6 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 		return err
 	}
 
-	if p.Tracer != nil {
-		trace.SpanFromContext(c.Context()).SetAttributes(
-			attribute.String("model.requested", envelope.Model),
-		)
-	}
-
 	keyInfo := auth.KeyInfoFromCtx(c)
 	requestID := apierror.RequestIDFromCtx(c)
 
@@ -205,6 +204,12 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 		return err
 	}
 
+	// Set tracing attributes only after successful model resolution so that the
+	// raw, client-supplied model string (envelope.Model) never reaches the
+	// tracing backend. A client that embeds PII in the model field would
+	// otherwise persist that PII in spans — a Zero-Knowledge violation.
+	// model.Name is the canonical, registry-validated name; model.Provider is
+	// set by the registry loader and is never derived from client input.
 	if p.Tracer != nil {
 		trace.SpanFromContext(c.Context()).SetAttributes(
 			attribute.String("model.canonical", model.Name),
@@ -222,9 +227,96 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 	// request's fallback chain so that runtime cycles are detected and broken.
 	visited := make(map[string]bool)
 
-	// currentModel and currentBody may be replaced on each fallback iteration.
+	// currentModel may be replaced on each fallback iteration.
 	currentModel := model
-	currentBody := body
+
+	// PII anonymization: create a per-request filter and pre-anonymize the
+	// body ONCE before the fallback loop. We hold both the original body
+	// and an anonymized body in parallel. On each hop we choose which body
+	// to send based on the ACTUAL provider resolved for that hop (after
+	// applyDeployment). This is the only correct approach: the initial model
+	// provider may differ from the deployment or fallback provider, and a
+	// later hop could route to an external provider even when the primary
+	// was internal.
+	//
+	// Design: the filter is created with the authenticated key's OrgID so
+	// that pseudonyms are tenant-scoped. The filter lives until the response
+	// is fully handled (including inside the streaming goroutine, which
+	// captures it by value on the heap). The filter is never accessed from
+	// multiple goroutines.
+	//
+	// Fail-closed: if anonymization fails (parse error, mapping cap exceeded),
+	// the request is rejected immediately. We never forward the original body
+	// when the engine is enabled and anonymization cannot be guaranteed.
+	var piiFilter *pii.Filter
+	var anonBody []byte // anonymized body; nil when PII engine is disabled
+	if p.PIIEngine != nil {
+		// OrgID is always non-empty for authenticated requests because the auth
+		// middleware (internal/auth) validates the API key and rejects requests
+		// with no matching key. The only path with a nil keyInfo is test code or
+		// an unauthenticated bypass — neither is possible on the production hot
+		// path (auth middleware is always wired before Handle). If keyInfo is nil
+		// here, orgID defaults to "" which still produces valid pseudonyms scoped
+		// to the empty-string tenant; anonymization is still applied.
+		orgID := ""
+		if keyInfo != nil {
+			orgID = keyInfo.OrgID
+		}
+		piiFilter = p.PIIEngine.NewFilter(orgID)
+		var anonErr error
+		anonBody, anonErr = piiFilter.AnonymizeJSON(body)
+		if anonErr != nil {
+			// Fail-closed: reject the request rather than risk sending PII
+			// to an external provider on any hop in the fallback chain.
+			return apierror.Send(c, fiber.StatusUnprocessableEntity,
+				"pii_policy", "request rejected by PII policy")
+		}
+	}
+
+	// shouldAnonymize reports whether PII anonymization must be applied for the
+	// given deployment. The decision follows this priority order:
+	//
+	//  1. dep.PIIFilter != nil  → use *dep.PIIFilter (explicit per-deployment)
+	//  2. model.PIIFilter != nil → use *model.PIIFilter (explicit per-model)
+	//  3. default               → anonymize when the destination is NOT private
+	//                             (!dep.destPrivate), pass through when private
+	//
+	// An explicit pii_filter: true on a private destination forces anonymization;
+	// an explicit pii_filter: false on a public destination suppresses it (trusted
+	// public endpoint). The default (nil flag) uses the network-based heuristic
+	// so that self-hosted models on loopback/private IPs are never anonymized by
+	// default, while cloud-provider endpoints are always anonymized by default.
+	//
+	// The model captured here is the ORIGINAL resolved model (before any fallback
+	// hop replaces currentModel). Within a single hop, currentModel is passed into
+	// tryModel which passes it as the model arg; the closure below captures the
+	// outer currentModel by reference, so it always reflects the model for the
+	// current hop. This is correct: each hop's shouldAnonymize reads the model
+	// for that hop, not the original requested model.
+	shouldAnonymize := func(dep Deployment, m Model) bool {
+		if dep.PIIFilter != nil {
+			return *dep.PIIFilter
+		}
+		if m.PIIFilter != nil {
+			return *m.PIIFilter
+		}
+		return !dep.destPrivate
+	}
+
+	// pickBody returns the body that should be sent to a given deployment.
+	// It delegates to shouldAnonymize and selects the anonymized body when
+	// the PII engine is active and anonymization is required. The model
+	// argument is the hop-local model (after applyDeployment in tryModel).
+	//
+	// The anonymous function signature matches what tryModel expects: only
+	// a Deployment is passed as the first argument. We capture currentModel
+	// by reference so the closure always sees the active hop's model.
+	pickBody := func(dep Deployment) []byte {
+		if piiFilter != nil && shouldAnonymize(dep, currentModel) {
+			return anonBody
+		}
+		return body
+	}
 
 	// Per-model timeout overrides the global stream duration limit when set.
 	// Recomputed on each iteration in case the fallback model has a different timeout.
@@ -256,7 +348,11 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 		visited[currentModel.Name] = true
 
 		var tryErr error
-		resp, cancelUpstream, adapter, usedDep, lastErr, lastStatus, tryErr = p.tryModel(c, currentModel, currentBody, envelope)
+		// pickBody is passed as a closure so tryModel can evaluate the correct
+		// body variant per deployment, after applyDeployment has resolved the
+		// effective provider. This is the fix for VULN-001: the body selection
+		// must happen inside the deployment loop, not at the loop's call site.
+		resp, cancelUpstream, adapter, usedDep, lastErr, lastStatus, tryErr = p.tryModel(c, currentModel, pickBody, envelope)
 		if tryErr != nil {
 			// tryModel wrote an error response to c (errResponseSent) or
 			// returned a framework error. Either way, stop immediately.
@@ -310,7 +406,11 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 			}
 		}
 
-		newBody, berr := rewriteModelInBody(currentBody, next.Name)
+		// Rewrite the model field in both the original and anonymized bodies
+		// so that the next hop uses the correct model name regardless of
+		// which body variant is ultimately sent. The rewrite only modifies
+		// the "model" field, not any content field.
+		newBody, berr := rewriteModelInBody(body, next.Name)
 		if berr != nil {
 			p.Log.LogAttrs(c.Context(), slog.LevelWarn, "fallback: cannot rewrite request body; stopping chain",
 				slog.String("from", currentModel.Name),
@@ -319,6 +419,19 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 			)
 			// Preserve the primary's error; do not leak the body-rewrite error.
 			break
+		}
+		body = newBody
+		if anonBody != nil {
+			newAnonBody, anonBerr := rewriteModelInBody(anonBody, next.Name)
+			if anonBerr != nil {
+				p.Log.LogAttrs(c.Context(), slog.LevelWarn, "fallback: cannot rewrite anonymized request body; stopping chain",
+					slog.String("from", currentModel.Name),
+					slog.String("to", next.Name),
+					slog.String("error", anonBerr.Error()),
+				)
+				break
+			}
+			anonBody = newAnonBody
 		}
 
 		// We have a fallback target, access is permitted, and the body has been
@@ -341,8 +454,11 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 			cancelUpstream = nil
 		}
 
-		currentBody = newBody
 		currentModel = next
+		// The correct body variant (original vs anonymized) for the next hop
+		// is selected inside tryModel via the pickBody closure, after
+		// applyDeployment resolves the effective provider for each deployment.
+		// No per-hop body pre-selection is needed here.
 		effectiveStreamDur = maxStreamDur
 		if currentModel.Timeout > 0 {
 			effectiveStreamDur = currentModel.Timeout
@@ -366,18 +482,27 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 			breaker = p.CircuitBreakers.Get(deploymentKey(currentModel.Name, usedDep.Name))
 		}
 		return p.handleStreamingResponse(c, resp, cancelUpstream, currentModel,
-			keyInfo, adapter, startTime, requestID, requestedModelName, effectiveStreamDur, trackDone, breaker)
+			keyInfo, adapter, startTime, requestID, requestedModelName, effectiveStreamDur, maxRespBody, trackDone, breaker, piiFilter)
 	}
 
 	defer cancelUpstream()
 	return p.handleBufferedResponse(c, resp, currentModel, keyInfo, adapter,
-		startTime, requestID, requestedModelName, maxRespBody)
+		startTime, requestID, requestedModelName, maxRespBody, piiFilter)
 }
 
 // tryModel attempts to forward the request to the given model using its
 // configured deployment candidates. It selects candidates via the Router (or
 // synthesises a single candidate), iterates them in order, and returns as soon
 // as one succeeds or returns a non-retryable status.
+//
+// pickBody is called once per deployment with the fully resolved Deployment
+// value (after applyDeployment). It returns the correct body variant (original
+// or anonymized) based on the deployment's pre-computed TrustedInternal flag.
+// This is the only correct place to perform this selection: the model-level
+// provider may differ from the deployment provider, and a deployment on a
+// public-internet host must receive the anonymized body regardless of the
+// model-level provider field. When PII anonymization is disabled, pickBody
+// always returns the original body.
 //
 // Return values:
 //   - resp: the upstream response, or nil if all candidates failed.
@@ -392,7 +517,7 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 func (p *ProxyHandler) tryModel(
 	c fiber.Ctx,
 	model Model,
-	body []byte,
+	pickBody func(dep Deployment) []byte,
 	envelope requestEnvelope,
 ) (*http.Response, context.CancelFunc, Adapter, Deployment, error, int, error) {
 	// Build the ordered list of deployment candidates. When Router is nil or
@@ -402,6 +527,11 @@ func (p *ProxyHandler) tryModel(
 	if p.Router != nil && len(model.Deployments) > 0 {
 		candidates = p.Router.Pick(model)
 	} else {
+		// Synthesize a single deployment from the model's own fields.
+		// destPrivate and PIIFilter are copied from the model's pre-computed
+		// fields so that single-deployment models receive the same PII decision
+		// as multi-deployment models. Both fields are immutable after registry
+		// load; the pointer copy for PIIFilter is safe.
 		candidates = []Deployment{{
 			Name:            model.Name,
 			Provider:        model.Provider,
@@ -412,6 +542,8 @@ func (p *ProxyHandler) tryModel(
 			GCPProject:      model.GCPProject,
 			GCPLocation:     model.GCPLocation,
 			Weight:          1,
+			destPrivate:     model.destPrivate,
+			PIIFilter:       model.PIIFilter,
 		}}
 	}
 
@@ -446,8 +578,16 @@ func (p *ProxyHandler) tryModel(
 		m := model
 		applyDeployment(&m, d)
 
+		// Select the correct body variant for this specific deployment.
+		// The security boundary is the deployment's TrustedInternal flag, which
+		// was pre-computed from the BaseURL host at registry load time. We pass
+		// the full Deployment so pickBody can read the flag directly. This is
+		// evaluated AFTER applyDeployment so the per-deployment BaseURL is used,
+		// not the model-level BaseURL which may differ.
+		effectiveBody := pickBody(d)
+
 		var buildErr error
-		req, cancelUpstream, currentAdapter, buildErr = p.buildUpstreamRequest(c, m, body, envelope)
+		req, cancelUpstream, currentAdapter, buildErr = p.buildUpstreamRequest(c, m, effectiveBody, envelope)
 		if buildErr != nil {
 			return nil, nil, nil, Deployment{}, nil, 0, buildErr
 		}
@@ -840,7 +980,10 @@ func (p *ProxyHandler) buildUpstreamRequest(c fiber.Ctx, model Model, body []byt
 // goroutine records success or failure after the stream completes.
 // requestedModelName is the canonical name the client originally asked for;
 // it may differ from model.Name when a fallback was activated.
-func (p *ProxyHandler) handleStreamingResponse(c fiber.Ctx, resp *http.Response, cancelUpstream context.CancelFunc, model Model, keyInfo *auth.KeyInfo, adapter Adapter, startTime time.Time, requestID string, requestedModelName string, maxStreamDuration time.Duration, trackDone func(), breaker *circuitbreaker.Breaker) error {
+// maxRespBody is the aggregate byte cap for the PII-buffered streaming path;
+// it is the same limit used for non-streaming responses.
+// filter may be nil when PII anonymization is disabled.
+func (p *ProxyHandler) handleStreamingResponse(c fiber.Ctx, resp *http.Response, cancelUpstream context.CancelFunc, model Model, keyInfo *auth.KeyInfo, adapter Adapter, startTime time.Time, requestID string, requestedModelName string, maxStreamDuration time.Duration, maxRespBody int, trackDone func(), breaker *circuitbreaker.Breaker, filter *pii.Filter) error {
 	copyResponseHeaders(c, resp)
 	c.Set("Content-Type", "text/event-stream")
 	c.Set("Cache-Control", "no-cache")
@@ -881,53 +1024,220 @@ func (p *ProxyHandler) handleStreamingResponse(c fiber.Ctx, resp *http.Response,
 		extractor := &streamUsageExtractor{}
 		scanner := bufio.NewScanner(resp.Body)
 		scanner.Buffer(make([]byte, 64*1024), 4*1024*1024) // up to 4MB per SSE line
+
+		// PII streaming strategy (Stage 0a — content-aware restore):
+		//
+		// When PII was detected (filter.Touched()), pseudonym tokens in the
+		// response may be split across SSE event boundaries by the LLM
+		// tokenizer. For example, "PII_EM_1bd7" may appear as the delta.content
+		// in event 1 and "5caa...restofhex" in event 2. In the raw SSE byte
+		// stream the full token never appears as a contiguous byte sequence, so
+		// a strings.Replacer running over joined raw bytes cannot find it.
+		//
+		// The correct fix: extract delta.content per choice index from each
+		// event's JSON payload, concatenate, apply Restore over the assembled
+		// string (where the token is always contiguous), then re-emit valid SSE.
+		// pii.RestoreSSEStream implements this content-aware restore.
+		//
+		// Trade-offs:
+		//   - PII-hit requests receive the full restored content in one or two
+		//     synthetic SSE chunks instead of token-by-token. This is correct
+		//     and leak-free. Stage 0b: optional incremental cross-event rolling
+		//     buffer for token-by-token streaming; the buffered content-aware
+		//     restore here is correct and leak-free.
+		//   - Tool-call streaming with PII anonymization is fail-closed: if any
+		//     choice carries tool_calls deltas, RestoreSSEStream returns an
+		//     error and the request is aborted (no un-restored content reaches
+		//     the client).
+		//
+		// For non-PII or filter-nil requests, the original per-line passthrough
+		// is used with zero overhead.
+		// needsContentRestore is true when PII was detected: the response must
+		// be buffered so that pseudonyms can be restored before delivery to the
+		// client. The name reflects the purpose (restore content), not the
+		// detection mechanism.
+		needsContentRestore := filter != nil && filter.Touched()
+
 		var ttftMS *int
 		firstChunk := true
-		for scanner.Scan() {
-			line := scanner.Bytes()
-			if firstChunk && bytes.HasPrefix(line, []byte("data: ")) {
-				t := int(time.Since(startTime).Milliseconds())
-				ttftMS = &t
-				firstChunk = false
-				metrics.ProxyTTFTSeconds.WithLabelValues(model.Name).Observe(float64(t) / 1000)
+
+		// maxPIIStreamBytes is the aggregate byte cap for the buffered PII
+		// streaming path. Collecting unlimited SSE lines into memory would
+		// allow a malicious upstream to exhaust the proxy's heap. We use the
+		// effective response body limit (maxRespBody) as the cap so that the
+		// PII path never holds more bytes than the non-streaming path would.
+		// On breach we fail-closed: no un-restored content is emitted.
+		maxPIIStreamBytes := maxRespBody
+
+		if needsContentRestore {
+			// Content-aware buffered path: read ALL SSE lines, check scanner.Err
+			// BEFORE emitting, then call RestoreSSEStream which extracts content
+			// per choice, reassembles across event boundaries, applies Restore,
+			// and returns synthetic SSE lines with the restored content.
+			//
+			// scanner.Err() is checked before emit (Finding 5): a truncated or
+			// oversized scan must abort before any un-restored content is written.
+			// Aggregate byte cap (Finding 6): we count raw bytes accumulated and
+			// fail-closed if the total exceeds maxPIIStreamBytes.
+			var sseLines [][]byte
+			var totalBytes int
+			var streamCapExceeded bool
+			for scanner.Scan() {
+				line := scanner.Bytes()
+
+				// Enforce aggregate byte cap BEFORE copying the line into heap
+				// memory. This prevents the overshooting line from being allocated
+				// when the limit is already reached. +1 accounts for the newline.
+				totalBytes += len(line) + 1
+				if totalBytes > maxPIIStreamBytes {
+					streamCapExceeded = true
+					break
+				}
+
+				// Copy: scanner.Bytes() is reused on the next Scan call.
+				lineCopy := make([]byte, len(line))
+				copy(lineCopy, line)
+
+				if firstChunk && bytes.HasPrefix(lineCopy, []byte("data:")) {
+					t := int(time.Since(startTime).Milliseconds())
+					ttftMS = &t
+					firstChunk = false
+					metrics.ProxyTTFTSeconds.WithLabelValues(model.Name).Observe(float64(t) / 1000)
+				}
+				if adapter != nil {
+					lineCopy = adapter.TransformStreamLine(lineCopy)
+					if lineCopy == nil {
+						continue // adapter says skip this line
+					}
+				}
+				extractor.observe(lineCopy)
+				sseLines = append(sseLines, lineCopy)
 			}
-			if adapter != nil {
-				line = adapter.TransformStreamLine(line)
-				if line == nil {
-					continue // adapter says skip this line
+
+			// Check scanner.Err() BEFORE emitting any content (Finding 5).
+			// A scan error (truncated stream, oversized line, transport failure)
+			// means the accumulated sseLines may be incomplete. Emitting a partial
+			// restore could leak un-restored pseudonyms. Fail-closed: log and return
+			// without writing anything to the client.
+			if scanErr := scanner.Err(); scanErr != nil {
+				p.Log.LogAttrs(context.Background(), slog.LevelWarn,
+					"pii: stream read error before restore; stream aborted to prevent pseudonym leak",
+					slog.String("error", scanErr.Error()),
+				)
+				if breaker != nil {
+					breaker.RecordFailure()
+				}
+				_ = w.Flush()
+				return
+			}
+
+			if streamCapExceeded {
+				p.Log.LogAttrs(context.Background(), slog.LevelWarn,
+					"pii: aggregate stream size limit exceeded; stream aborted to prevent memory exhaustion")
+				if breaker != nil {
+					breaker.RecordFailure()
+				}
+				_ = w.Flush()
+				return
+			}
+
+			// Content-aware restore: extract delta.content per choice, apply
+			// Restore over the assembled string (where split tokens are now
+			// contiguous), and re-emit valid SSE. Fail-closed on parse error.
+			restoredLines, restoreErr := pii.RestoreSSEStream(sseLines, filter.Restore)
+			if restoreErr != nil {
+				// Fail-closed: cannot safely restore content. Write nothing;
+				// log the error without any content detail (zero-knowledge).
+				p.Log.LogAttrs(context.Background(), slog.LevelWarn,
+					"pii: sse restore failed; stream aborted to prevent pseudonym leak")
+				if breaker != nil {
+					breaker.RecordFailure()
+				}
+				_ = w.Flush()
+				return
+			}
+
+			// Record circuit breaker success after successful restore. The outer
+			// scanErr check after the if/else block only runs for the non-buffered
+			// path; in the buffered PII path we handle all outcomes here.
+			if breaker != nil {
+				breaker.RecordSuccess()
+			}
+
+			writeErr := false
+			for _, b := range restoredLines {
+				if b == nil {
+					// nil element signals a blank SSE event separator line.
+					if err := w.WriteByte('\n'); err != nil {
+						writeErr = true
+						break
+					}
+					continue
+				}
+				if _, err := w.Write(b); err != nil {
+					writeErr = true
+					break
+				}
+				if err := w.WriteByte('\n'); err != nil {
+					writeErr = true
+					break
 				}
 			}
-			// Always observe the (possibly transformed) line. Transformed
-			// lines are OpenAI-shaped (Azure passthrough, Anthropic → OpenAI),
-			// and raw passthrough lines are already OpenAI-shaped, so the
-			// extractor can parse usage from all of them.
-			extractor.observe(line)
-			if _, err := w.Write(line); err != nil {
-				break // client disconnected
+			if !writeErr {
+				_ = w.Flush()
 			}
-			if err := w.WriteByte('\n'); err != nil {
-				break // client disconnected
-			}
-			if err := w.Flush(); err != nil {
-				break // client disconnected
-			}
-		}
-		scanErr := scanner.Err()
-		if scanErr != nil {
-			p.Log.LogAttrs(context.Background(), slog.LevelWarn,
-				"streaming scan error",
-				slog.String("error", scanErr.Error()),
-			)
-		}
+		} else {
+			// Non-buffered path: per-line passthrough with no PII overhead.
+			for scanner.Scan() {
+				line := scanner.Bytes()
+				if firstChunk && bytes.HasPrefix(line, []byte("data: ")) {
+					t := int(time.Since(startTime).Milliseconds())
+					ttftMS = &t
+					firstChunk = false
+					metrics.ProxyTTFTSeconds.WithLabelValues(model.Name).Observe(float64(t) / 1000)
+				}
+				if adapter != nil {
+					line = adapter.TransformStreamLine(line)
+					if line == nil {
+						continue // adapter says skip this line
+					}
+				}
+				// Always observe the (possibly transformed) line. Transformed
+				// lines are OpenAI-shaped (Azure passthrough, Anthropic → OpenAI),
+				// and raw passthrough lines are already OpenAI-shaped, so the
+				// extractor can parse usage from all of them.
+				extractor.observe(line)
 
-		// Record the circuit breaker outcome now that we know whether the
-		// stream completed successfully. A scan error (transport failure,
-		// context cancellation) counts as a failure; a clean EOF does not.
-		if breaker != nil {
+				if _, err := w.Write(line); err != nil {
+					break // client disconnected
+				}
+				if err := w.WriteByte('\n'); err != nil {
+					break // client disconnected
+				}
+				if err := w.Flush(); err != nil {
+					break // client disconnected
+				}
+			}
+		}
+		// In the non-buffered path, check scanner.Err() here and record the
+		// circuit breaker outcome. In the buffered PII path, both checks
+		// and the breaker recording are handled inside the needsContentRestore
+		// block above (which also returns early on error), so we skip breaker
+		// recording here for that path to avoid double-counting.
+		if !needsContentRestore {
+			scanErr := scanner.Err()
 			if scanErr != nil {
-				breaker.RecordFailure()
-			} else {
-				breaker.RecordSuccess()
+				p.Log.LogAttrs(context.Background(), slog.LevelWarn,
+					"streaming scan error",
+					slog.String("error", scanErr.Error()),
+				)
+			}
+			if breaker != nil {
+				if scanErr != nil {
+					breaker.RecordFailure()
+				} else {
+					breaker.RecordSuccess()
+				}
 			}
 		}
 
@@ -955,7 +1265,8 @@ func (p *ProxyHandler) handleStreamingResponse(c fiber.Ctx, resp *http.Response,
 // body to the client. Usage is logged asynchronously on success.
 // requestedModelName is the canonical name the client originally asked for;
 // it may differ from model.Name when a fallback was activated.
-func (p *ProxyHandler) handleBufferedResponse(c fiber.Ctx, resp *http.Response, model Model, keyInfo *auth.KeyInfo, adapter Adapter, startTime time.Time, requestID string, requestedModelName string, maxResponseBody int) error {
+// filter may be nil when PII anonymization is disabled.
+func (p *ProxyHandler) handleBufferedResponse(c fiber.Ctx, resp *http.Response, model Model, keyInfo *auth.KeyInfo, adapter Adapter, startTime time.Time, requestID string, requestedModelName string, maxResponseBody int, filter *pii.Filter) error {
 	// Content-Length pre-check: fast-reject optimization to avoid allocating
 	// memory for obviously oversized responses. Not the security boundary —
 	// io.LimitReader on the next line handles chunked/unknown-length responses.
@@ -1014,6 +1325,18 @@ func (p *ProxyHandler) handleBufferedResponse(c fiber.Ctx, resp *http.Response, 
 	} else {
 		finalBody = responseBody
 		usageBody = responseBody // already OpenAI-shaped
+	}
+
+	// PII restore: replace pseudonyms with original values on all responses,
+	// including 4xx and 5xx. Provider error messages sometimes echo back
+	// parts of the request (e.g. the model name or request fields); if a
+	// pseudonym appears in an error body, the client must see the original
+	// value. Restoring on non-2xx is a no-op when the provider did not echo
+	// any pseudonym — and when it did, restoring is the correct behaviour.
+	// filter.Touched() guards against the cost of building the Replacer on
+	// requests where no PII was detected.
+	if filter != nil && filter.Touched() {
+		finalBody = filter.Restore(finalBody)
 	}
 
 	if err := c.Send(finalBody); err != nil {

--- a/internal/proxy/pii_handler_test.go
+++ b/internal/proxy/pii_handler_test.go
@@ -1,0 +1,1102 @@
+package proxy
+
+// pii_handler_test.go tests the PII anonymization behaviour that was introduced
+// alongside the feat/pii-anonymization-stage0a changes. All eight critical
+// behaviours described in the review findings are covered here.
+//
+// Conventions:
+//   - Each test spins up its own httptest.Server so no state is shared.
+//   - t.Parallel() at top-level and inside sub-test loops (safe in Go 1.22+).
+//   - No mocks for storage — ProxyHandler holds no DB state; the registry is
+//     built in-process from config.ModelConfig slices.
+//   - The PII engine uses DefaultPatterns so EMAIL detection is always active.
+//     The test email "test.user@piitest.example" is unambiguously recognisable.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/voidmind-io/voidllm/internal/pii"
+)
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+// piiTestSecret is a fixed 32-byte secret used to build all test PII engines.
+// It must never be a real installation secret.
+var piiTestSecret = []byte("pii-test-secret-32bytes-00000000")
+
+// newTestPIIEngine returns a PII Engine backed by the DefaultPatterns detector.
+func newTestPIIEngine(t *testing.T) *pii.Engine {
+	t.Helper()
+	d, err := pii.NewRegexDetector(pii.DefaultPatterns())
+	if err != nil {
+		t.Fatalf("NewRegexDetector(DefaultPatterns()): %v", err)
+	}
+	return pii.NewEngine(piiTestSecret, []pii.Detector{d})
+}
+
+// piiTestEmail is the canonical PII email used across all proxy PII tests.
+// It must not contain sub-strings that happen to match other DefaultPatterns
+// (IBAN, PHONE, CREDIT_CARD, TAX_ID) to keep assertions unambiguous.
+const piiTestEmail = "test.user@piitest.example"
+
+// piiPseudonymPattern matches the format PII_EM_<24 hex chars>.
+var piiPseudonymPattern = regexp.MustCompile(`PII_EM_[0-9a-f]{24}`)
+
+// captureUpstream creates an httptest.Server that records the body of every
+// received request into a shared atomic counter for hit-count and into a
+// lastBody pointer. The server responds with the given status and body.
+//
+// Each call to the handler appends the received body to *lastBody; only the
+// most-recently written request is accessible via the returned pointer because
+// most tests send exactly one request per upstream.
+func captureUpstream(t *testing.T, status int, respBody string, respHeaders map[string]string) (*httptest.Server, *[]byte, *int32) {
+	t.Helper()
+	var last []byte
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("captureUpstream: read body: %v", err)
+		}
+		last = b
+		for k, v := range respHeaders {
+			w.Header().Set(k, v)
+		}
+		w.WriteHeader(status)
+		fmt.Fprint(w, respBody)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &last, &calls
+}
+
+// piiRegistryExternal builds a Registry with a single model whose
+// destPrivate=false (no PIIFilter set), so the network-default applies:
+// PII anonymization is applied because the destination is classified as public.
+//
+// Test servers run on 127.0.0.1 (loopback), which classifyDestPrivate would
+// classify as private (destPrivate=true), causing the default to skip
+// anonymization. We construct the Model directly and leave destPrivate at its
+// zero value (false) and PIIFilter=nil, which means shouldAnonymize returns
+// !destPrivate = true — exercising the external/anonymized code path.
+func piiRegistryExternal(t *testing.T, upstreamURL string) *Registry {
+	t.Helper()
+	m := &Model{
+		Name:     "ext-model",
+		Provider: "openai",
+		Type:     "chat",
+		BaseURL:  upstreamURL,
+		APIKey:   "key-ext",
+		// destPrivate=false (zero value), PIIFilter=nil:
+		// shouldAnonymize returns !destPrivate = true → PII must be anonymized.
+	}
+	r := &Registry{
+		models:  map[string]*Model{"ext-model": m},
+		aliases: make(map[string]string),
+	}
+	r.rebuildSorted()
+	return r
+}
+
+// piiRegistryInternal builds a Registry with a single model whose
+// destPrivate=true (no PIIFilter set), so the network-default applies:
+// the original body passes through unmodified because the destination is
+// classified as private.
+//
+// In production, classifyDestPrivate sets destPrivate=true when the BaseURL
+// host is loopback, private, link-local, or "localhost".
+func piiRegistryInternal(t *testing.T, upstreamURL string) *Registry {
+	t.Helper()
+	m := &Model{
+		Name:        "int-model",
+		Provider:    "vllm",
+		Type:        "chat",
+		BaseURL:     upstreamURL,
+		APIKey:      "key-int",
+		destPrivate: true, // private destination: original body passes through by default
+	}
+	r := &Registry{
+		models:  map[string]*Model{"int-model": m},
+		aliases: make(map[string]string),
+	}
+	r.rebuildSorted()
+	return r
+}
+
+// piiHandler returns a ProxyHandler with PIIEngine set, no fallback.
+func piiHandler(t *testing.T, reg *Registry) *ProxyHandler {
+	t.Helper()
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.PIIEngine = newTestPIIEngine(t)
+	return h
+}
+
+// piiHandlerNoEngine returns a ProxyHandler WITHOUT a PII engine (nil).
+func piiHandlerNoEngine(t *testing.T, reg *Registry) *ProxyHandler {
+	t.Helper()
+	return NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+// chatBody constructs a minimal OpenAI chat-completion request body with the
+// given model name and user content.
+func chatBody(model, content string) string {
+	return fmt.Sprintf(`{"model":%q,"messages":[{"role":"user","content":%q}]}`, model, content)
+}
+
+// extractContentFromResponse extracts the "content" field from the first
+// choice in a non-streaming OpenAI chat completion response body.
+func extractContentFromResponse(t *testing.T, body []byte) string {
+	t.Helper()
+	var resp struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("extractContentFromResponse: unmarshal: %v\nbody: %s", err, body)
+	}
+	if len(resp.Choices) == 0 {
+		t.Fatalf("extractContentFromResponse: no choices in: %s", body)
+	}
+	return resp.Choices[0].Message.Content
+}
+
+// extractModelFromUpstreamBody extracts the "model" field from a raw upstream
+// request body captured by captureUpstream.
+func extractModelFromUpstreamBody(t *testing.T, body []byte) string {
+	t.Helper()
+	var env struct {
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("extractModelFromUpstreamBody: unmarshal: %v\nbody: %s", err, body)
+	}
+	return env.Model
+}
+
+// ── Test 1: External provider — body anonymised ───────────────────────────────
+
+// TestPII_ExternalProvider_BodyAnonymised verifies that when a request targeting
+// an external provider (openai) contains an email address, the body received by
+// the mock upstream carries the pseudonym, not the original email. The client
+// response restores the original email from the pseudonym.
+func TestPII_ExternalProvider_BodyAnonymised(t *testing.T) {
+	t.Parallel()
+
+	// The upstream echoes the pseudonym back in the content field so we can
+	// verify end-to-end restore. We capture what the upstream receives first,
+	// then build the response on the fly.
+	var upstreamBody []byte
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		upstreamBody = b
+
+		// Extract the pseudonym from the upstream body so we can echo it back.
+		pseudo := piiPseudonymPattern.FindString(string(b))
+		if pseudo == "" {
+			// Fallback: echo raw to expose the issue clearly.
+			pseudo = "[no pseudonym found]"
+		}
+		resp := fmt.Sprintf(`{"id":"cmp-1","object":"chat.completion","choices":[{"message":{"role":"assistant","content":%q}}]}`, pseudo)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, resp)
+	}))
+	t.Cleanup(upstream.Close)
+
+	reg := piiRegistryExternal(t, upstream.URL)
+	handler := piiHandler(t, reg)
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(chatBody("ext-model", "contact "+piiTestEmail+" please")))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	// Assert 1a: upstream did NOT receive the original email.
+	if strings.Contains(string(upstreamBody), piiTestEmail) {
+		t.Errorf("SECURITY: upstream received original PII email %q; expected pseudonym", piiTestEmail)
+	}
+
+	// Assert 1b: upstream received a PII_EM_ pseudonym.
+	if !piiPseudonymPattern.MatchString(string(upstreamBody)) {
+		t.Errorf("upstream body does not contain PII pseudonym; body: %s", upstreamBody)
+	}
+
+	// Assert 1c: the client response contains the restored original email.
+	clientBody, _ := io.ReadAll(resp.Body)
+	content := extractContentFromResponse(t, clientBody)
+	if !strings.Contains(content, piiTestEmail) {
+		t.Errorf("client response missing restored email %q; content: %q", piiTestEmail, content)
+	}
+	// And the raw pseudonym must not be visible to the client.
+	if piiPseudonymPattern.MatchString(content) {
+		t.Errorf("client response still contains raw pseudonym; content: %q", content)
+	}
+}
+
+// ── Test 2: Internal provider — body NOT anonymised ───────────────────────────
+
+// TestPII_InternalProvider_BodyNotAnonymised verifies that when a request targets
+// a vllm (internal) provider, the original email passes through unmodified.
+func TestPII_InternalProvider_BodyNotAnonymised(t *testing.T) {
+	t.Parallel()
+
+	upstream, lastBody, _ := captureUpstream(t,
+		http.StatusOK,
+		`{"id":"cmp-2","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"ok"}}]}`,
+		map[string]string{"Content-Type": "application/json"},
+	)
+
+	reg := piiRegistryInternal(t, upstream.URL)
+	handler := piiHandler(t, reg)
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(chatBody("int-model", "contact "+piiTestEmail+" please")))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	// Assert: internal upstream received the original email (full fidelity).
+	if !strings.Contains(string(*lastBody), piiTestEmail) {
+		t.Errorf("internal upstream did not receive original email %q; body: %s", piiTestEmail, *lastBody)
+	}
+
+	// Assert: no pseudonym was introduced.
+	if piiPseudonymPattern.MatchString(string(*lastBody)) {
+		t.Errorf("internal upstream received a pseudonym; expected original content; body: %s", *lastBody)
+	}
+}
+
+// ── Test 3: CRITICAL — Fallback internal→external, PII must be anonymised ────
+
+// TestPII_FallbackInternalToExternal_PseudonymSentToExternal is the key
+// regression test for the fix. Before the fix, the original body (built for the
+// internal primary) was forwarded verbatim to the external fallback, leaking PII.
+//
+// Setup: primary "prim" → provider vllm (Mock A, returns 500), fallback "fb" →
+// provider openai (Mock B, returns 200). The request contains a test email.
+//
+// Expected: Mock A receives the original email (internal). Mock B receives the
+// pseudonym, NOT the original email.
+func TestPII_FallbackInternalToExternal_PseudonymSentToExternal(t *testing.T) {
+	t.Parallel()
+
+	// mockA: primary (vllm, internal) — always returns 500 to trigger fallback.
+	var mockABody []byte
+	var mockACalls int32
+	mockA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&mockACalls, 1)
+		b, _ := io.ReadAll(r.Body)
+		mockABody = b
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"error":{"message":"upstream A down"}}`)
+	}))
+	t.Cleanup(mockA.Close)
+
+	// mockB: fallback (openai, external) — records what it receives.
+	var mockBBody []byte
+	var mockBCalls int32
+	mockB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&mockBCalls, 1)
+		b, _ := io.ReadAll(r.Body)
+		mockBBody = b
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"cmp-fb","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"ok"}}]}`)
+	}))
+	t.Cleanup(mockB.Close)
+
+	// Registry: prim (vllm, destPrivate=true) → fallback fb (openai, destPrivate=false).
+	// Test servers listen on 127.0.0.1; classifyDestPrivate would classify both
+	// as private (loopback). We construct the Registry directly:
+	//   - prim: destPrivate=true, PIIFilter=nil → shouldAnonymize returns false (pass through)
+	//   - fb:   destPrivate=false, PIIFilter=nil → shouldAnonymize returns true (anonymize)
+	// This exercises the internal-primary / external-fallback code path.
+	primModel := &Model{
+		Name:              "prim",
+		Provider:          "vllm",
+		Type:              "chat",
+		BaseURL:           mockA.URL,
+		APIKey:            "key-a",
+		destPrivate:       true,
+		FallbackModelName: "fb",
+	}
+	fbModel := &Model{
+		Name:        "fb",
+		Provider:    "openai",
+		Type:        "chat",
+		BaseURL:     mockB.URL,
+		APIKey:      "key-b",
+		destPrivate: false, // public destination: PII must be anonymized
+	}
+	reg := &Registry{
+		models:  map[string]*Model{"prim": primModel, "fb": fbModel},
+		aliases: make(map[string]string),
+	}
+	reg.rebuildSorted()
+
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.PIIEngine = newTestPIIEngine(t)
+	handler.FallbackMaxDepth = 1
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(chatBody("prim", "my email is "+piiTestEmail)))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200 (fallback succeeded); body: %s", resp.StatusCode, body)
+	}
+
+	// Assert: mock A (internal primary) was called.
+	if atomic.LoadInt32(&mockACalls) == 0 {
+		t.Error("mockA (primary vllm) was never called")
+	}
+
+	// Assert: mock B (external fallback) was called.
+	if atomic.LoadInt32(&mockBCalls) == 0 {
+		t.Error("mockB (fallback openai) was never called")
+	}
+
+	// Assert: internal primary received the original email (full fidelity).
+	if !strings.Contains(string(mockABody), piiTestEmail) {
+		t.Errorf("internal primary did not receive original email %q; body: %s", piiTestEmail, mockABody)
+	}
+
+	// CRITICAL: external fallback must NOT receive the original email.
+	if strings.Contains(string(mockBBody), piiTestEmail) {
+		t.Errorf("SECURITY REGRESSION: external fallback (openai) received original PII email %q; expected pseudonym only", piiTestEmail)
+	}
+
+	// CRITICAL: external fallback must receive a pseudonym.
+	if !piiPseudonymPattern.MatchString(string(mockBBody)) {
+		t.Errorf("external fallback body does not contain PII pseudonym; body: %s", mockBBody)
+	}
+}
+
+// ── Test 4: CRITICAL — Multi-deployment mixed providers ──────────────────────
+
+// TestPII_MultiDeployment_ExternalDeploymentReceivesPseudonym tests the scenario
+// where a model has two deployments: deployment 1 (vllm, internal) returns a
+// retryable error, and deployment 2 (openai, external) receives the request.
+// The external deployment must receive the pseudonym, not the original PII.
+//
+// This test uses the Router path (Deployments field on the model).
+// Since the current handler.go only enters multi-deployment logic when
+// p.Router != nil && len(model.Deployments) > 0, and the test does not wire a
+// Router, the deployment-retry path is exercised via the model-level fallback
+// mechanism using two separate models instead.
+//
+// NOTE: True multi-Deployment retry with a Router requires the router package
+// (which imports proxy and would create an import cycle). We therefore test the
+// semantically equivalent configuration: two models in a fallback chain where
+// model-a has provider vllm and model-b has provider openai.  The body-selection
+// logic (pickBody) is per-hop and exercises the same code path regardless of
+// whether the hop is driven by Deployment retry or by model fallback.
+func TestPII_MultiDeployment_ExternalDeploymentReceivesPseudonym(t *testing.T) {
+	t.Parallel()
+
+	// Deployment-style setup via two-model fallback (semantically equivalent
+	// to a two-deployment model for the purposes of PII body selection):
+	// dep1 (vllm) fails → dep2 (openai) must receive pseudonym.
+
+	var dep1Body []byte
+	dep1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		dep1Body = b
+		// Return a retryable 5xx so the fallback triggers.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		fmt.Fprint(w, `{"error":{"message":"dep1 unavailable"}}`)
+	}))
+	t.Cleanup(dep1.Close)
+
+	var dep2Body []byte
+	dep2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		dep2Body = b
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"cmp-dep2","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"ok"}}]}`)
+	}))
+	t.Cleanup(dep2.Close)
+
+	// Construct registry directly to set destPrivate on each model.
+	// Test servers use 127.0.0.1 (loopback); classifyDestPrivate would set
+	// destPrivate=true for both. We override:
+	//   - dep1-model: destPrivate=true → shouldAnonymize=false (pass through)
+	//   - dep2-model: destPrivate=false → shouldAnonymize=true (anonymize)
+	dep1Model := &Model{
+		Name:              "dep1-model",
+		Provider:          "vllm",
+		Type:              "chat",
+		BaseURL:           dep1.URL,
+		APIKey:            "key-dep1",
+		destPrivate:       true,
+		FallbackModelName: "dep2-model",
+	}
+	dep2Model := &Model{
+		Name:        "dep2-model",
+		Provider:    "openai",
+		Type:        "chat",
+		BaseURL:     dep2.URL,
+		APIKey:      "key-dep2",
+		destPrivate: false, // public: PII must be anonymized
+	}
+	reg := &Registry{
+		models:  map[string]*Model{"dep1-model": dep1Model, "dep2-model": dep2Model},
+		aliases: make(map[string]string),
+	}
+	reg.rebuildSorted()
+
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.PIIEngine = newTestPIIEngine(t)
+	handler.FallbackMaxDepth = 1
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(chatBody("dep1-model", "send to "+piiTestEmail)))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	// dep1 (internal vllm) received original content.
+	if !strings.Contains(string(dep1Body), piiTestEmail) {
+		t.Errorf("internal dep1 did not receive original email %q; body: %s", piiTestEmail, dep1Body)
+	}
+
+	// CRITICAL: dep2 (external openai) must NOT receive original PII.
+	if strings.Contains(string(dep2Body), piiTestEmail) {
+		t.Errorf("SECURITY REGRESSION: external dep2 received original PII email %q; expected pseudonym", piiTestEmail)
+	}
+	if !piiPseudonymPattern.MatchString(string(dep2Body)) {
+		t.Errorf("external dep2 body has no pseudonym; body: %s", dep2Body)
+	}
+}
+
+// ── Test 5: Restore on non-2xx ───────────────────────────────────────────────
+
+// TestPII_RestoreOnNon2xx verifies that when an external provider responds with
+// a 4xx status that echoes a pseudonym in the error body, the client sees the
+// restored original value, not the raw pseudonym.
+func TestPII_RestoreOnNon2xx(t *testing.T) {
+	t.Parallel()
+
+	// We need to know what pseudonym will be generated for piiTestEmail so we
+	// can echo it in the upstream error response. Pre-compute it via a throw-away
+	// filter with the same engine parameters.
+	engine := newTestPIIEngine(t)
+	sampleFilter := engine.NewFilter("org-test")
+	sampleBody := []byte(chatBody("ext-model", "email: "+piiTestEmail))
+	anonBody, err := sampleFilter.AnonymizeJSON(sampleBody)
+	if err != nil {
+		t.Fatalf("pre-compute AnonymizeJSON: %v", err)
+	}
+	pseudo := piiPseudonymPattern.FindString(string(anonBody))
+	if pseudo == "" {
+		t.Fatal("could not derive pseudonym for piiTestEmail via sample filter")
+	}
+
+	// Mock upstream returns 400 with the pseudonym in the error message.
+	upstream, _, _ := captureUpstream(t,
+		http.StatusBadRequest,
+		fmt.Sprintf(`{"error":{"message":"invalid value %s in request"}}`, pseudo),
+		map[string]string{"Content-Type": "application/json"},
+	)
+
+	reg := piiRegistryExternal(t, upstream.URL)
+
+	// Use a real engine — but we need the same engine/filter that was used to
+	// pre-compute the pseudonym. Because the engine is request-stateless (the
+	// filter is created per-request inside Handle), we must ensure both use the
+	// same secret and orgID. The handler uses PIIEngine.NewFilter("") because
+	// no auth.KeyInfo is set in this test (no middleware). We pre-computed with
+	// org "org-test" which differs from "" — so we must re-derive with orgID "".
+	engine2 := newTestPIIEngine(t)
+	sampleFilter2 := engine2.NewFilter("")
+	anonBody2, err := sampleFilter2.AnonymizeJSON(sampleBody)
+	if err != nil {
+		t.Fatalf("pre-compute AnonymizeJSON (orgID empty): %v", err)
+	}
+	pseudo2 := piiPseudonymPattern.FindString(string(anonBody2))
+	if pseudo2 == "" {
+		t.Fatal("could not derive pseudonym for orgID=empty")
+	}
+
+	// Rebuild the mock to echo pseudo2 (orgID="" matches handler's orgID when
+	// keyInfo is nil).
+	upstream2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(w, `{"error":{"message":"invalid value %s in request"}}`, pseudo2)
+	}))
+	t.Cleanup(upstream2.Close)
+
+	reg2 := piiRegistryExternal(t, upstream2.URL)
+	handler := NewProxyHandler(reg2, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.PIIEngine = engine2
+	app := testApp(t, handler)
+	_ = reg // suppress unused variable
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(chatBody("ext-model", "email: "+piiTestEmail)))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+
+	clientBody, _ := io.ReadAll(resp.Body)
+
+	// Assert: the raw pseudonym must NOT appear in the client response.
+	if strings.Contains(string(clientBody), pseudo2) {
+		t.Errorf("client response contains raw pseudonym %q; expected restored original", pseudo2)
+	}
+
+	// Assert: the original email must appear in the client response (restored).
+	if !strings.Contains(string(clientBody), piiTestEmail) {
+		t.Errorf("client response missing restored email %q; body: %s", piiTestEmail, clientBody)
+	}
+}
+
+// ── Test 6: Fail-closed on AnonymizeJSON error ────────────────────────────────
+
+// TestPII_FailClosedOnAnonymizationError verifies that when the request body
+// is valid enough to pass the envelope parse (has a "model" field) but
+// AnonymizeJSON fails (invalid JSON outer structure — which cannot happen on the
+// normal path since envelope parsing passes first), the handler rejects the
+// request.
+//
+// Directly triggering AnonymizeJSON failure through the handler is difficult
+// because readAndValidateBody requires valid JSON with a "model" field, and any
+// body that satisfies that also satisfies anonymizeWithDetectors. The PII
+// mapping-cap failure is the only runtime-reachable path within normal operation.
+//
+// LIMITATION: triggering the fail-closed path at the handler level requires
+// synthetic injection of an AnonymizeJSON error, which would need an injectable
+// AnonymizeJSON interface not present in the current design. We therefore test
+// the fail-closed guarantee at the pii.Filter level (AnonymizeJSON returns an
+// error on invalid JSON) and verify that the handler returns 422 when the
+// mapping cap is exceeded via a body that triggers enough unique PII spans.
+//
+// The mapping-cap path is tested at pii package level in pii_test.go
+// (TestFilter_MappingCapExceeded). At the handler level we verify the 422
+// response code for a body where AnonymizeJSON would fail — but since we cannot
+// inject the failure without mocking the engine, we verify the 422 code is
+// returned for an unparseable body that sneaks past the envelope check: such a
+// body does not exist in the current implementation (the envelope parse is also
+// JSON-based and fails first).
+//
+// We therefore document the gap and cover the reachable subset: the handler
+// must return 400 (bad_request) — NOT forward to upstream — when the body is
+// not valid JSON.
+func TestPII_FailClosedOnAnonymizationError_BodyParseFails(t *testing.T) {
+	t.Parallel()
+
+	upstream, _, calls := captureUpstream(t,
+		http.StatusOK,
+		`{}`,
+		map[string]string{"Content-Type": "application/json"},
+	)
+
+	reg := piiRegistryExternal(t, upstream.URL)
+	handler := piiHandler(t, reg)
+	app := testApp(t, handler)
+
+	// An invalid JSON body that also lacks a model field — this is the only
+	// body that readAndValidateBody rejects before AnonymizeJSON can run.
+	// The assertion is: upstream receives NOTHING (calls == 0) and the client
+	// receives an error response.
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`not valid json`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		t.Errorf("status = 200, want non-200 for invalid request body")
+	}
+
+	// The upstream must never have been called.
+	if atomic.LoadInt32(calls) > 0 {
+		t.Errorf("upstream was called %d times; should not have been called for an invalid body", atomic.LoadInt32(calls))
+	}
+}
+
+// TestPII_FailClosed_422_Documented documents the fail-closed 422 path and
+// notes the limitation: the handler returns 422 only when AnonymizeJSON succeeds
+// at JSON parsing but fails internally (e.g. mapping cap). This path cannot be
+// triggered from the handler level in the current design without a mock engine,
+// because the mapping cap requires 10,000 unique PII values in a single request
+// which exceeds the default 20 MB body limit with the current body format.
+//
+// The unit-level coverage for this path lives in TestFilter_MappingCapExceeded
+// in internal/pii/pii_test.go.
+//
+// This test is a documented placeholder confirming the gap and is intentionally
+// not a failing test.
+func TestPII_FailClosed_422_LimitationDocumented(t *testing.T) {
+	t.Parallel()
+	// No assertions. This test exists as documentation that the handler-level
+	// 422 fail-closed path for mapping-cap errors is covered at the pii package
+	// level (TestFilter_MappingCapExceeded) and cannot be triggered via the
+	// handler without mock injection.
+	t.Log("COVERAGE GAP: handler 422 for pii.mapping-cap is covered at pii package level only")
+}
+
+// ── Test 7: Engine nil → no-op ────────────────────────────────────────────────
+
+// TestPII_EngineNil_NoOp verifies that when PIIEngine is nil, the original
+// request body passes through unmodified and the upstream receives it intact.
+// This is the regression test ensuring the PII feature has zero overhead when
+// disabled.
+func TestPII_EngineNil_NoOp(t *testing.T) {
+	t.Parallel()
+
+	upstream, lastBody, _ := captureUpstream(t,
+		http.StatusOK,
+		`{"id":"cmp-noop","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"fine"}}]}`,
+		map[string]string{"Content-Type": "application/json"},
+	)
+
+	// External provider, but PIIEngine is nil — no anonymization should happen.
+	reg := piiRegistryExternal(t, upstream.URL)
+	handler := piiHandlerNoEngine(t, reg)
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(chatBody("ext-model", "my email is "+piiTestEmail)))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	// Assert: upstream received the original email (no anonymization).
+	if !strings.Contains(string(*lastBody), piiTestEmail) {
+		t.Errorf("upstream missing original email %q (engine nil should be no-op); body: %s", piiTestEmail, *lastBody)
+	}
+
+	// Assert: no pseudonym was introduced.
+	if piiPseudonymPattern.MatchString(string(*lastBody)) {
+		t.Errorf("upstream body contains pseudonym but PIIEngine is nil; body: %s", *lastBody)
+	}
+}
+
+// ── Test 8: Streaming with PII restore ───────────────────────────────────────
+
+// TestPII_Streaming_PseudonymRestoredInSSEResponse verifies the Stage-0a
+// streaming strategy: when an external provider returns a streaming SSE response
+// containing pseudonyms in the content, the client-side SSE body contains the
+// restored original email after the buffered-restore pass.
+//
+// The handler buffers the entire SSE stream when filter.Touched() is true and
+// applies Restore once over the joined buffer. This test verifies the result —
+// not the incremental delivery — which is the correct behaviour to test for
+// Stage-0a.
+func TestPII_Streaming_PseudonymRestoredInSSEResponse(t *testing.T) {
+	t.Parallel()
+
+	// Pre-compute the pseudonym that the engine will produce for piiTestEmail
+	// with orgID="" (no auth.KeyInfo in this test).
+	engine := newTestPIIEngine(t)
+	sampleFilter := engine.NewFilter("")
+	sampleBody := []byte(chatBody("ext-model", "email: "+piiTestEmail))
+	anonBody, err := sampleFilter.AnonymizeJSON(sampleBody)
+	if err != nil {
+		t.Fatalf("pre-compute AnonymizeJSON: %v", err)
+	}
+	pseudo := piiPseudonymPattern.FindString(string(anonBody))
+	if pseudo == "" {
+		t.Fatal("could not derive pseudonym for streaming test")
+	}
+
+	// Mock upstream returns an SSE stream where the pseudonym appears in the
+	// content delta. This simulates the LLM echoing back the pseudonymised value.
+	//
+	// The pseudonym is emitted in a single SSE chunk. The split-pseudonym case
+	// (pseudonym divided across two events by the LLM tokenizer) is covered by
+	// TestRestoreSSEStream_SplitPseudonym and
+	// TestRestoreSSEStream_SplitPseudonymRawJoinFails in internal/pii/stream_test.go,
+	// which test pii.RestoreSSEStream directly and demonstrate both the bug in the
+	// old raw-byte-join approach and the correctness of the content-aware fix.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("upstream: http.Flusher not available")
+			return
+		}
+		chunk1 := fmt.Sprintf(`data: {"id":"s1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":%q},"finish_reason":null}]}`, pseudo)
+		chunks := []string{chunk1, "data: [DONE]"}
+		for _, c := range chunks {
+			fmt.Fprintln(w, c)
+			fmt.Fprintln(w) // blank line = SSE event separator
+			flusher.Flush()
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	reg := piiRegistryExternal(t, upstream.URL)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.PIIEngine = engine // reuse the same engine for consistent pseudonyms
+
+	// Streaming requires a real TCP listener (app.Test does not reliably stream).
+	baseURL := startTestServer(t, handler)
+
+	httpReq, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions",
+		strings.NewReader(chatBody("ext-model", "email: "+piiTestEmail)+""))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	// Note: the actual request body sent to buildUpstreamRequest does NOT have
+	// "stream":true here — but the upstream always returns SSE content-type,
+	// so the handler treats it as streaming regardless.
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	// Add stream:true so the handler injects stream_options (and upstream is
+	// instructed to behave as a stream — which our mock does anyway).
+	streamBody := fmt.Sprintf(`{"model":"ext-model","messages":[{"role":"user","content":"email: %s"}],"stream":true}`, piiTestEmail)
+	httpReq, err = http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions",
+		strings.NewReader(streamBody))
+	if err != nil {
+		t.Fatalf("build streaming request: %v", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: testTimeout.Timeout}
+	streamResp, err := client.Do(httpReq)
+	if err != nil {
+		t.Fatalf("streaming request: %v", err)
+	}
+	defer streamResp.Body.Close()
+
+	if streamResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(streamResp.Body)
+		t.Fatalf("streaming status = %d, want 200; body: %s", streamResp.StatusCode, body)
+	}
+
+	ct := streamResp.Header.Get("Content-Type")
+	if !strings.Contains(ct, "text/event-stream") {
+		t.Errorf("Content-Type = %q, want text/event-stream", ct)
+	}
+
+	fullBody, _ := io.ReadAll(streamResp.Body)
+	bodyStr := string(fullBody)
+
+	// Assert: the client SSE body contains the restored original email.
+	if !strings.Contains(bodyStr, piiTestEmail) {
+		t.Errorf("streaming response missing restored email %q; body snippet: %q", piiTestEmail, bodyStr[:min(len(bodyStr), 512)])
+	}
+
+	// Assert: the client SSE body does NOT contain the raw pseudonym.
+	if strings.Contains(bodyStr, pseudo) {
+		t.Errorf("streaming response still contains raw pseudonym %q; body snippet: %q", pseudo, bodyStr[:min(len(bodyStr), 512)])
+	}
+}
+
+// ── Test 9: VULN-001 — per-deployment body selection inside tryModel ─────────
+
+// TestPII_VULN001_MultiDeploymentPerDeploymentBodySelection directly exercises
+// the tryModel deployment loop with a mixed-provider model: deployment 1 is
+// vllm (internal, returns 5xx) and deployment 2 is openai (external, returns
+// 200). This test confirms that body selection happens per-deployment inside
+// tryModel — not once at the call site — so the external deployment always
+// receives the anonymized body regardless of the model-level provider field.
+//
+// A stub DeploymentPicker is wired as p.Router so the multi-deployment path
+// inside tryModel is exercised (p.Router != nil && len(model.Deployments) > 0).
+// No import cycle arises because DeploymentPicker is defined in this package.
+func TestPII_VULN001_MultiDeploymentPerDeploymentBodySelection(t *testing.T) {
+	t.Parallel()
+
+	// mockInternal: vllm deployment — returns 500 to force retry to next dep.
+	var internalBody []byte
+	var internalCalls int32
+	mockInternal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&internalCalls, 1)
+		b, _ := io.ReadAll(r.Body)
+		internalBody = b
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(w, `{"error":{"message":"internal dep unavailable"}}`)
+	}))
+	t.Cleanup(mockInternal.Close)
+
+	// mockExternal: openai deployment — records what it receives.
+	var externalBody []byte
+	var externalCalls int32
+	mockExternal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&externalCalls, 1)
+		b, _ := io.ReadAll(r.Body)
+		externalBody = b
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"cmp-vuln001","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"ok"}}]}`)
+	}))
+	t.Cleanup(mockExternal.Close)
+
+	// Build the model with two deployments: dep1 (vllm, destPrivate=true)
+	// and dep2 (openai, destPrivate=false). The model-level provider is "vllm"
+	// but PII body selection uses the per-deployment destPrivate flag via
+	// shouldAnonymize, not the model-level provider. If body selection used the
+	// model-level provider, dep2 (external openai) would incorrectly receive the
+	// original (non-anonymized) body because the model declares "vllm" at the top
+	// level.
+	//
+	// No PIIFilter is set on either deployment or the model, so shouldAnonymize
+	// falls through to the network-based default: !dep.destPrivate.
+	dep1 := Deployment{
+		Name:        "dep-internal",
+		Provider:    "vllm",
+		BaseURL:     mockInternal.URL,
+		APIKey:      "key-internal",
+		Weight:      1,
+		destPrivate: true, // private destination: original body passes through
+	}
+	dep2 := Deployment{
+		Name:        "dep-external",
+		Provider:    "openai",
+		BaseURL:     mockExternal.URL,
+		APIKey:      "key-external",
+		Weight:      1,
+		destPrivate: false, // public destination: must receive anonymized body
+	}
+
+	model := Model{
+		Name:        "mixed-model",
+		Provider:    "vllm", // model-level provider is internal
+		BaseURL:     mockInternal.URL,
+		APIKey:      "key-internal",
+		Deployments: []Deployment{dep1, dep2},
+	}
+
+	reg := &Registry{
+		models:  map[string]*Model{"mixed-model": &model},
+		aliases: make(map[string]string),
+	}
+
+	// staticPicker always returns the two deployments in fixed order: internal
+	// first, external second. This drives the deployment retry loop in tryModel.
+	staticPicker := &staticDeploymentPicker{deps: []Deployment{dep1, dep2}}
+
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.PIIEngine = newTestPIIEngine(t)
+	handler.Router = staticPicker
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(chatBody("mixed-model", "email me at "+piiTestEmail)))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200 (external dep succeeded); body: %s", resp.StatusCode, body)
+	}
+
+	// Assert: internal deployment (vllm) was called.
+	if atomic.LoadInt32(&internalCalls) == 0 {
+		t.Error("internal vllm deployment was never called")
+	}
+
+	// Assert: external deployment (openai) was called after the internal 5xx.
+	if atomic.LoadInt32(&externalCalls) == 0 {
+		t.Error("external openai deployment was never called")
+	}
+
+	// Assert: internal deployment received the original email (internal = trusted).
+	if !strings.Contains(string(internalBody), piiTestEmail) {
+		t.Errorf("internal dep did not receive original email %q; body: %s", piiTestEmail, internalBody)
+	}
+
+	// CRITICAL: external deployment must NOT receive the original email (VULN-001).
+	if strings.Contains(string(externalBody), piiTestEmail) {
+		t.Errorf("SECURITY REGRESSION (VULN-001): external dep received original PII email %q; expected pseudonym", piiTestEmail)
+	}
+
+	// CRITICAL: external deployment must receive the pseudonym.
+	if !piiPseudonymPattern.MatchString(string(externalBody)) {
+		t.Errorf("external dep body has no pseudonym; body: %s", externalBody)
+	}
+}
+
+// staticDeploymentPicker is a test-only DeploymentPicker that returns a fixed
+// ordered slice of deployments regardless of the model argument.
+type staticDeploymentPicker struct {
+	deps []Deployment
+}
+
+// Pick implements DeploymentPicker for staticDeploymentPicker.
+func (s *staticDeploymentPicker) Pick(_ Model) []Deployment {
+	return s.deps
+}
+
+// ── Table-driven: provider IsExternal classification ─────────────────────────
+
+// TestPII_PickBody_ByDestPrivate verifies the body-selection logic through the
+// full handler path based on the deployment's destPrivate flag (network-based
+// default, no explicit PIIFilter set).
+//
+// The PII decision follows shouldAnonymize: with PIIFilter=nil on both
+// deployment and model, the result is !dep.destPrivate. This test explicitly
+// sets destPrivate on each model because test servers always listen on
+// 127.0.0.1 (loopback), which classifyDestPrivate would classify as private
+// (destPrivate=true, no anonymization). We bypass NewRegistry and construct
+// Models directly to exercise both code paths.
+func TestPII_PickBody_ByDestPrivate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		provider     string
+		destPrivate  bool
+		wantOriginal bool // true = upstream must receive original; false = must receive pseudonym
+	}{
+		{"external: public destination (openai)", "openai", false, false},
+		{"external: public destination (anthropic)", "anthropic", false, false},
+		{"external: public destination (azure)", "azure", false, false},
+		{"external: public destination (custom)", "custom", false, false},
+		{"internal: private destination (vllm loopback)", "vllm", true, true},
+		{"internal: private destination (ollama loopback)", "ollama", true, true},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			upstream, lastBody, _ := captureUpstream(t,
+				http.StatusOK,
+				`{"id":"cmp-x","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"ok"}}]}`,
+				map[string]string{"Content-Type": "application/json"},
+			)
+
+			// Construct model directly to set destPrivate explicitly.
+			// No PIIFilter is set, so shouldAnonymize returns !destPrivate.
+			// Azure requires AzureDeployment and AzureAPIVersion.
+			m := &Model{
+				Name:        "model-x",
+				Provider:    tc.provider,
+				Type:        "chat",
+				BaseURL:     upstream.URL,
+				APIKey:      "key-x",
+				destPrivate: tc.destPrivate,
+			}
+			if tc.provider == "azure" {
+				m.AzureDeployment = "gpt-4o"
+				m.AzureAPIVersion = "2024-02-01"
+			}
+			reg := &Registry{
+				models:  map[string]*Model{"model-x": m},
+				aliases: make(map[string]string),
+			}
+			reg.rebuildSorted()
+
+			handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			handler.PIIEngine = newTestPIIEngine(t)
+			app := testApp(t, handler)
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+				strings.NewReader(chatBody("model-x", "contact "+piiTestEmail)))
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := app.Test(req, testTimeout)
+			if err != nil {
+				t.Fatalf("app.Test: %v", err)
+			}
+			defer resp.Body.Close()
+
+			body := string(*lastBody)
+
+			if tc.wantOriginal {
+				if !strings.Contains(body, piiTestEmail) {
+					t.Errorf("[%s] upstream missing original email %q; body: %s", tc.provider, piiTestEmail, body)
+				}
+				if piiPseudonymPattern.MatchString(body) {
+					t.Errorf("[%s] upstream body has pseudonym but destPrivate=true; body: %s", tc.provider, body)
+				}
+			} else {
+				if strings.Contains(body, piiTestEmail) {
+					t.Errorf("SECURITY [%s]: upstream received original PII email %q; expected pseudonym", tc.provider, piiTestEmail)
+				}
+				if !piiPseudonymPattern.MatchString(body) {
+					t.Errorf("[%s] upstream body missing pseudonym; body: %s", tc.provider, body)
+				}
+			}
+		})
+	}
+}

--- a/internal/proxy/pii_new_test.go
+++ b/internal/proxy/pii_new_test.go
@@ -1,0 +1,708 @@
+package proxy
+
+// pii_new_test.go covers the additional proxy-level PII cases required by the
+// feat/pii-anonymization-stage0a test task:
+//
+//  7. per-model pii_filter flag priority (5 sub-cases)
+//  8. stream-cap / scanner.Err fail-closed behavior (via handler path)
+//  9. classifyDestPrivate coverage
+// 10. FIX 4: raw model name must not appear in OTel spans
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// ── helpers (ptr for *bool) ───────────────────────────────────────────────────
+
+func boolPtr(b bool) *bool { return &b }
+
+// buildModelWithPIIFilter constructs a single-model Registry where destPrivate
+// and PIIFilter are set as requested, pointing at upstreamURL.
+func buildModelWithPIIFilter(t *testing.T, upstreamURL string, destPrivate bool, piiFilter *bool) *Registry {
+	t.Helper()
+	m := &Model{
+		Name:        "model-x",
+		Provider:    "openai",
+		Type:        "chat",
+		BaseURL:     upstreamURL,
+		APIKey:      "key-x",
+		destPrivate: destPrivate,
+		PIIFilter:   piiFilter,
+	}
+	r := &Registry{
+		models:  map[string]*Model{"model-x": m},
+		aliases: make(map[string]string),
+	}
+	r.rebuildSorted()
+	return r
+}
+
+// buildModelWithDeploymentPIIFilter builds a Registry where the PIIFilter is
+// set on the Deployment (not the model), using a staticDeploymentPicker to
+// exercise the per-deployment code path.
+func buildModelWithDeploymentPIIFilter(t *testing.T, upstreamURL string, destPrivate bool, depFilter *bool) (*Registry, *staticDeploymentPicker) {
+	t.Helper()
+	dep := Deployment{
+		Name:        "dep-x",
+		Provider:    "openai",
+		BaseURL:     upstreamURL,
+		APIKey:      "key-dep",
+		Weight:      1,
+		destPrivate: destPrivate,
+		PIIFilter:   depFilter,
+	}
+	m := &Model{
+		Name:        "model-x",
+		Provider:    "openai",
+		Type:        "chat",
+		BaseURL:     upstreamURL,
+		APIKey:      "key-x",
+		destPrivate: destPrivate,
+		Deployments: []Deployment{dep},
+		// model-level PIIFilter intentionally nil
+	}
+	r := &Registry{
+		models:  map[string]*Model{"model-x": m},
+		aliases: make(map[string]string),
+	}
+	r.rebuildSorted()
+	picker := &staticDeploymentPicker{deps: []Deployment{dep}}
+	return r, picker
+}
+
+// captureOK starts an httptest.Server that records the body and responds 200 OK
+// with a minimal OpenAI non-streaming response.
+func captureOK(t *testing.T) (*httptest.Server, *[]byte) {
+	t.Helper()
+	var last []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		last = b
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"cmp","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"ok"}}]}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &last
+}
+
+// ── 7. per-model pii_filter flag priority ─────────────────────────────────────
+
+// TestPIIFilter_Priority_7a: destPrivate=true, PIIFilter=ptr(true) → anonymized.
+// An explicit pii_filter:true overrides the private-network default.
+func TestPIIFilter_Priority_7a_PrivateDestExplicitTrue(t *testing.T) {
+	t.Parallel()
+
+	upstream, lastBody := captureOK(t)
+	// destPrivate=true (would normally skip PII), PIIFilter=ptr(true) → must anonymize
+	reg := buildModelWithPIIFilter(t, upstream.URL, true, boolPtr(true))
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.PIIEngine = newTestPIIEngine(t)
+	app := testApp(t, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(chatBody("model-x", "contact "+piiTestEmail)))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, b)
+	}
+
+	body := string(*lastBody)
+	// With explicit pii_filter:true the body MUST be anonymized even though
+	// destPrivate is true.
+	if strings.Contains(body, piiTestEmail) {
+		t.Errorf("7a: upstream received original PII despite pii_filter:true on private dest; body: %s", body)
+	}
+	if !piiPseudonymPattern.MatchString(body) {
+		t.Errorf("7a: upstream body missing pseudonym; body: %s", body)
+	}
+}
+
+// TestPIIFilter_Priority_7b: destPrivate=false, PIIFilter=ptr(false) → NOT anonymized.
+// An explicit pii_filter:false suppresses anonymization even on a public destination.
+func TestPIIFilter_Priority_7b_PublicDestExplicitFalse(t *testing.T) {
+	t.Parallel()
+
+	upstream, lastBody := captureOK(t)
+	// destPrivate=false (would normally anonymize), PIIFilter=ptr(false) → must NOT anonymize
+	reg := buildModelWithPIIFilter(t, upstream.URL, false, boolPtr(false))
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.PIIEngine = newTestPIIEngine(t)
+	app := testApp(t, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(chatBody("model-x", "contact "+piiTestEmail)))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, b)
+	}
+
+	body := string(*lastBody)
+	// With explicit pii_filter:false, original email passes through.
+	if !strings.Contains(body, piiTestEmail) {
+		t.Errorf("7b: upstream missing original email; pii_filter:false should suppress anonymization; body: %s", body)
+	}
+	if piiPseudonymPattern.MatchString(body) {
+		t.Errorf("7b: upstream body contains pseudonym but pii_filter:false was set; body: %s", body)
+	}
+}
+
+// TestPIIFilter_Priority_7c: PIIFilter=nil, destPrivate=false → anonymized (default for public).
+func TestPIIFilter_Priority_7c_NilFlagPublicDest(t *testing.T) {
+	t.Parallel()
+
+	upstream, lastBody := captureOK(t)
+	// PIIFilter=nil, destPrivate=false → default: anonymize (public destination)
+	reg := buildModelWithPIIFilter(t, upstream.URL, false, nil)
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.PIIEngine = newTestPIIEngine(t)
+	app := testApp(t, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(chatBody("model-x", "contact "+piiTestEmail)))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, b)
+	}
+
+	body := string(*lastBody)
+	if strings.Contains(body, piiTestEmail) {
+		t.Errorf("7c: upstream received original PII; default for public dest must anonymize; body: %s", body)
+	}
+	if !piiPseudonymPattern.MatchString(body) {
+		t.Errorf("7c: upstream body missing pseudonym; body: %s", body)
+	}
+}
+
+// TestPIIFilter_Priority_7d: PIIFilter=nil, destPrivate=true → NOT anonymized (default for private).
+func TestPIIFilter_Priority_7d_NilFlagPrivateDest(t *testing.T) {
+	t.Parallel()
+
+	upstream, lastBody := captureOK(t)
+	// PIIFilter=nil, destPrivate=true → default: do NOT anonymize (private destination)
+	reg := buildModelWithPIIFilter(t, upstream.URL, true, nil)
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.PIIEngine = newTestPIIEngine(t)
+	app := testApp(t, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(chatBody("model-x", "contact "+piiTestEmail)))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, b)
+	}
+
+	body := string(*lastBody)
+	if !strings.Contains(body, piiTestEmail) {
+		t.Errorf("7d: original email missing; default for private dest must NOT anonymize; body: %s", body)
+	}
+	if piiPseudonymPattern.MatchString(body) {
+		t.Errorf("7d: upstream received pseudonym on private dest without explicit flag; body: %s", body)
+	}
+}
+
+// TestPIIFilter_Priority_7e: deployment-level PIIFilter overrides model-level nil.
+// Model.PIIFilter=nil, dep.PIIFilter=ptr(true), destPrivate=true → anonymized.
+func TestPIIFilter_Priority_7e_DeploymentFlagOverridesModel(t *testing.T) {
+	t.Parallel()
+
+	upstream, lastBody := captureOK(t)
+	// dep.PIIFilter=ptr(true), destPrivate=true (model.PIIFilter=nil)
+	// → dep flag takes precedence → anonymize despite private dest
+	reg, picker := buildModelWithDeploymentPIIFilter(t, upstream.URL, true, boolPtr(true))
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.PIIEngine = newTestPIIEngine(t)
+	h.Router = picker
+	app := testApp(t, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(chatBody("model-x", "contact "+piiTestEmail)))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, b)
+	}
+
+	body := string(*lastBody)
+	if strings.Contains(body, piiTestEmail) {
+		t.Errorf("7e: original PII reached upstream despite dep.PIIFilter=true; body: %s", body)
+	}
+	if !piiPseudonymPattern.MatchString(body) {
+		t.Errorf("7e: upstream body missing pseudonym; body: %s", body)
+	}
+}
+
+// TestPIIFilter_Priority_Table is a table-driven summary that covers the full
+// priority matrix in compact form, complementing the individual sub-tests above.
+func TestPIIFilter_Priority_Table(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		destPrivate bool
+		piiFilter   *bool
+		wantAnon    bool // true = must receive pseudonym
+	}{
+		{"private+true", true, boolPtr(true), true},
+		{"private+false", true, boolPtr(false), false},
+		{"private+nil", true, nil, false},
+		{"public+true", false, boolPtr(true), true},
+		{"public+false", false, boolPtr(false), false},
+		{"public+nil", false, nil, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			upstream, lastBody := captureOK(t)
+			reg := buildModelWithPIIFilter(t, upstream.URL, tc.destPrivate, tc.piiFilter)
+			h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+			h.PIIEngine = newTestPIIEngine(t)
+			app := testApp(t, h)
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+				strings.NewReader(chatBody("model-x", "hello "+piiTestEmail)))
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := app.Test(req, testTimeout)
+			if err != nil {
+				t.Fatalf("app.Test: %v", err)
+			}
+			defer resp.Body.Close()
+
+			body := string(*lastBody)
+			if tc.wantAnon {
+				if strings.Contains(body, piiTestEmail) {
+					t.Errorf("[%s] original PII present; expected pseudonym; body: %s", tc.name, body)
+				}
+				if !piiPseudonymPattern.MatchString(body) {
+					t.Errorf("[%s] pseudonym missing; body: %s", tc.name, body)
+				}
+			} else {
+				if !strings.Contains(body, piiTestEmail) {
+					t.Errorf("[%s] original email missing; expected pass-through; body: %s", tc.name, body)
+				}
+				if piiPseudonymPattern.MatchString(body) {
+					t.Errorf("[%s] unexpected pseudonym in body; body: %s", tc.name, body)
+				}
+			}
+		})
+	}
+}
+
+// ── 8. stream-cap / scanner.Err fail-closed ───────────────────────────────────
+
+// TestPIIFilter_StreamCap_FailClosed verifies that when the upstream SSE
+// response exceeds the aggregate stream byte cap (MaxResponseBody), the handler
+// aborts the stream without emitting any un-restored content to the client.
+//
+// Approach: set a very small MaxResponseBody on the handler so that even a
+// minimal SSE response triggers the cap. The upstream emits PII pseudonyms
+// in multiple SSE chunks that collectively exceed the cap.
+//
+// Expected behavior: the client receives an empty or minimal response, and
+// the pseudonym must not appear in the client body (fail-closed: no partial
+// un-restored content).
+func TestPIIFilter_StreamCap_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	// Pre-compute the pseudonym that will be generated for piiTestEmail.
+	engine := newTestPIIEngine(t)
+	sampleFilter := engine.NewFilter("")
+	sampleBody := []byte(chatBody("model-x", "email: "+piiTestEmail))
+	anonBody, err := sampleFilter.AnonymizeJSON(sampleBody)
+	if err != nil {
+		t.Fatalf("pre-compute AnonymizeJSON: %v", err)
+	}
+	pseudo := piiPseudonymPattern.FindString(string(anonBody))
+	if pseudo == "" {
+		t.Fatal("could not derive pseudonym")
+	}
+
+	// Mock upstream: emits a large SSE response where each chunk carries the
+	// pseudonym, so the total byte count will exceed the small cap we set.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			return
+		}
+		// Emit 20 chunks, each ~100 bytes, to exceed a 512-byte cap.
+		for i := 0; i < 20; i++ {
+			chunk := fmt.Sprintf(
+				`data: {"id":"sc%d","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":%q},"finish_reason":null}]}`,
+				i, pseudo)
+			fmt.Fprintln(w, chunk)
+			fmt.Fprintln(w) // blank line = SSE separator
+			flusher.Flush()
+		}
+		fmt.Fprintln(w, "data: [DONE]")
+		fmt.Fprintln(w)
+		flusher.Flush()
+	}))
+	t.Cleanup(upstream.Close)
+
+	reg := piiRegistryExternal(t, upstream.URL)
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.PIIEngine = engine
+	// Set a tiny response body limit (512 bytes) so the cap fires on the SSE path.
+	h.MaxResponseBody = 512
+
+	baseURL := startTestServer(t, h)
+
+	streamBody := fmt.Sprintf(`{"model":"ext-model","messages":[{"role":"user","content":"email: %s"}],"stream":true}`, piiTestEmail)
+	httpReq, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions",
+		strings.NewReader(streamBody))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: testTimeout.Timeout}
+	streamResp, err := client.Do(httpReq)
+	if err != nil {
+		t.Fatalf("streaming request: %v", err)
+	}
+	defer streamResp.Body.Close()
+
+	fullBody, _ := io.ReadAll(streamResp.Body)
+	bodyStr := string(fullBody)
+
+	// Fail-closed: the raw pseudonym must NOT appear in the client response.
+	// When the cap is exceeded, the handler writes nothing and flushes before
+	// returning, so the body should be empty or contain only SSE framing without
+	// pseudonym content.
+	if strings.Contains(bodyStr, pseudo) {
+		t.Errorf("stream-cap fail-closed VIOLATED: pseudonym %q visible in client response\nbody: %s",
+			pseudo, bodyStr)
+	}
+
+	// The original PII email must also not appear (it was never restored because
+	// the stream was aborted before RestoreSSEStream ran).
+	if strings.Contains(bodyStr, piiTestEmail) {
+		t.Errorf("original PII email %q visible in client response after stream-cap abort", piiTestEmail)
+	}
+}
+
+// TestPIIFilter_StreamCapNote documents the coverage gap for scanner.Err.
+// The scanner.Err path is triggered when the upstream connection is closed
+// mid-stream or when a single SSE line exceeds the scanner buffer (4MB).
+// These conditions are hard to trigger deterministically in tests because
+// httptest.Server and the Go HTTP client do not easily simulate transport-level
+// truncation on the streaming path.
+//
+// The fail-closed logic for scanner.Err is in handler.go's needsContentRestore
+// block (lines ~1119-1129): when scanErr != nil, the handler logs a warning and
+// returns without writing anything to the client.
+//
+// Coverage at the unit level lives in stream_test.go (the RestoreSSEStream
+// function itself is tested with well-formed and broken inputs). This test
+// is intentionally a non-asserting placeholder documenting the gap.
+func TestPIIFilter_ScannerErr_CoverageGapDocumented(t *testing.T) {
+	t.Parallel()
+	t.Log("COVERAGE GAP: scanner.Err fail-closed path (mid-stream transport truncation) " +
+		"cannot be triggered deterministically via httptest.Server. " +
+		"The logic is covered by code inspection + stream_test.go unit tests on RestoreSSEStream.")
+}
+
+// ── 9. classifyDestPrivate ────────────────────────────────────────────────────
+
+// TestClassifyDestPrivate covers the classification of various host types.
+// The function is unexported so we test it from package proxy.
+func TestClassifyDestPrivate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		rawURL string
+		want   bool // true = private
+	}{
+		// Loopback
+		{"loopback 127.0.0.1", "http://127.0.0.1:8080/v1", true},
+		{"loopback 127.0.0.2", "http://127.0.0.2/v1", true},
+		{"loopback ::1", "http://[::1]:11434/api", true},
+		// localhost literal
+		{"localhost literal", "http://localhost:8080", true},
+		{"localhost https", "https://localhost/v1", true},
+		// RFC 1918
+		{"10.x private", "http://10.0.0.1:8080/v1", true},
+		{"10.255.255.255 private", "http://10.255.255.255/v1", true},
+		{"192.168.x private", "http://192.168.1.1:8080/v1", true},
+		{"172.16.x private", "http://172.16.0.1/v1", true},
+		{"172.31.255.255 private", "http://172.31.255.255/v1", true},
+		// Link-local
+		{"169.254.x link-local", "http://169.254.1.1/v1", true},
+		{"fe80:: link-local", "http://[fe80::1]/v1", true},
+		// Public addresses
+		{"openai public", "https://api.openai.com/v1", false},
+		{"anthropic public", "https://api.anthropic.com/v1", false},
+		{"8.8.8.8 public", "http://8.8.8.8/v1", false},
+		{"203.0.113.1 public (TEST-NET-3)", "http://203.0.113.1/v1", false},
+		// Named host (not localhost) → public (no DNS lookup)
+		{"custom named host", "http://my-vllm-server.internal:8080/v1", false},
+		{"corp hostname", "http://llm.corp.example.com/v1", false},
+		// Edge cases
+		{"empty URL", "", false},
+		{"172.32.x (just outside 172.16/12)", "http://172.32.0.1/v1", false},
+		{"192.169.x (just outside 192.168/16)", "http://192.169.0.1/v1", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := classifyDestPrivate(tc.rawURL)
+			if got != tc.want {
+				t.Errorf("classifyDestPrivate(%q) = %v, want %v", tc.rawURL, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyDestPrivate_UsedByAddModel verifies that AddModel correctly
+// derives destPrivate via classifyDestPrivate from the model's BaseURL.
+// We assert the resulting behavior end-to-end: a model pointing at a loopback
+// address must pass the original body through unmodified (no anonymization).
+func TestClassifyDestPrivate_UsedByAddModel(t *testing.T) {
+	t.Parallel()
+
+	upstream, lastBody := captureOK(t)
+	// The upstream listens on 127.0.0.1 (loopback). AddModel calls
+	// classifyDestPrivate which must return true, setting destPrivate=true.
+	// With PIIEngine set and PIIFilter=nil, shouldAnonymize returns !destPrivate = false.
+	r := &Registry{
+		models:  make(map[string]*Model),
+		aliases: make(map[string]string),
+	}
+	r.AddModel(Model{
+		Name:     "loopback-model",
+		Provider: "vllm",
+		Type:     "chat",
+		BaseURL:  upstream.URL, // 127.0.0.1 → classifyDestPrivate → destPrivate=true
+		APIKey:   "key",
+	})
+
+	h := NewProxyHandler(r, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.PIIEngine = newTestPIIEngine(t)
+	app := testApp(t, h)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(chatBody("loopback-model", "contact "+piiTestEmail)))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body := string(*lastBody)
+	// loopback → destPrivate=true → shouldAnonymize returns false → original email passes through.
+	if !strings.Contains(body, piiTestEmail) {
+		t.Errorf("loopback model via AddModel: original email missing; "+
+			"classifyDestPrivate may not have set destPrivate=true; body: %s", body)
+	}
+	if piiPseudonymPattern.MatchString(body) {
+		t.Errorf("loopback model via AddModel: unexpected pseudonym in body; body: %s", body)
+	}
+}
+
+// ── 10. FIX 4: raw model name must not appear in OTel spans ──────────────────
+
+// TestFIX4_Tracing_RawModelNotInSpan verifies that the raw, client-supplied
+// model string never appears as a span attribute. Before the fix, the raw
+// envelope.Model was set as model.requested BEFORE resolveModel was called —
+// meaning a PII-containing model string (e.g. "gpt-4/user@example.com") would
+// be persisted in the tracing backend.
+//
+// After the fix, only the validated canonical model name (model.Name from the
+// registry) is set as model.canonical. The raw string never appears in any
+// span attribute.
+func TestFIX4_Tracing_RawModelNotInSpan(t *testing.T) {
+	t.Parallel()
+
+	upstream, _ := captureOK(t)
+	reg := buildModelWithPIIFilter(t, upstream.URL, false, nil)
+
+	// Wire an in-memory span recorder so we can inspect emitted attributes.
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	tracer := tp.Tracer("test")
+
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.Tracer = tracer
+	app := testApp(t, h)
+
+	// Send a request with a valid model name. The canonical name is "model-x".
+	req := httptest.NewRequest("POST", "/v1/chat/completions",
+		strings.NewReader(`{"model":"model-x","messages":[{"role":"user","content":"hello"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, b)
+	}
+
+	// Flush the tracer so all spans are recorded.
+	_ = tp.Shutdown(t.Context())
+
+	ended := recorder.Ended()
+	if len(ended) == 0 {
+		t.Fatal("no spans recorded; expected at least one proxy.handle span")
+	}
+
+	// Inspect all span attributes across all recorded spans.
+	for _, span := range ended {
+		for _, attr := range span.Attributes() {
+			key := string(attr.Key)
+			val := attr.Value.AsString()
+
+			// model.requested must NEVER appear (raw client value must not be set).
+			if key == "model.requested" {
+				t.Errorf("FIX 4: span %q has attribute model.requested=%q; "+
+					"raw client model must not be set as a span attribute",
+					span.Name(), val)
+			}
+
+			// model.canonical must be the registry-validated name, not a raw value.
+			if key == "model.canonical" && val != "model-x" {
+				t.Errorf("FIX 4: span %q has model.canonical=%q, want %q",
+					span.Name(), val, "model-x")
+			}
+		}
+	}
+
+	// Verify model.canonical IS set (the fix does not suppress all tracing,
+	// only the pre-resolution raw-value attribute).
+	found := false
+	for _, span := range ended {
+		for _, attr := range span.Attributes() {
+			if string(attr.Key) == "model.canonical" {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Error("FIX 4: model.canonical span attribute not found; expected it to be set after resolution")
+	}
+}
+
+// TestFIX4_Tracing_UnknownModelNoRawAttr verifies that when model resolution
+// fails (model not in registry), NO span attribute with the raw client-supplied
+// model name is emitted. A PII-containing model name would otherwise be
+// persisted in the tracing backend.
+func TestFIX4_Tracing_UnknownModelNoRawAttr(t *testing.T) {
+	t.Parallel()
+
+	upstream, _ := captureOK(t)
+	reg := buildModelWithPIIFilter(t, upstream.URL, false, nil)
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	tracer := tp.Tracer("test")
+
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.Tracer = tracer
+	app := testApp(t, h)
+
+	// Use a model name that embeds PII — this is the adversarial case the fix
+	// protects against. The model does not exist in the registry.
+	rawModelWithPII := "gpt-4/user@example.com"
+	req := httptest.NewRequest("POST", "/v1/chat/completions",
+		strings.NewReader(`{"model":"`+rawModelWithPII+`","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Expect 404 — model not found.
+	if resp.StatusCode != http.StatusNotFound {
+		b, _ := io.ReadAll(resp.Body)
+		t.Logf("status = %d, body: %s", resp.StatusCode, b)
+	}
+
+	_ = tp.Shutdown(t.Context())
+
+	ended := recorder.Ended()
+
+	// Verify the raw PII-containing model name does NOT appear in any span attribute.
+	for _, span := range ended {
+		for _, attr := range span.Attributes() {
+			val := attr.Value.AsString()
+			if strings.Contains(val, rawModelWithPII) {
+				t.Errorf("FIX 4: span %q attribute %q = %q leaks raw model name with PII",
+					span.Name(), attr.Key, val)
+			}
+			// Also check for the email portion specifically.
+			if strings.Contains(val, "user@example.com") {
+				t.Errorf("FIX 4: span %q attribute %q = %q leaks PII from model name",
+					span.Name(), attr.Key, val)
+			}
+			if string(attr.Key) == "model.requested" {
+				t.Errorf("FIX 4: span %q has model.requested=%q; attribute must never be set",
+					span.Name(), val)
+			}
+		}
+	}
+}

--- a/internal/proxy/registry.go
+++ b/internal/proxy/registry.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
+	"net/url"
 	"sort"
 	"sync"
 	"time"
@@ -31,6 +33,22 @@ type Deployment struct {
 	GCPLocation string
 	Weight      int
 	Priority    int
+	// destPrivate is computed once at registry/config load time from the
+	// deployment's BaseURL host. It is true when the host is a loopback address
+	// (127.0.0.0/8, ::1), a private RFC-1918/ULA address (10/8, 172.16/12,
+	// 192.168/16, fc00::/7), a link-local address (169.254/16, fe80::/10), or
+	// the literal string "localhost". Named hosts other than "localhost" are
+	// classified as non-private (public) because no DNS lookup is performed on
+	// the hot path — the conservative default is to anonymize.
+	//
+	// The flag is immutable after registry load and read concurrently; it must
+	// not be mutated after the Deployment is stored in the registry.
+	destPrivate bool
+	// PIIFilter explicitly enables or disables PII anonymization for requests
+	// routed to this deployment. When non-nil it overrides both the model-level
+	// PIIFilter and the network-based default (destPrivate). The pointer is
+	// treated as immutable after registry load.
+	PIIFilter *bool
 }
 
 // LogValue implements slog.LogValuer to prevent the upstream API key from
@@ -79,6 +97,21 @@ type Model struct {
 	// non-empty, the model-level Provider, BaseURL, and APIKey are ignored
 	// in favour of the per-deployment values.
 	Deployments []Deployment
+	// destPrivate is computed once at registry/config load time from the
+	// model's BaseURL host (same rules as Deployment.destPrivate). It is used
+	// when Deployments is empty and a single candidate is synthesized from the
+	// model's own fields in tryModel. When Deployments is non-empty, the
+	// per-deployment destPrivate flags govern PII body selection.
+	//
+	// The flag is immutable after registry load and must not be mutated
+	// after the Model is stored in the registry.
+	destPrivate bool
+	// PIIFilter explicitly enables or disables PII anonymization for all
+	// deployments of this model when no per-deployment PIIFilter is set.
+	// When non-nil it overrides the network-based default (destPrivate).
+	// A per-deployment PIIFilter takes precedence over this field.
+	// The pointer is treated as immutable after registry load.
+	PIIFilter *bool
 }
 
 // LogValue implements slog.LogValuer to prevent the upstream API key from
@@ -99,6 +132,52 @@ type Registry struct {
 	models  map[string]*Model // canonical name → model
 	aliases map[string]string // alias → canonical name
 	sorted  []*Model          // pre-sorted by name for List()
+}
+
+// classifyDestPrivate reports whether the destination host in rawURL is a
+// private or loopback address. It returns true when the host is:
+//   - the literal string "localhost"
+//   - a loopback address (127.0.0.0/8 or ::1)
+//   - a private address per net.IP.IsPrivate: RFC-1918 (10/8, 172.16/12,
+//     192.168/16) and ULA (fc00::/7)
+//   - a link-local unicast address (169.254/16 or fe80::/10)
+//
+// Named hosts other than "localhost" are classified as non-private (public)
+// because no DNS lookup is performed on the hot path. The conservative default
+// — anonymize when the classification is uncertain — means unknown named hosts
+// are treated as external targets, so PII anonymization applies.
+//
+// The classification is derived entirely from the literal host string in
+// rawURL. It is computed once at registry/config load time and stored on the
+// Deployment or Model as an immutable bool so the hot path never re-derives it.
+//
+// The private-IP detection logic mirrors the SSRF protection in
+// internal/mcp/http_transport.go (NewSSRFSafeTransport): both use
+// ip.IsLoopback(), ip.IsPrivate(), and ip.IsLinkLocalUnicast() from the
+// standard library so the classification is consistent across subsystems.
+func classifyDestPrivate(rawURL string) bool {
+	if rawURL == "" {
+		return false // no URL configured → treat as public
+	}
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false // unparseable URL → treat as public
+	}
+	host := u.Hostname() // strips port
+	if host == "" {
+		return false
+	}
+	// Literal "localhost" is always private regardless of /etc/hosts overrides.
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		// Named host other than "localhost": no DNS lookup on the hot path.
+		// Classify as public (conservative: anonymize when uncertain).
+		return false
+	}
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast()
 }
 
 // NewRegistry builds a Registry from a slice of ModelConfig values. It returns
@@ -152,6 +231,8 @@ func NewRegistry(models []config.ModelConfig) (*Registry, error) {
 				GCPLocation:     d.GCPLocation,
 				Weight:          d.Weight,
 				Priority:        d.Priority,
+				destPrivate:     classifyDestPrivate(d.BaseURL),
+				PIIFilter:       d.PIIFilter,
 			}
 		}
 
@@ -173,6 +254,8 @@ func NewRegistry(models []config.ModelConfig) (*Registry, error) {
 			MaxRetries:        mc.MaxRetries,
 			Deployments:       deployments,
 			FallbackModelName: mc.Fallback,
+			destPrivate:       classifyDestPrivate(mc.BaseURL),
+			PIIFilter:         mc.PIIFilter,
 		}
 		r.models[mc.Name] = m
 	}
@@ -284,8 +367,16 @@ func (r *Registry) AddModel(m Model) {
 	aliases := make([]string, len(m.Aliases))
 	copy(aliases, m.Aliases)
 
+	// Re-derive destPrivate from each deployment's BaseURL so that models
+	// added via AddModel (e.g. from the Admin API) have the same classification
+	// as those loaded from config at startup. PIIFilter is carried over from
+	// the caller-supplied Deployment; the pointer is treated as immutable so
+	// shallow copying the pointer is safe.
 	deployments := make([]Deployment, len(m.Deployments))
-	copy(deployments, m.Deployments)
+	for i, d := range m.Deployments {
+		d.destPrivate = classifyDestPrivate(d.BaseURL)
+		deployments[i] = d
+	}
 
 	entry := &Model{
 		Name:              m.Name,
@@ -305,6 +396,8 @@ func (r *Registry) AddModel(m Model) {
 		MaxRetries:        m.MaxRetries,
 		Deployments:       deployments,
 		FallbackModelName: m.FallbackModelName,
+		destPrivate:       classifyDestPrivate(m.BaseURL),
+		PIIFilter:         m.PIIFilter,
 	}
 	r.models[m.Name] = entry
 
@@ -400,7 +493,10 @@ func (r *Registry) FallbackFor(currentName string, visited map[string]bool) (Mod
 }
 
 // copyModel returns a deep copy of m so callers cannot mutate the registry's
-// internal state. Slices (Aliases, Deployments) are copied into new backing arrays.
+// internal state. Slices (Aliases, Deployments) are copied into new backing
+// arrays. PIIFilter and Deployment.PIIFilter are pointer fields treated as
+// immutable after registry load, so shallow pointer copies are safe — callers
+// must not write through these pointers.
 func copyModel(m *Model) Model {
 	result := *m
 	result.Aliases = make([]string, len(m.Aliases))

--- a/ui/src/hooks/useModels.ts
+++ b/ui/src/hooks/useModels.ts
@@ -12,6 +12,7 @@ export interface DeploymentResponse {
   weight: number
   priority: number
   is_active: boolean
+  pii_filter?: boolean
   created_at: string
   updated_at: string
 }
@@ -36,6 +37,7 @@ export interface ModelResponse {
   strategy?: string
   max_retries?: number
   fallback_model_name?: string
+  pii_filter?: boolean
   deployments?: DeploymentResponse[]
 }
 
@@ -61,6 +63,7 @@ export interface CreateModelParams {
   strategy?: string
   max_retries?: number
   fallback_model_name?: string
+  pii_filter?: boolean
 }
 
 export interface CreateDeploymentParams {
@@ -99,6 +102,7 @@ export interface UpdateModelParams {
   timeout?: string
   aliases?: string[]
   fallback_model_name?: string | null
+  pii_filter?: boolean | null
 }
 
 export function useModels(cursor?: string) {

--- a/ui/src/pages/ModelsPage.tsx
+++ b/ui/src/pages/ModelsPage.tsx
@@ -70,6 +70,39 @@ const STRATEGY_OPTIONS = [
   { value: 'priority', label: 'Priority' },
 ]
 
+// Tri-state: 'default' maps to undefined (omit from request), 'true' / 'false' map to boolean.
+const PII_FILTER_OPTIONS = [
+  {
+    value: 'default',
+    label: 'Default (network-based)',
+    description: 'Private endpoints pass through; public endpoints are anonymized.',
+  },
+  {
+    value: 'true',
+    label: 'Always anonymize',
+    description: 'PII is stripped from every request to this model.',
+  },
+  {
+    value: 'false',
+    label: 'Never (trusted endpoint)',
+    description: 'No anonymization — use only for private, trusted endpoints.',
+  },
+]
+
+/** Converts the PII filter Select string value back to the API boolean. */
+function piiFilterToParam(value: string): boolean | undefined {
+  if (value === 'true') return true
+  if (value === 'false') return false
+  return undefined
+}
+
+/** Converts an API boolean (or undefined/null) to the Select string value. */
+function piiFilterFromResponse(value: boolean | undefined | null): string {
+  if (value === true) return 'true'
+  if (value === false) return 'false'
+  return 'default'
+}
+
 const typeLabels: Record<string, string> = {
   chat: 'Chat',
   embedding: 'Embedding',
@@ -460,6 +493,7 @@ function CreateModelDialog({ open, onClose }: CreateModelDialogProps) {
   const [azureDeployment, setAzureDeployment] = useState('')
   const [azureApiVersion, setAzureApiVersion] = useState('')
   const [timeout, setTimeout] = useState('')
+  const [piiFilter, setPiiFilter] = useState('default')
 
   // Load-balanced fields
   const [strategy, setStrategy] = useState('round-robin')
@@ -499,6 +533,7 @@ function CreateModelDialog({ open, onClose }: CreateModelDialogProps) {
     setStrategy('round-robin')
     setMaxRetries('')
     setFallbackModelName('')
+    setPiiFilter('default')
     setDeployments([])
     setShowDeploymentForm(false)
     setEditingDeployment(null)
@@ -640,6 +675,8 @@ function CreateModelDialog({ open, onClose }: CreateModelDialogProps) {
       }
       if (timeout.trim()) params.timeout = timeout.trim()
       if (parsedAliases.length > 0) params.aliases = parsedAliases
+      const piiFilterValue = piiFilterToParam(piiFilter)
+      if (piiFilterValue !== undefined) params.pii_filter = piiFilterValue
 
       createModel.mutate(params, {
         onSuccess: () => {
@@ -679,6 +716,8 @@ function CreateModelDialog({ open, onClose }: CreateModelDialogProps) {
       }
       if (timeout.trim()) params.timeout = timeout.trim()
       if (parsedAliases.length > 0) params.aliases = parsedAliases
+      const piiFilterValueLB = piiFilterToParam(piiFilter)
+      if (piiFilterValueLB !== undefined) params.pii_filter = piiFilterValueLB
 
       try {
         const model = await createModel.mutateAsync(params)
@@ -1142,6 +1181,18 @@ function CreateModelDialog({ open, onClose }: CreateModelDialogProps) {
               description="Per-model upstream timeout. Empty = use global default."
               disabled={isPending}
             />
+            <div>
+              <Select
+                label="PII Filter"
+                options={PII_FILTER_OPTIONS}
+                value={piiFilter}
+                onChange={setPiiFilter}
+                disabled={isPending}
+              />
+              <p className="text-xs text-text-tertiary mt-1">
+                Controls PII anonymization for requests to this model. Default applies network-based rules.
+              </p>
+            </div>
           </div>
         </details>
 
@@ -1191,6 +1242,7 @@ function EditModelDialog({ model, onClose }: EditModelDialogProps) {
   const [azureApiVersion, setAzureApiVersion] = useState(model.azure_api_version ?? '')
   const [timeout, setTimeout] = useState(model.timeout ?? '')
   const [fallbackModelName, setFallbackModelName] = useState(model.fallback_model_name ?? '')
+  const [piiFilter, setPiiFilter] = useState(() => piiFilterFromResponse(model.pii_filter))
 
   const updateModel = useUpdateModel()
   const { toast } = useToast()
@@ -1273,6 +1325,18 @@ function EditModelDialog({ model, onClose }: EditModelDialogProps) {
       // Empty string sent as empty string — backend treats it as "clear"
       // Non-empty string sent as the chosen name
       params.fallback_model_name = fallbackModelName || ''
+    }
+
+    const newPiiFilter = piiFilterToParam(piiFilter)
+    const currentPiiFilter = model.pii_filter
+    // Only include in the patch when the value differs from what the server has.
+    // null and undefined both mean "default", so compare normalized values.
+    const piiFilterChanged =
+      newPiiFilter !== currentPiiFilter &&
+      !(newPiiFilter === undefined && (currentPiiFilter === undefined || currentPiiFilter === null))
+    if (piiFilterChanged) {
+      // Send null to clear (reset to default), boolean to set explicitly.
+      params.pii_filter = newPiiFilter ?? null
     }
 
     if (Object.keys(params).length === 0) {
@@ -1421,6 +1485,18 @@ function EditModelDialog({ model, onClose }: EditModelDialogProps) {
           description="Comma-separated. Must be globally unique."
           disabled={updateModel.isPending}
         />
+        <div>
+          <Select
+            label="PII Filter"
+            options={PII_FILTER_OPTIONS}
+            value={piiFilter}
+            onChange={setPiiFilter}
+            disabled={updateModel.isPending}
+          />
+          <p className="text-xs text-text-tertiary mt-1">
+            Controls PII anonymization for requests to this model. Default applies network-based rules.
+          </p>
+        </div>
         <div className="flex justify-end gap-2 pt-2">
           <Button variant="secondary" onClick={onClose} disabled={updateModel.isPending}>
             Cancel

--- a/voidllm.yaml.example
+++ b/voidllm.yaml.example
@@ -115,6 +115,11 @@ models:
     pricing:
       input_per_1m:  0.50
       output_per_1m: 1.50
+    # pii_filter: false              # Explicit override: never anonymize for this model.
+    #                                # Default (absent): public destinations anonymize,
+    #                                # private/loopback destinations pass through as-is.
+    #                                # pii_filter: true  forces anonymization even on private URLs.
+    #                                # pii_filter: false disables anonymization even on public URLs.
 
   - name: gpt-oss-20b
     provider: vllm
@@ -177,6 +182,7 @@ models:
         azure_api_version: "2024-02-01"
         weight: 2                    # For weighted strategy
         priority: 1                  # For priority strategy (lower = higher priority)
+        # pii_filter: true           # Per-deployment override (takes precedence over model-level flag)
       - name: azure-west
         provider: azure
         base_url: https://westus.openai.azure.com
@@ -290,6 +296,17 @@ settings:
   #   allowed_domains: ["company.com"]
   #   default_role: "member"
   #   auto_provision: true
+
+  # PII anonymization - replace PII in outbound prompts with pseudonyms.
+  # Pseudonyms are restored in the response; no PII is ever persisted or logged.
+  # Applies only to external providers (openai, anthropic, azure, gemini, vertex).
+  # Disabled by default. Only "pseudonymize" is supported as action.
+  # pii:
+  #   enabled: false
+  #   action: pseudonymize
+  #   patterns:                     # custom patterns added to the built-in defaults
+  #     - type: PASSPORT_NO
+  #       regexp: '\b[A-Z]{1,3}[0-9]{6,9}\b'
 
 
 # =============================================================================

--- a/voidllm.yaml.example
+++ b/voidllm.yaml.example
@@ -120,6 +120,10 @@ models:
     #                                # private/loopback destinations pass through as-is.
     #                                # pii_filter: true  forces anonymization even on private URLs.
     #                                # pii_filter: false disables anonymization even on public URLs.
+    #                                # WARNING: pii_filter: false sends prompt content (including any
+    #                                # PII) to this upstream IN CLEARTEXT, even for public endpoints.
+    #                                # This is a deliberate opt-out for upstreams you trust; only set
+    #                                # it when you are sure the destination is acceptable for raw data.
 
   - name: gpt-oss-20b
     provider: vllm


### PR DESCRIPTION
## What

Opt-in PII anonymization for outbound LLM traffic. PII in a request is detected in memory, replaced with deterministic pseudonyms, the **anonymized** body is sent to external upstreams, and the originals are restored in the response. Nothing is logged, persisted, or traced — the core zero-knowledge constraint is fully intact; the upstream provider never sees the real PII.

Disabled by default (`settings.pii.enabled: false`).

## How it works

- **Detection (Stage 0a):** regex for structured PII (IBAN, email, phone, credit card, tax id) + optional custom patterns. The `Detector` interface is built so a gazetteer (Stage 1) and an NER sidecar (Stage 2) can be added later without touching the engine.
- **Pseudonyms:** deterministic `HMAC(secret, orgID || type || value)`, fixed-length, 96-bit — scoped per org (no cross-tenant correlation) and per type. Restored from a per-request in-memory map.
- **Field coverage:** chat `content` (string + parts), `name`, `tool_calls`/`function_call` arguments, `tools[].function` description + parameters (incl. keys), top-level `user`, completions `prompt` (token-arrays pass through), embeddings `input`.
- **Trust (when to anonymize):** per-model/deployment `pii_filter` flag (tri-state, wired end-to-end config → DB migration 0014 → registry → admin API → UI). When unset, the network default applies: public destination = anonymize, private/loopback = pass through. Evaluated **per deployment** (covers fallback and mixed-provider deployments).
- **Streaming:** content-aware restore that reassembles pseudonyms split across SSE delta events. Correct and leak-free; currently buffered (incremental token streaming for PII requests is Stage 0b).
- **Fail-closed everywhere:** parse/shape/recursion-depth/mapping-cap/startup errors and duplicate JSON keys all reject the request rather than forward un-anonymized content.

## Reviewed

Multiple internal review rounds plus external (Codex + Gemini). All findings addressed. ~70 tests incl. the critical regressions (fallback internal→external, multi-deployment, split-pseudonym, duplicate-key smuggling, malformed-shape fail-closed). `go test -race`, `go vet`, UI build all green locally.

## Documented intentional relaxations

- `pii_filter: false` is a conscious cleartext opt-out for trusted upstreams (WARNING in `voidllm.yaml.example`).
- Response-header pseudonym echo is an accepted residual risk (providers don't echo request content in server-generated headers).

Details + rationale: internal design notes.

## Follow-ups (separate branches)

- Stage 0b — incremental token streaming (rolling buffer)
- Stage 1 — gazetteer detector (names/places/companies)
- Stage 2 — optional NER sidecar
- Org/team/key named-policy CRUD (currently a global config policy)
- Smaller: per-type action (mask/block), match-count metric, pattern-management UI