### PR TITLE
feat(pii): Stage 0c incremental streaming tool-call restore

### DIFF
--- a/internal/pii/stream.go
+++ b/internal/pii/stream.go
@@ -3,13 +3,24 @@ package pii
 import (
 	"bytes"
 	"errors"
+	"regexp"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/voidmind-io/voidllm/internal/jsonx"
 )
+
+// toolIDCharsetRe and toolNameCharsetRe are precompiled conservative charset
+// validators for tool-call id and function name respectively. Both use the
+// same charset — [A-Za-z0-9_.-]+ — which covers all known provider tool-call
+// id formats (e.g. "call_abc123") and valid OpenAI function names. Any
+// character outside this set (including '@', spaces, ':', non-ASCII) would
+// indicate an encoding anomaly and could carry PII. Such values fail-closed.
+var toolIDCharsetRe = regexp.MustCompile(`^[A-Za-z0-9_.+-]+$`)
+var toolNameCharsetRe = regexp.MustCompile(`^[A-Za-z0-9_.+-]+$`)
 
 // dataLinePrefix is the SSE field prefix per RFC 6202 §4.2. A "data" field
 // line MUST begin with "data:" — the space after the colon is optional.
@@ -48,19 +59,137 @@ const maxStreamChoices = 128
 // and causes fail-closed abort. An empty or null finish_reason is never
 // passed to this check (the caller guards with *rc.FinishReason != "").
 //
-// "tool_calls" and "function_call" are intentionally excluded: the Anthropic
-// adapter translates tool_use stop_reason to "tool_calls" but drops all
-// tool_use content deltas (they are not text and cannot be PII-restored).
-// This means the StreamRestorer would never see any tool_calls delta (so the
-// delta-level fail-closed check never fires), yet the stream closes with
-// finish_reason:"tool_calls" — producing a response with no tool_calls body
-// but the wrong finish_reason. Excluding these values from the allowlist
-// ensures that any stream involving tool use is fail-closed, regardless of
-// whether the tool_calls delta was visible to the restorer.
+// "tool_calls" is included here but is additionally gated at the choice level:
+// it is only accepted when cc.sawToolCall is true for that choice (i.e. at
+// least one fully-validated, non-empty tool-call element was processed). This
+// keeps the Anthropic adapter correctly fail-closed: the Anthropic adapter
+// translates tool_use stop_reason to "tool_calls" but drops all tool_use
+// content deltas, so sawToolCall is never set and the finish_reason is
+// rejected. For OpenAI/vLLM passthrough streams with real tool_calls deltas,
+// sawToolCall is set and the finish_reason is accepted.
+//
+// "function_call" is intentionally excluded: legacy singular delta.function_call
+// is always fail-closed and must not be authorized via the finish_reason allowlist.
 var allowedFinishReasons = map[string]bool{
 	"stop":           true,
 	"length":         true,
 	"content_filter": true,
+	"tool_calls":     true,
+}
+
+// maxToolCallsPerChoice is the maximum number of distinct tool-call indices
+// allowed per choice. A tool_calls array with more distinct indices than this
+// limit is a protocol violation and causes fail-closed abort. 64 covers all
+// realistic LLM use cases with generous headroom.
+const maxToolCallsPerChoice = 64
+
+// maxToolCallsTotal is the global cap on distinct tool-call carries across ALL
+// choices in a single streaming request. A request that emits more than this
+// number of distinct (choice, tool-index) pairs is a protocol violation and
+// causes fail-closed abort. 1024 is orders of magnitude above any realistic
+// use-case while still bounding memory growth from adversarial inputs.
+const maxToolCallsTotal = 1024
+
+// maxToolIDLen and maxToolNameLen bound the per-key retained state to prevent
+// unbounded memory growth from adversarial inputs.
+const maxToolIDLen = 256
+const maxToolNameLen = 256
+
+// canonicalPseudonymRe matches the canonical pseudonym shape: PII_ followed by
+// exactly 2 alphanumeric characters, then _, then exactly 24 lowercase hex
+// characters (total 31 bytes). This is the shape produced by pseudonym().
+// The regexp is compiled once at package load.
+var canonicalPseudonymRe = regexp.MustCompile(`PII_[A-Za-z0-9]{2}_[0-9a-f]{24}`)
+
+// isCanonicalPseudonym reports whether s contains a value matching the
+// canonical pseudonym shape (31 bytes: PII_<2alnum>_<24hex>). Any occurrence
+// — known to this filter or not — triggers the check; unknown canonical shapes
+// must fail-closed to uphold the "no pseudonym to client" guarantee.
+func isCanonicalPseudonym(s string) bool {
+	return canonicalPseudonymRe.MatchString(s)
+}
+
+// residualSubCanonicalTotal counts the number of times a sub-canonical PII_
+// marker (not a full canonical pseudonym shape) was observed in restored content
+// text. The counter is package-level, content-free (count only), and exported
+// for testing and metric collection. It is incremented atomically so it is safe
+// to read concurrently from multiple goroutines.
+//
+// A sub-canonical marker in content is passed through (the restorer cannot
+// recover what it did not anonymize, and blocking would cause false-positive
+// aborts on natural text). This counter lets operators detect anomalies without
+// recording any content value.
+var residualSubCanonicalTotal atomic.Int64
+
+// ResidualSubCanonicalCount returns the total number of sub-canonical PII_
+// markers observed in restored content across all requests since process start.
+// The value is informational only; it does not identify any specific request,
+// value, or user.
+func ResidualSubCanonicalCount() int64 {
+	return residualSubCanonicalTotal.Load()
+}
+
+// residualScan checks whether a canonical pseudonym spans the boundary between
+// previously-emitted bytes and the new fragment frag by inspecting the
+// accumulated view [emittedTail + frag]. It also checks for sub-canonical PII_
+// markers spanning that boundary.
+//
+// The tail field (a pointer to a []byte) holds the last pseudonymLen-1 (30)
+// bytes emitted in the lane. On each call residualScan:
+//  1. Builds check = *tail + frag (only the suffix of combined that is needed
+//     for pattern matching, bounded by len(frag)+pseudonymLen-1 bytes).
+//  2. If canonicalPseudonymRe matches check → fail-closed (errStreamAborted),
+//     regardless of inToolArgs.
+//  3. If strings.Contains(check, pseudonymMarker) and inToolArgs → fail-closed
+//     (sub-canonical marker in tool arguments is always fail-closed).
+//  4. If strings.Contains(check, pseudonymMarker) and !inToolArgs → increment
+//     residualSubCanonicalTotal (count-only; pass through).
+//  5. Updates *tail to the last min(len(check), pseudonymLen-1) bytes of check.
+//
+// The caller must call residualScan AFTER the Restore call, passing the
+// restored fragment as frag. residualScan does not read the lane's carry.
+//
+// Note: step 4 may over-count sub-canonical markers when the tail window
+// overlaps with the previous emission, causing a marker near an emission
+// boundary to be counted twice. The counter is an approximate anomaly signal
+// only — content-free and count-only — and should not be treated as an exact
+// occurrence tally.
+func residualScan(tail *[]byte, frag string, inToolArgs bool) error {
+	// Build the combined view: prior tail bytes + new fragment.
+	// We only need the last pseudonymLen-1 bytes of tail + all of frag to
+	// detect a pattern that begins in tail and ends in frag.
+	combined := make([]byte, 0, len(*tail)+len(frag))
+	combined = append(combined, *tail...)
+	combined = append(combined, frag...)
+
+	check := string(combined)
+
+	// Step 2: canonical pseudonym → fail-closed (both content and tool args).
+	if canonicalPseudonymRe.MatchString(check) {
+		return errStreamAborted
+	}
+
+	// Step 3/4: sub-canonical PII_ marker.
+	if strings.Contains(check, pseudonymMarker) {
+		if inToolArgs {
+			return errStreamAborted
+		}
+		// Content: count-only, pass through.
+		residualSubCanonicalTotal.Add(1)
+	}
+
+	// Step 5: update tail to last pseudonymLen-1 bytes of combined.
+	const tailLen = pseudonymLen - 1
+	if len(combined) <= tailLen {
+		*tail = combined
+	} else {
+		// Take only the last tailLen bytes.
+		suffix := make([]byte, tailLen)
+		copy(suffix, combined[len(combined)-tailLen:])
+		*tail = suffix
+	}
+
+	return nil
 }
 
 // choiceFormat is the detected format of a streaming choice's content field.
@@ -81,12 +210,41 @@ const (
 	formatRefusal
 )
 
+// toolCallCarry holds per-(choice, tool-call-index) state for tool_calls
+// argument restoration. Each distinct tool-call index within a choice gets
+// its own toolCallCarry, allocated on first observation.
+type toolCallCarry struct {
+	// argsCarry is the rolling buffer for function.arguments, analogous to
+	// choiceCarry.carry for content. Invariant: argsCarry is either empty or a
+	// proper prefix of a known pseudonym.
+	argsCarry []byte
+	// emittedTail holds the last min(len(emitted), pseudonymLen-1) bytes that
+	// have been emitted for this tool-call's arguments lane. It is used by
+	// residualScan to detect a canonical pseudonym that spans two consecutive
+	// emission fragments (cross-emission boundary detection).
+	emittedTail []byte
+	// headerSent is true after the first tool_calls chunk for this index has
+	// been emitted (which included id, type, and name).
+	headerSent bool
+	// id is the tool call id, stored from the first observation. Later
+	// fragments must repeat the same id or omit it.
+	id string
+	// name is the function name, stored from the first observation. Later
+	// fragments must repeat the same name or omit it.
+	name string
+}
+
 // choiceCarry holds the per-choice rolling-buffer state for StreamRestorer.
 type choiceCarry struct {
 	// carry is the accumulated, not-yet-emitted content bytes. Invariant: carry
 	// is either empty or a proper prefix of a known pseudonym — never arbitrary
 	// buffered text, never an emittable fragment.
 	carry []byte
+	// emittedTail holds the last min(len(emitted), pseudonymLen-1) bytes that
+	// have been emitted for this choice's content lane (delta.content, refusal,
+	// or text). It is used by residualScan to detect a canonical pseudonym that
+	// spans two consecutive emission fragments.
+	emittedTail []byte
 	// format is set on the first delta with content and never changes.
 	format choiceFormat
 	// role is emitted once with the first content chunk.
@@ -99,6 +257,13 @@ type choiceCarry struct {
 	// finished is true after a finish_reason has been seen; content after this
 	// point is a protocol violation (fail-closed).
 	finished bool
+	// toolCalls holds per-tool-call-index carry state. Keyed by the integer
+	// index from the upstream delta.tool_calls array.
+	toolCalls map[int]*toolCallCarry
+	// sawToolCall is true after at least one fully-validated, non-empty
+	// tool-call element has been processed for this choice. Empty/null
+	// tool_calls arrays do not set this flag.
+	sawToolCall bool
 }
 
 // StreamRestorer performs incremental, content-aware PII restore over a
@@ -114,15 +279,28 @@ type choiceCarry struct {
 // carry that is a proper prefix of ANY known pseudonym has length L, making the
 // first len(carry)-L bytes safe to emit.
 //
-// Availability trade-off: if the upstream response ends (via [DONE]) while any
-// per-choice carry is non-empty, the restorer returns errCarryNotEmpty and
-// aborts the stream fail-closed. This covers the case where natural content
-// happens to end on a proper prefix of a known pseudonym (e.g. the response
-// legitimately ends with a capital "P", "PI", "PII", or "PII_"). Because
-// truncation is indistinguishable from a partial pseudonym at the stream
-// boundary, the restorer cannot safely emit the held bytes. This is a
-// deliberate, leak-safe design choice: the alternative — emitting ambiguous
-// trailing bytes — risks exposing a real pseudonym fragment to the client.
+// # Guarantee precision
+//
+// The client never receives a canonical/exact pseudonym (PII_<2 alnum>_<24
+// hex>). A sub-canonical PII_-prefixed fragment in free CONTENT (e.g. "PII_X")
+// may pass through: it is not a restorable pseudonym and failing closed would
+// abort on natural text containing "PII_". Such fragments carry no PII — they
+// are opaque character sequences that were never inserted by the anonymizer. In
+// tool-call arguments, even sub-canonical PII_-prefixed fragments are
+// fail-closed because tool arguments must contain only structured data (no
+// natural text containing "PII_" is expected there).
+//
+// # Availability trade-off
+//
+// If the upstream response ends (via [DONE]) while any per-choice carry is
+// non-empty, the restorer returns errCarryNotEmpty and aborts the stream
+// fail-closed. This covers the case where natural content happens to end on a
+// proper prefix of a known pseudonym (e.g. the response legitimately ends with
+// a capital "P", "PI", "PII", or "PII_"). Because truncation is
+// indistinguishable from a partial pseudonym at the stream boundary, the
+// restorer cannot safely emit the held bytes. This is a deliberate, leak-safe
+// design choice: the alternative — emitting ambiguous trailing bytes — risks
+// exposing a real pseudonym fragment to the client.
 //
 // Concurrency: StreamRestorer is NOT safe for concurrent use. It is designed
 // for single-goroutine use inside the streaming SendStreamWriter closure.
@@ -161,6 +339,9 @@ type StreamRestorer struct {
 	// totalCarryBytes is the sum of carry lengths across all choices.
 	// Used to enforce maxPIIStreamBytes.
 	totalCarryBytes int
+	// totalToolCalls is the count of distinct toolCallCarry entries created
+	// across all choices. Used to enforce maxToolCallsTotal.
+	totalToolCalls int
 }
 
 // NewStreamRestorer creates a StreamRestorer for a single proxy request.
@@ -322,12 +503,29 @@ func (s *StreamRestorer) Push(line []byte) (out [][]byte, terminal bool, err err
 
 // handleDone processes the [DONE] sentinel.
 func (s *StreamRestorer) handleDone() ([][]byte, bool, error) {
-	// Verify all carries are empty. A non-empty carry means the upstream
-	// truncated a pseudonym — fail-closed.
+	// Verify all carries (content and tool-call arguments) are empty across
+	// all choices. A non-empty carry means the upstream truncated a pseudonym.
 	for _, cc := range s.choices {
 		if len(cc.carry) > 0 {
 			s.aborted = true
 			return nil, false, errCarryNotEmpty
+		}
+		for _, tc := range cc.toolCalls {
+			if len(tc.argsCarry) > 0 {
+				s.aborted = true
+				return nil, false, errCarryNotEmpty
+			}
+		}
+	}
+
+	// For every choice that streamed at least one validated tool call, a
+	// finish_reason must have been seen before [DONE]. OpenAI and vLLM always
+	// send finish_reason before [DONE]; if it is absent the stream is truncated
+	// or malformed — fail-closed. Non-tool choices are unaffected.
+	for _, cc := range s.choices {
+		if cc.sawToolCall && !cc.finished {
+			s.aborted = true
+			return nil, false, errStreamAborted
 		}
 	}
 
@@ -353,6 +551,36 @@ func (s *StreamRestorer) handleDone() ([][]byte, bool, error) {
 	return out, true, nil
 }
 
+// rawToolCallFunction is the typed representation of the function field inside
+// a tool_calls delta element.
+//
+// Name is a *string because sonic (the JSON library) correctly distinguishes
+// absent string key (nil) from explicit string value (non-nil).
+//
+// Arguments is parsed separately from the raw function map (not via a struct
+// tag) because sonic maps JSON null → nil *string, making it impossible to
+// distinguish `"arguments": null` from `"arguments"` being absent when both
+// are represented as *string. Instead, the validation loop in
+// handleToolCallsDelta checks the raw function JSON map directly: if the
+// "arguments" key is present, its value must be a JSON string; null or any
+// non-string type causes fail-closed abort.
+type rawToolCallFunction struct {
+	Name *string `json:"name"`
+	// Arguments is intentionally absent as a struct field; it is read from the
+	// raw function map in handleToolCallsDelta to support null detection.
+}
+
+// rawToolCall is the typed representation of one element in delta.tool_calls.
+// The Function field holds the raw JSON bytes of the function object so that
+// handleToolCallsDelta can parse it both as a typed struct (for Name) and as a
+// raw key-presence map (for Arguments null-vs-absent detection).
+type rawToolCall struct {
+	Index    *int              `json:"index"`
+	ID       *string           `json:"id"`
+	Type     *string           `json:"type"`
+	Function *jsonx.RawMessage `json:"function"`
+}
+
 // handleChoices processes a non-empty choices array from one upstream SSE chunk.
 func (s *StreamRestorer) handleChoices(rawChoices []jsonx.RawMessage) ([][]byte, bool, error) {
 	// Parse choices as typed structs.
@@ -360,7 +588,7 @@ func (s *StreamRestorer) handleChoices(rawChoices []jsonx.RawMessage) ([][]byte,
 		Role    *string `json:"role"`
 		Content *string `json:"content"`
 		Refusal *string `json:"refusal"`
-		// ToolCalls is parsed via the raw map for key-presence detection (see below).
+		// ToolCalls is parsed separately via rawDeltaMap for key-presence detection.
 	}
 	type rawChoice struct {
 		Index        *int              `json:"index"`
@@ -406,7 +634,9 @@ func (s *StreamRestorer) handleChoices(rawChoices []jsonx.RawMessage) ([][]byte,
 		hasDeltaContent := false
 		hasDeltaRefusal := false
 		hasTextContent := false
+		hasDeltaToolCalls := false
 		var contentStr string
+		var rawToolCallsJSON jsonx.RawMessage
 		// deltaHasRole is true when the upstream delta contained a "role" key
 		// (regardless of value). Used after cc is obtained to synthesize the
 		// canonical "assistant" role without ever storing the upstream value.
@@ -427,30 +657,24 @@ func (s *StreamRestorer) handleChoices(rawChoices []jsonx.RawMessage) ([][]byte,
 				return nil, false, errStreamAborted
 			}
 
-			// Audit every delta key for unknown content-bearing fields. Known
-			// content fields are content, refusal, and the legacy text field on
-			// the choice level. tool_calls and function_call are always
-			// fail-closed, regardless of whether they are null — key presence
-			// alone signals tool-call intent and that path is not safe to
-			// forward through the PII restorer. A null tool_calls or
-			// function_call unmarshals to nil in the typed struct and is
-			// indistinguishable from "field absent", so we check the raw map.
-			for k := range rawDeltaMap {
+			// Audit every delta key. Known content fields: content, refusal,
+			// tool_calls. Legacy function_call stays fail-closed. Unknown fields
+			// are conservatively dropped (envelope is synthesized, so unknown
+			// fields cannot leak pseudonyms).
+			for k, v := range rawDeltaMap {
 				switch k {
 				case "role", "content", "refusal":
-					// Explicitly handled fields.
+					// Explicitly handled fields — fall through.
 				case "tool_calls":
-					// Fail-closed: tool_calls key present (even if null/empty).
-					s.aborted = true
-					return nil, false, errStreamAborted
+					// tool_calls is handled below; capture raw JSON for typed parsing.
+					hasDeltaToolCalls = true
+					rawToolCallsJSON = v
 				case "function_call":
-					// function_call in delta: fail-closed regardless of value.
+					// Legacy singular delta.function_call: always fail-closed.
 					s.aborted = true
 					return nil, false, errStreamAborted
 				}
 				// All other unrecognised delta fields are conservatively ignored.
-				// They are not forwarded (the envelope is synthesized), so unknown
-				// fields cannot leak pseudonyms through unhandled paths.
 			}
 
 			if delta.Content != nil {
@@ -473,17 +697,23 @@ func (s *StreamRestorer) handleChoices(rawChoices []jsonx.RawMessage) ([][]byte,
 		// A single chunk must not mix content-bearing fields. Mixing any two of
 		// delta.content, delta.refusal, and choice-level text is a protocol
 		// violation: fail-closed.
-		activeFields := 0
+		activeContentFields := 0
 		if hasDeltaContent {
-			activeFields++
+			activeContentFields++
 		}
 		if hasDeltaRefusal {
-			activeFields++
+			activeContentFields++
 		}
 		if hasTextContent {
-			activeFields++
+			activeContentFields++
 		}
-		if activeFields > 1 {
+		if activeContentFields > 1 {
+			s.aborted = true
+			return nil, false, errStreamAborted
+		}
+
+		// tool_calls must not appear alongside content fields in the same chunk.
+		if hasDeltaToolCalls && activeContentFields > 0 {
 			s.aborted = true
 			return nil, false, errStreamAborted
 		}
@@ -512,10 +742,23 @@ func (s *StreamRestorer) handleChoices(rawChoices []jsonx.RawMessage) ([][]byte,
 			cc.role = "assistant"
 		}
 
-		// Fail-closed: content after finish_reason.
-		if cc.finished && activeFields > 0 {
+		// Fail-closed: content or tool_calls after finish_reason.
+		if cc.finished && (activeContentFields > 0 || hasDeltaToolCalls) {
 			s.aborted = true
 			return nil, false, errStreamAborted
+		}
+
+		// Format guard: tool_calls only valid when format is unknown or chat.
+		// If format is already locked to completion or refusal, tool_calls is
+		// a protocol violation.
+		if hasDeltaToolCalls {
+			switch cc.format {
+			case formatUnknown, formatChat:
+				// Valid.
+			default:
+				s.aborted = true
+				return nil, false, errStreamAborted
+			}
 		}
 
 		// Detect and lock in format. A choice that changes its content field
@@ -554,14 +797,54 @@ func (s *StreamRestorer) handleChoices(rawChoices []jsonx.RawMessage) ([][]byte,
 			}
 		}
 
+		// Cross-lane ownership within a choice: a pseudonym always lies entirely
+		// within one lane (content-kind or tool-index) of a given choice.
+		// While the content carry for this choice is non-empty, emitting from a
+		// tool-call lane of the SAME choice is fail-closed, and vice versa.
+		// Across different choices, independent carries are expected and valid
+		// (multiple choices may stream content simultaneously in separate lanes).
+		// Validate cross-lane constraints BEFORE processing so the operation is
+		// transactional: detect violations before emitting anything.
+		if hasDeltaToolCalls {
+			if err := s.checkCrossLane(choiceIdx, true, nil); err != nil {
+				s.aborted = true
+				return nil, false, err
+			}
+		}
+
+		// Reverse cross-lane check: when emitting content for this choice, verify
+		// that no tool-call lane of the SAME choice holds a non-empty argsCarry.
+		// This is the symmetric rule to checkCrossLane(emittingTool=true): if a
+		// tool argument carry is live, a content delta in the same choice is a
+		// cross-lane violation. Cross-CHOICE carries are independent and must not
+		// block each other.
+		if activeContentFields > 0 && cc.toolCalls != nil {
+			for _, tc := range cc.toolCalls {
+				if len(tc.argsCarry) > 0 {
+					s.aborted = true
+					return nil, false, errStreamAborted
+				}
+			}
+		}
+
 		// Process content through the rolling buffer.
-		if activeFields > 0 {
+		if activeContentFields > 0 {
 			emitLines, err := s.pushContent(choiceIdx, cc, contentStr)
 			if err != nil {
 				s.aborted = true
 				return nil, false, err
 			}
 			out = append(out, emitLines...)
+		}
+
+		// Process tool_calls delta.
+		if hasDeltaToolCalls {
+			toolLines, err := s.handleToolCallsDelta(choiceIdx, cc, rawToolCallsJSON)
+			if err != nil {
+				s.aborted = true
+				return nil, false, err
+			}
+			out = append(out, toolLines...)
 		}
 
 		// Process finish_reason.
@@ -579,12 +862,31 @@ func (s *StreamRestorer) handleChoices(rawChoices []jsonx.RawMessage) ([][]byte,
 				s.aborted = true
 				return nil, false, errStreamAborted
 			}
+			// Additional gate: "tool_calls" finish_reason requires that at least
+			// one fully-validated tool-call element was processed for this choice.
+			// Without this gate, the Anthropic adapter's translated tool_use→tool_calls
+			// finish_reason would slip through even though sawToolCall is false.
+			if reason == "tool_calls" && !cc.sawToolCall {
+				s.aborted = true
+				return nil, false, errStreamAborted
+			}
+			// Conversely: a choice that processed tool calls must finish with
+			// "tool_calls", not silently accept "stop" or any other reason.
+			if cc.sawToolCall && reason != "tool_calls" {
+				s.aborted = true
+				return nil, false, errStreamAborted
+			}
 			cc.finished = true
-			// Carry must be empty here by the rolling-buffer invariant. If it
-			// is not empty, the upstream truncated a pseudonym.
+			// All carries for this choice must be empty at finish time.
 			if len(cc.carry) > 0 {
 				s.aborted = true
 				return nil, false, errCarryNotEmpty
+			}
+			for _, tc := range cc.toolCalls {
+				if len(tc.argsCarry) > 0 {
+					s.aborted = true
+					return nil, false, errCarryNotEmpty
+				}
 			}
 			// Emit the finish chunk immediately.
 			line, err := s.buildFinishChunk(choiceIdx, cc.role, reason)
@@ -598,6 +900,325 @@ func (s *StreamRestorer) handleChoices(rawChoices []jsonx.RawMessage) ([][]byte,
 	}
 
 	return out, false, nil
+}
+
+// checkCrossLane enforces the within-choice cross-lane carry ownership invariant.
+// A pseudonym always lies entirely within one lane (content-kind or tool-index)
+// of a given choice. While the content carry for a choice is non-empty, emitting
+// from a tool-call lane of the SAME choice must fail-closed, and vice versa.
+// Across different choices, independent carries are expected and valid.
+//
+// emittingTool must be true when the caller is processing a tool_calls delta for
+// choiceIdx. toolIndices (if non-nil) lists the tool indices being written in
+// this chunk; any OTHER tool index for the same choice with a non-empty carry is
+// a cross-lane violation.
+//
+// This function only detects cross-lane violations within choiceIdx. Intra-lane
+// content continuation (same choice, same field kind) is always allowed.
+func (s *StreamRestorer) checkCrossLane(choiceIdx int, emittingTool bool, toolIndices []int) error {
+	cc, ok := s.choices[choiceIdx]
+	if !ok {
+		return nil
+	}
+	if emittingTool {
+		// Content carry and tool carry are different lanes within the same choice.
+		// If the content carry is non-empty, emitting a tool_calls delta is
+		// cross-lane — fail-closed.
+		if len(cc.carry) > 0 {
+			return errStreamAborted
+		}
+		// If emitting for specific tool indices, verify no OTHER tool index for
+		// this choice holds a non-empty argsCarry.
+		if len(toolIndices) > 0 && len(cc.toolCalls) > 0 {
+			emittingSet := make(map[int]struct{}, len(toolIndices))
+			for _, ti := range toolIndices {
+				emittingSet[ti] = struct{}{}
+			}
+			for ti, tc := range cc.toolCalls {
+				if _, active := emittingSet[ti]; active {
+					continue
+				}
+				if len(tc.argsCarry) > 0 {
+					return errStreamAborted
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// parsedToolElement holds the fully-decoded fields of one tool_calls delta
+// element after validation. It is populated during the validation pass in
+// handleToolCallsDelta and consumed during the emit pass.
+type parsedToolElement struct {
+	toolIdx int
+	// argsFragment is the decoded Go string value of the arguments field.
+	// hasArgs is true when the arguments key was present in the JSON; when
+	// false, argsFragment is the zero string and argsRaw is nil.
+	hasArgs      bool
+	argsFragment string
+}
+
+// handleToolCallsDelta processes the raw JSON of a delta.tool_calls array for
+// the given choice. It parses each element, validates the header state machine,
+// applies the rolling-buffer hold-back to function.arguments, and emits
+// synthesized tool_calls chunks.
+func (s *StreamRestorer) handleToolCallsDelta(choiceIdx int, cc *choiceCarry, rawJSON jsonx.RawMessage) ([][]byte, error) {
+	// Validate that the value is a JSON array, not null or any other type.
+	// A null tool_calls key ("tool_calls": null) is a protocol violation:
+	// key presence signals tool-call intent, and null is not an array.
+	// An empty array ("tool_calls": []) is similarly a protocol violation:
+	// the upstream is signaling tool-call intent with no actual tool calls.
+	// Both cases are fail-closed to prevent ambiguity.
+	trimmed := bytes.TrimSpace(rawJSON)
+	if len(trimmed) == 0 || trimmed[0] != '[' {
+		return nil, errStreamAborted
+	}
+
+	// Parse as array — fail-closed if unparseable.
+	var elements []rawToolCall
+	if err := jsonx.Unmarshal(rawJSON, &elements); err != nil {
+		return nil, errStreamAborted
+	}
+
+	// An empty array is a protocol violation (see comment above).
+	if len(elements) == 0 {
+		return nil, errStreamAborted
+	}
+
+	// Enforce per-choice distinct-tool-call cap.
+	if cc.toolCalls == nil {
+		cc.toolCalls = make(map[int]*toolCallCarry)
+	}
+
+	// Validate all elements before emitting anything (transactional).
+	// seenInChunk detects duplicate indices within THIS chunk's tool_calls array.
+	seenInChunk := make(map[int]struct{}, len(elements))
+	// toolIndicesInChunk collects all tool indices referenced in this chunk
+	// for the cross-lane ownership check.
+	toolIndicesInChunk := make([]int, 0, len(elements))
+	// parsed holds the per-element decoded state built during validation and
+	// used in the emit pass to avoid re-parsing.
+	parsed := make([]parsedToolElement, len(elements))
+
+	for i := range elements {
+		el := &elements[i]
+		// Index is required.
+		if el.Index == nil {
+			return nil, errStreamAborted
+		}
+		toolIdx := *el.Index
+		if toolIdx < 0 || toolIdx >= maxToolCallsPerChoice {
+			return nil, errStreamAborted
+		}
+		// Duplicate index within this chunk is a protocol violation.
+		if _, dup := seenInChunk[toolIdx]; dup {
+			return nil, errStreamAborted
+		}
+		seenInChunk[toolIdx] = struct{}{}
+		toolIndicesInChunk = append(toolIndicesInChunk, toolIdx)
+		parsed[i].toolIdx = toolIdx
+
+		// Parse the function field as both a typed struct (for Name) and a raw
+		// key-presence map (for arguments null-vs-absent detection). Both parses
+		// target the same bytes; the raw map parse is authoritative for argument
+		// validation because sonic maps JSON null → nil *string, making a *string
+		// Arguments field unable to distinguish null from absent.
+		var fnName *string
+		var fnRawMap map[string]jsonx.RawMessage
+		if el.Function != nil {
+			var fnStruct rawToolCallFunction
+			if err := jsonx.Unmarshal(*el.Function, &fnStruct); err != nil {
+				return nil, errStreamAborted
+			}
+			fnName = fnStruct.Name
+			if err := jsonx.Unmarshal(*el.Function, &fnRawMap); err != nil {
+				return nil, errStreamAborted
+			}
+		}
+
+		tc, exists := cc.toolCalls[toolIdx]
+		if !exists {
+			// First observation of this index: enforce per-choice cap.
+			if len(cc.toolCalls) >= maxToolCallsPerChoice {
+				return nil, errStreamAborted
+			}
+			// Enforce global tool-call cap across all choices.
+			if s.totalToolCalls >= maxToolCallsTotal {
+				return nil, errStreamAborted
+			}
+			// First observation requires non-empty id, type=="function", function.name.
+			if el.ID == nil || *el.ID == "" {
+				return nil, errStreamAborted
+			}
+			if el.Type == nil || *el.Type != "function" {
+				return nil, errStreamAborted
+			}
+			if fnName == nil || *fnName == "" {
+				return nil, errStreamAborted
+			}
+			id := *el.ID
+			name := *fnName
+			// Validate id: must use only the conservative charset [A-Za-z0-9_.+-]
+			// and must not contain a PII_ marker or canonical pseudonym shape.
+			// Characters outside the charset (e.g. '@', spaces, ':', non-ASCII) can
+			// carry PII and are always fail-closed. Length is capped at maxToolIDLen.
+			if len(id) > maxToolIDLen {
+				return nil, errStreamAborted
+			}
+			if !toolIDCharsetRe.MatchString(id) {
+				return nil, errStreamAborted
+			}
+			if strings.Contains(id, pseudonymMarker) || isCanonicalPseudonym(id) {
+				return nil, errStreamAborted
+			}
+			// Validate name: same conservative charset and PII checks.
+			if len(name) > maxToolNameLen {
+				return nil, errStreamAborted
+			}
+			if !toolNameCharsetRe.MatchString(name) {
+				return nil, errStreamAborted
+			}
+			if strings.Contains(name, pseudonymMarker) || isCanonicalPseudonym(name) {
+				return nil, errStreamAborted
+			}
+			tc = &toolCallCarry{id: id, name: name}
+			cc.toolCalls[toolIdx] = tc
+			s.totalToolCalls++
+		} else {
+			// Subsequent fragment: id/type/name must be absent (nil pointer) or an
+			// exact repeat of the stored value. A present-but-empty string (non-nil
+			// pointer to "") is "present but empty" and is treated as a protocol
+			// violation — fail-closed — because a present key with an empty value is
+			// structurally anomalous and distinct from a legitimately absent key.
+			if el.ID != nil {
+				if *el.ID == "" || *el.ID != tc.id {
+					return nil, errStreamAborted
+				}
+			}
+			if el.Type != nil {
+				if *el.Type == "" || *el.Type != "function" {
+					return nil, errStreamAborted
+				}
+			}
+			if fnName != nil {
+				if *fnName == "" || *fnName != tc.name {
+					return nil, errStreamAborted
+				}
+			}
+		}
+
+		// Validate the arguments field. Use the raw function map to detect
+		// presence and type of the "arguments" key:
+		//   - key absent:          header-only fragment — valid, no arguments processing.
+		//   - key present + null:  fail-closed (JSON null is not a valid string).
+		//   - key present + string: decode and use as the fragment.
+		//   - key present + other (number, object, array, bool): fail-closed.
+		if rawArgsVal, argsKeyPresent := fnRawMap["arguments"]; argsKeyPresent {
+			trimmedArgs := bytes.TrimSpace(rawArgsVal)
+			// JSON null → fail-closed.
+			if bytes.Equal(trimmedArgs, []byte("null")) {
+				return nil, errStreamAborted
+			}
+			// Must be a JSON string (starts with '"').
+			if len(trimmedArgs) < 2 || trimmedArgs[0] != '"' {
+				return nil, errStreamAborted
+			}
+			// Unmarshal as string to confirm it is a valid JSON string value.
+			var argStr string
+			if err := jsonx.Unmarshal(rawArgsVal, &argStr); err != nil {
+				return nil, errStreamAborted
+			}
+			parsed[i].hasArgs = true
+			parsed[i].argsFragment = argStr
+		}
+	}
+
+	// Cross-lane check: verify that no OTHER tool index for this choice has a
+	// non-empty carry while we are emitting for toolIndicesInChunk.
+	if err := s.checkCrossLane(choiceIdx, true, toolIndicesInChunk); err != nil {
+		return nil, err
+	}
+
+	// Now emit: all validation above passed.
+	var out [][]byte
+	for i := range elements {
+		toolIdx := parsed[i].toolIdx
+		tc := cc.toolCalls[toolIdx]
+
+		// Only process arguments if the key was present in the JSON.
+		if !parsed[i].hasArgs {
+			// Header-only fragment (arguments key absent): emit header chunk if not yet sent.
+			if !tc.headerSent {
+				line, err := s.buildToolCallChunk(choiceIdx, toolIdx, cc, tc, "")
+				if err != nil {
+					return nil, errStreamAborted
+				}
+				out = append(out, line, nil)
+				tc.headerSent = true
+				cc.roleSent = true
+				cc.sawToolCall = true
+			}
+			continue
+		}
+
+		fragment := parsed[i].argsFragment
+
+		// Append fragment to argsCarry.
+		before := len(tc.argsCarry)
+		tc.argsCarry = append(tc.argsCarry, fragment...)
+		s.totalCarryBytes += len(tc.argsCarry) - before
+
+		if s.totalCarryBytes > maxPIIStreamBytes {
+			return nil, errStreamAborted
+		}
+
+		// Apply the same hold-back as content.
+		L := s.longestPseudonymPrefixSuffix(tc.argsCarry)
+		B := len(tc.argsCarry) - L
+
+		if B <= 0 {
+			// Nothing safe to emit yet; emit header if not yet sent.
+			if !tc.headerSent {
+				line, err := s.buildToolCallChunk(choiceIdx, toolIdx, cc, tc, "")
+				if err != nil {
+					return nil, errStreamAborted
+				}
+				out = append(out, line, nil)
+				tc.headerSent = true
+				cc.roleSent = true
+				cc.sawToolCall = true
+			}
+			continue
+		}
+
+		safe := tc.argsCarry[:B]
+		restored := string(s.filter.Restore(safe))
+
+		// Residual scan: detect a canonical or sub-canonical PII_ token spanning
+		// the boundary between the last emission and this fragment. Both canonical
+		// and sub-canonical tokens in tool arguments are fail-closed.
+		if err := residualScan(&tc.emittedTail, restored, true); err != nil {
+			return nil, err
+		}
+
+		// Advance carry.
+		carry := tc.argsCarry[B:]
+		tc.argsCarry = make([]byte, len(carry))
+		copy(tc.argsCarry, carry)
+		s.totalCarryBytes -= B
+
+		line, err := s.buildToolCallChunk(choiceIdx, toolIdx, cc, tc, restored)
+		if err != nil {
+			return nil, errStreamAborted
+		}
+		out = append(out, line, nil)
+		tc.headerSent = true
+		cc.roleSent = true
+		cc.sawToolCall = true
+	}
+
+	return out, nil
 }
 
 // pushContent appends content to the per-choice carry and emits safe bytes.
@@ -632,9 +1253,16 @@ func (s *StreamRestorer) pushContent(choiceIdx int, cc *choiceCarry, content str
 	copy(cc.carry, carry)
 	s.totalCarryBytes -= B
 
+	// Residual scan: detect a canonical or sub-canonical PII_ token spanning
+	// the boundary between the last emission and this fragment. For content:
+	// canonical tokens → fail-closed; sub-canonical → count-only, pass through.
+	restoredStr := string(restored)
+	if err := residualScan(&cc.emittedTail, restoredStr, false); err != nil {
+		return nil, err
+	}
+
 	// Build SSE output lines.
-	contentChunk := string(restored)
-	line, err := s.buildContentChunk(choiceIdx, cc, contentChunk)
+	line, err := s.buildContentChunk(choiceIdx, cc, restoredStr)
 	if err != nil {
 		return nil, errStreamAborted
 	}
@@ -778,6 +1406,36 @@ type sseFinishChoiceCompletion struct {
 	FinishReason string `json:"finish_reason"`
 }
 
+// sseToolCallFunction is the typed function field inside a synthesized tool_calls delta.
+type sseToolCallFunction struct {
+	// Name is emitted only on the first chunk for a given tool-call index.
+	Name      string `json:"name,omitempty"`
+	Arguments string `json:"arguments"`
+}
+
+// sseToolCallElement is one element of the tool_calls array in a synthesized delta.
+// ID and Type are emitted only on the first chunk for a given tool-call index
+// (headerSent=false before emission); subsequent chunks omit them.
+type sseToolCallElement struct {
+	Index    int                 `json:"index"`
+	ID       string              `json:"id,omitempty"`
+	Type     string              `json:"type,omitempty"`
+	Function sseToolCallFunction `json:"function"`
+}
+
+// sseDeltaToolCalls is the typed delta for a tool_calls chunk.
+type sseDeltaToolCalls struct {
+	Role      string               `json:"role,omitempty"`
+	ToolCalls []sseToolCallElement `json:"tool_calls"`
+}
+
+// sseToolCallsChoice is a typed chat-completion choice carrying a tool_calls delta.
+type sseToolCallsChoice struct {
+	Index        int               `json:"index"`
+	Delta        sseDeltaToolCalls `json:"delta"`
+	FinishReason *string           `json:"finish_reason"`
+}
+
 // whitelistedUsage contains only the fields we re-emit from upstream usage chunks.
 type whitelistedUsage struct {
 	PromptTokens     int `json:"prompt_tokens"`
@@ -831,6 +1489,70 @@ func (s *StreamRestorer) buildContentChunk(choiceIdx int, cc *choiceCarry, conte
 		Created: s.created,
 		Model:   s.modelName,
 		Choices: choices,
+	}
+
+	payload, err := jsonx.Marshal(env)
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte("data: "), payload...), nil
+}
+
+// buildToolCallChunk builds a data: SSE line carrying a tool_calls delta for
+// the given (choice index, tool-call index). The arguments field is set to the
+// already-restored string fragment (may be empty for header-only chunks). The
+// envelope (id, object, created, model) is synthesized locally — never copied
+// from the upstream response — to prevent pseudonym echo.
+//
+// On the first chunk for a given tool-call index (tc.headerSent==false), the
+// id, type, and function.name fields are emitted. On subsequent chunks they are
+// omitted (empty omitempty fields). The arguments fragment is always included,
+// even when empty, so the client receives complete JSON framing.
+//
+// Role synthesis: if this is the first emitted chunk for the choice
+// (cc.roleSent==false), the synthesized role "assistant" is included in the
+// delta — regardless of whether the upstream sent a role field. The upstream
+// role value is never echoed. Subsequent chunks omit the role (cc.roleSent is
+// set to true by the caller immediately after this function returns).
+func (s *StreamRestorer) buildToolCallChunk(choiceIdx int, toolIdx int, cc *choiceCarry, tc *toolCallCarry, argsFragment string) ([]byte, error) {
+	// Build the tool call element.
+	elem := sseToolCallElement{
+		Index: toolIdx,
+		Function: sseToolCallFunction{
+			Arguments: argsFragment,
+		},
+	}
+	if !tc.headerSent {
+		// Emit header fields only on the first chunk for this tool-call index.
+		elem.ID = tc.id
+		elem.Type = "function"
+		elem.Function.Name = tc.name
+	}
+
+	// Synthesize "assistant" role on the first emitted chunk for this choice.
+	// The upstream role value is never used — we always synthesize "assistant".
+	// This ensures tool-only streams deliver role:"assistant" to the client on
+	// the very first chunk, consistent with content streams.
+	role := ""
+	if !cc.roleSent {
+		role = "assistant"
+	}
+
+	delta := sseDeltaToolCalls{
+		Role:      role,
+		ToolCalls: []sseToolCallElement{elem},
+	}
+
+	env := sseEnvelope{
+		ID:      s.chunkID,
+		Object:  "chat.completion.chunk",
+		Created: s.created,
+		Model:   s.modelName,
+		Choices: []sseToolCallsChoice{{
+			Index:        choiceIdx,
+			Delta:        delta,
+			FinishReason: nil,
+		}},
 	}
 
 	payload, err := jsonx.Marshal(env)

--- a/internal/pii/stream_restorer_test.go
+++ b/internal/pii/stream_restorer_test.go
@@ -877,19 +877,17 @@ func TestStreamRestorer_FunctionCall_FailClosed(t *testing.T) {
 	}
 }
 
-// TestStreamRestorer_ToolCalls_FailClosed verifies that delta.tool_calls
-// (even an empty array []) causes errStreamAborted.
-func TestStreamRestorer_ToolCalls_FailClosed(t *testing.T) {
+// TestStreamRestorer_ToolCalls_InvalidShape_FailClosed verifies that malformed
+// or semantically invalid delta.tool_calls shapes cause errStreamAborted.
+// Stage 0c handles well-formed non-empty tool_calls arrays; this test covers
+// the shapes that remain fail-closed after Stage 0c.
+func TestStreamRestorer_ToolCalls_InvalidShape_FailClosed(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name    string
 		dataStr string
 	}{
-		{
-			name:    "non-empty tool_calls",
-			dataStr: `data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"c1","type":"function","function":{"name":"search","arguments":""}}]},"finish_reason":null}]}`,
-		},
 		{
 			name:    "empty tool_calls array",
 			dataStr: `data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[]},"finish_reason":null}]}`,

--- a/internal/pii/stream_stage0c_test.go
+++ b/internal/pii/stream_stage0c_test.go
@@ -1,0 +1,2033 @@
+package pii
+
+// stream_stage0c_test.go covers Stage 0c: streaming tool-call argument restore
+// (feat/pii-stage0c-streaming-tool-calls).
+//
+// The test matrix follows the plan at
+// issues/L-016c-stage0c-streaming-tool-call-restore-plan.md §Test matrix.
+// Each numbered section below maps to a matrix item.
+//
+// Helper conventions (from stream_restorer_test.go):
+//   - realPseudonym(t, email) → (pseudonym string, *Filter) with filter.rev populated.
+//   - pushAllCollect(r, lines) → (output string, wasTerminal bool, finalErr error)
+//   - pushLines(t, r, lines) → (output string, finalErr error)
+//   - chatChunk / finishChunk / doneLines from stream_restorer_test.go
+//
+// New helpers defined below:
+//   - toolChunkHeader — first delta for a tool-call index (id, type, name, args)
+//   - toolChunkArgs   — subsequent argument fragment for a tool-call index
+//   - toolFinish      — finish_reason:"tool_calls" chunk
+//   - extractToolArgs — concatenate all arguments fragments from emitted lines
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// ── tool-call chunk builders ──────────────────────────────────────────────────
+
+// toolChunkHeader builds the first SSE data line for a tool call, containing
+// all header fields (id, type, function.name) and an optional arguments fragment.
+func toolChunkHeader(choiceIdx, toolIdx int, id, name, args string) string {
+	return fmt.Sprintf(
+		`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":%d,"delta":{"tool_calls":[{"index":%d,"id":%s,"type":"function","function":{"name":%s,"arguments":%s}}]},"finish_reason":null}]}`,
+		choiceIdx, toolIdx, jsonStr(id), jsonStr(name), jsonStr(args),
+	)
+}
+
+// toolChunkArgs builds a continuation SSE data line for a tool call, containing
+// only the arguments fragment (no header fields).
+func toolChunkArgs(choiceIdx, toolIdx int, args string) string {
+	return fmt.Sprintf(
+		`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":%d,"delta":{"tool_calls":[{"index":%d,"function":{"arguments":%s}}]},"finish_reason":null}]}`,
+		choiceIdx, toolIdx, jsonStr(args),
+	)
+}
+
+// toolFinish builds a finish_reason:"tool_calls" SSE data line.
+func toolFinish(choiceIdx int) string {
+	return fmt.Sprintf(
+		`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":%d,"delta":{},"finish_reason":"tool_calls"}]}`,
+		choiceIdx,
+	)
+}
+
+// extractAllToolArgs parses every emitted SSE data line and concatenates all
+// function.arguments values across all tool_calls[0] elements in emission order.
+// Returns the concatenated string and the set of emitted tool-call ids.
+func extractAllToolArgs(output string) (args string, ids []string) {
+	var sb strings.Builder
+	seenIDs := make(map[string]bool)
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.HasPrefix(line, "data: ") || strings.Contains(line, "[DONE]") {
+			continue
+		}
+		payload := line[len("data: "):]
+		var chunk struct {
+			Choices []struct {
+				Delta struct {
+					ToolCalls []struct {
+						ID       string `json:"id"`
+						Function struct {
+							Arguments string `json:"arguments"`
+						} `json:"function"`
+					} `json:"tool_calls"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			continue
+		}
+		for _, ch := range chunk.Choices {
+			for _, tc := range ch.Delta.ToolCalls {
+				sb.WriteString(tc.Function.Arguments)
+				if tc.ID != "" && !seenIDs[tc.ID] {
+					seenIDs[tc.ID] = true
+					ids = append(ids, tc.ID)
+				}
+			}
+		}
+	}
+	return sb.String(), ids
+}
+
+// extractToolArgsByIndex parses emitted SSE lines and returns per-tool-index
+// concatenated arguments as a map[toolIdx]string.
+func extractToolArgsByIndex(output string) map[int]string {
+	result := make(map[int]string)
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.HasPrefix(line, "data: ") || strings.Contains(line, "[DONE]") {
+			continue
+		}
+		payload := line[len("data: "):]
+		var chunk struct {
+			Choices []struct {
+				Delta struct {
+					ToolCalls []struct {
+						Index    int `json:"index"`
+						Function struct {
+							Arguments string `json:"arguments"`
+						} `json:"function"`
+					} `json:"tool_calls"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			continue
+		}
+		for _, ch := range chunk.Choices {
+			for _, tc := range ch.Delta.ToolCalls {
+				result[tc.Index] += tc.Function.Arguments
+			}
+		}
+	}
+	return result
+}
+
+// ── Matrix 1: Split a pseudonym across tool_call arguments at every byte position
+
+// TestToolCall_SplitAtEveryPosition verifies that a pseudonym inside
+// function.arguments split at every position (1..pseudonymLen-1) is fully
+// restored without emitting any PII_ fragment.
+func TestToolCall_SplitAtEveryPosition(t *testing.T) {
+	t.Parallel()
+
+	pseudo, f := realPseudonym(t, "toolsplit@example.com")
+	orig := f.rev[pseudo]
+	// Pre-warm replacer so parallel subtests only read (no write race).
+	f.Restore([]byte(pseudo))
+
+	for splitAt := 1; splitAt < pseudonymLen; splitAt++ {
+		splitAt := splitAt
+		t.Run(fmt.Sprintf("split_at_%d", splitAt), func(t *testing.T) {
+			t.Parallel()
+
+			part1 := pseudo[:splitAt]
+			part2 := pseudo[splitAt:]
+
+			r := NewStreamRestorer(f, "gpt-4o")
+			lines := []string{
+				toolChunkHeader(0, 0, "call_abc", "get_user", part1),
+				"",
+				toolChunkArgs(0, 0, part2),
+				"",
+				toolFinish(0),
+				"",
+			}
+			lines = append(lines, doneLines()...)
+
+			output, _, err := pushAllCollect(r, lines)
+			if err != nil {
+				t.Fatalf("split_at_%d: Push error: %v", splitAt, err)
+			}
+
+			// No PII_ must appear anywhere in the output.
+			if strings.Contains(output, "PII_") {
+				t.Errorf("split_at_%d: PII_ fragment in output:\n%s", splitAt, output)
+			}
+
+			// The original value must appear in the concatenated arguments.
+			allArgs, _ := extractAllToolArgs(output)
+			if !strings.Contains(allArgs, orig) {
+				t.Errorf("split_at_%d: restored original %q missing from tool args %q", splitAt, orig, allArgs)
+			}
+
+			// Multiple chunks must have been emitted (incremental delivery).
+			dataCount := 0
+			for _, line := range strings.Split(output, "\n") {
+				if strings.HasPrefix(line, "data: ") && !strings.Contains(line, "[DONE]") {
+					dataCount++
+				}
+			}
+			if dataCount < 2 {
+				t.Errorf("split_at_%d: expected incremental output (>=2 data: chunks), got %d", splitAt, dataCount)
+			}
+		})
+	}
+}
+
+// ── Matrix 2: Multiple parallel tool calls, both with split pseudonyms ────────
+
+// TestToolCall_ParallelToolCalls verifies that two parallel tool calls (indices
+// 0 and 1) each with a pseudonym split at different positions are both fully
+// restored, with indices preserved.
+func TestToolCall_ParallelToolCalls(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"alice@parallel.example bob@parallel.example"}]}`)
+	if _, err := f.AnonymizeJSON(body); err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	var alicePseudo, bobPseudo string
+	for p, orig := range f.rev {
+		if orig == "alice@parallel.example" {
+			alicePseudo = p
+		}
+		if orig == "bob@parallel.example" {
+			bobPseudo = p
+		}
+	}
+	if alicePseudo == "" || bobPseudo == "" {
+		t.Fatalf("pseudonyms not found: alice=%q bob=%q", alicePseudo, bobPseudo)
+	}
+	// Pre-warm replacer.
+	f.Restore([]byte(alicePseudo + bobPseudo))
+
+	aliceOrig := f.rev[alicePseudo]
+	bobOrig := f.rev[bobPseudo]
+
+	// Split alice at position 8, bob at position 20.
+	const aliceSplit = 8
+	const bobSplit = 20
+
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	// Chunk 1: headers + first fragment for both tool calls.
+	chunk1 := fmt.Sprintf(
+		`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[`+
+			`{"index":0,"id":"call_alice","type":"function","function":{"name":"lookup_user","arguments":%s}},`+
+			`{"index":1,"id":"call_bob","type":"function","function":{"name":"lookup_email","arguments":%s}}`+
+			`]},"finish_reason":null}]}`,
+		jsonStr(alicePseudo[:aliceSplit]),
+		jsonStr(bobPseudo[:bobSplit]),
+	)
+	// Chunk 2: remainders for both tool calls.
+	chunk2 := fmt.Sprintf(
+		`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[`+
+			`{"index":0,"function":{"arguments":%s}},`+
+			`{"index":1,"function":{"arguments":%s}}`+
+			`]},"finish_reason":null}]}`,
+		jsonStr(alicePseudo[aliceSplit:]),
+		jsonStr(bobPseudo[bobSplit:]),
+	)
+
+	lines := []string{chunk1, "", chunk2, "", toolFinish(0), ""}
+	lines = append(lines, doneLines()...)
+
+	output, terminal, err := pushAllCollect(r, lines)
+	if err != nil {
+		t.Fatalf("Push error: %v", err)
+	}
+	if !terminal {
+		t.Error("stream did not reach terminal")
+	}
+
+	byIdx := extractToolArgsByIndex(output)
+
+	// Tool index 0: alice restored.
+	if !strings.Contains(byIdx[0], aliceOrig) {
+		t.Errorf("tool[0] args %q does not contain alice's original %q", byIdx[0], aliceOrig)
+	}
+	// Tool index 1: bob restored.
+	if !strings.Contains(byIdx[1], bobOrig) {
+		t.Errorf("tool[1] args %q does not contain bob's original %q", byIdx[1], bobOrig)
+	}
+
+	// No PII_ in output.
+	if strings.Contains(output, "PII_") {
+		t.Errorf("PII_ fragment in output:\n%s", output)
+	}
+}
+
+// ── Matrix 3: Header validation ───────────────────────────────────────────────
+
+// TestToolCall_HeaderValidation covers the strict header state machine:
+// PII_ in id → fail-closed; PII_ in name → fail-closed; type != "function" →
+// fail-closed; missing/empty id → fail-closed; missing/empty name → fail-closed;
+// arguments before header → fail-closed; changed id → fail-closed; changed name →
+// fail-closed; id forwarded verbatim.
+func TestToolCall_HeaderValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		lines     func(pseudo string) []string
+		wantErr   error
+		checkLine func(t *testing.T, output string, pseudo string)
+	}{
+		{
+			name: "pii_marker_in_id_fail_closed",
+			lines: func(pseudo string) []string {
+				// id contains the full pseudonym (canonical shape).
+				line := fmt.Sprintf(
+					`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":%s,"type":"function","function":{"name":"fn","arguments":"{}"}}]},"finish_reason":null}]}`,
+					jsonStr(pseudo),
+				)
+				return []string{line, ""}
+			},
+			wantErr: errStreamAborted,
+		},
+		{
+			name: "pii_marker_in_name_fail_closed",
+			lines: func(pseudo string) []string {
+				// name contains the full pseudonym.
+				line := fmt.Sprintf(
+					`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"name":%s,"arguments":"{}"}}]},"finish_reason":null}]}`,
+					jsonStr(pseudo),
+				)
+				return []string{line, ""}
+			},
+			wantErr: errStreamAborted,
+		},
+		{
+			name: "pii_prefix_only_in_id_fail_closed",
+			lines: func(_ string) []string {
+				// id contains sub-canonical "PII_" marker (not a full canonical pseudonym).
+				line := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"PII_marker","type":"function","function":{"name":"fn","arguments":"{}"}}]},"finish_reason":null}]}`
+				return []string{line, ""}
+			},
+			wantErr: errStreamAborted,
+		},
+		{
+			name: "type_not_function_fail_closed",
+			lines: func(_ string) []string {
+				line := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","type":"retrieval","function":{"name":"fn","arguments":"{}"}}]},"finish_reason":null}]}`
+				return []string{line, ""}
+			},
+			wantErr: errStreamAborted,
+		},
+		{
+			name: "missing_id_on_first_observation_fail_closed",
+			lines: func(_ string) []string {
+				line := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"name":"fn","arguments":"{}"}}]},"finish_reason":null}]}`
+				return []string{line, ""}
+			},
+			wantErr: errStreamAborted,
+		},
+		{
+			name: "empty_id_on_first_observation_fail_closed",
+			lines: func(_ string) []string {
+				line := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"","type":"function","function":{"name":"fn","arguments":"{}"}}]},"finish_reason":null}]}`
+				return []string{line, ""}
+			},
+			wantErr: errStreamAborted,
+		},
+		{
+			name: "missing_name_on_first_observation_fail_closed",
+			lines: func(_ string) []string {
+				line := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"arguments":"{}"}}]},"finish_reason":null}]}`
+				return []string{line, ""}
+			},
+			wantErr: errStreamAborted,
+		},
+		{
+			name: "empty_name_on_first_observation_fail_closed",
+			lines: func(_ string) []string {
+				line := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"name":"","arguments":"{}"}}]},"finish_reason":null}]}`
+				return []string{line, ""}
+			},
+			wantErr: errStreamAborted,
+		},
+		{
+			name: "changed_id_on_subsequent_fragment_fail_closed",
+			lines: func(_ string) []string {
+				// First: valid header.
+				first := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_orig","type":"function","function":{"name":"fn","arguments":""}}]},"finish_reason":null}]}`
+				// Second: same index, DIFFERENT id.
+				second := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_different","function":{"arguments":""}}]},"finish_reason":null}]}`
+				return []string{first, "", second, ""}
+			},
+			wantErr: errStreamAborted,
+		},
+		{
+			name: "changed_name_on_subsequent_fragment_fail_closed",
+			lines: func(_ string) []string {
+				first := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"name":"fn_orig","arguments":""}}]},"finish_reason":null}]}`
+				second := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"fn_different","arguments":""}}]},"finish_reason":null}]}`
+				return []string{first, "", second, ""}
+			},
+			wantErr: errStreamAborted,
+		},
+		{
+			name: "id_forwarded_verbatim",
+			lines: func(_ string) []string {
+				return []string{
+					toolChunkHeader(0, 0, "call_verbatim_id", "fn", `"hello"`),
+					"",
+					toolFinish(0),
+					"",
+					"data: [DONE]",
+					"",
+				}
+			},
+			wantErr: nil,
+			checkLine: func(t *testing.T, output string, _ string) {
+				t.Helper()
+				// The emitted id must be the upstream verbatim id, not restored.
+				_, ids := extractAllToolArgs(output)
+				found := false
+				for _, id := range ids {
+					if id == "call_verbatim_id" {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("verbatim id 'call_verbatim_id' not found in emitted tool_calls output:\n%s", output)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pseudo, f := realPseudonym(t, "headerval@example.com")
+			f.Restore([]byte(pseudo)) // pre-warm
+
+			r := NewStreamRestorer(f, "gpt-4o")
+			lines := tc.lines(pseudo)
+
+			output, _, finalErr := pushAllCollect(r, lines)
+			if tc.wantErr != nil {
+				if !errors.Is(finalErr, tc.wantErr) {
+					t.Errorf("%s: error = %v, want %v", tc.name, finalErr, tc.wantErr)
+				}
+				// No PII_ must be visible even on error path.
+				if strings.Contains(output, "PII_") {
+					t.Errorf("%s: PII_ visible on error path: %s", tc.name, output)
+				}
+			} else {
+				if finalErr != nil {
+					t.Errorf("%s: unexpected error: %v", tc.name, finalErr)
+				}
+				if tc.checkLine != nil {
+					tc.checkLine(t, output, pseudo)
+				}
+			}
+		})
+	}
+}
+
+// ── Matrix 4: Format-transition guard ─────────────────────────────────────────
+
+// TestToolCall_FormatGuard verifies that tool_calls is only accepted when the
+// choice format is formatUnknown or formatChat. formatCompletion and
+// formatRefusal choices must reject tool_calls with errStreamAborted.
+func TestToolCall_FormatGuard(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		setup []string
+	}{
+		{
+			name: "completion_then_tool_calls_fail_closed",
+			setup: []string{
+				// First: legacy text chunk → format becomes formatCompletion.
+				textChunk(0, "hello world"),
+				"",
+			},
+		},
+		{
+			name: "refusal_then_tool_calls_fail_closed",
+			setup: []string{
+				// First: refusal delta → format becomes formatRefusal.
+				`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"refusal":"I cannot"},"finish_reason":null}]}`,
+				"",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, f := realPseudonym(t, "fmtguard@example.com")
+			r := NewStreamRestorer(f, "gpt-4o")
+
+			// Push setup lines (should succeed).
+			for _, l := range tc.setup {
+				var raw []byte
+				if l == "" {
+					raw = []byte{}
+				} else {
+					raw = []byte(l)
+				}
+				if _, _, err := r.Push(raw); err != nil {
+					t.Fatalf("%s: setup push error: %v (line=%q)", tc.name, err, l)
+				}
+			}
+
+			// Now push a tool_calls chunk — must fail-closed.
+			toolLine := toolChunkHeader(0, 0, "call_x", "fn", `""`)
+			_, _, err := r.Push([]byte(toolLine))
+			if !errors.Is(err, errStreamAborted) {
+				t.Errorf("%s: error = %v, want errStreamAborted", tc.name, err)
+			}
+		})
+	}
+
+	// Positive case: chat format accepts tool_calls.
+	t.Run("chat_then_tool_calls_ok", func(t *testing.T) {
+		t.Parallel()
+
+		_, f := realPseudonym(t, "fmtguardchat@example.com")
+		r := NewStreamRestorer(f, "gpt-4o")
+
+		// Push a chat content chunk first → format becomes formatChat.
+		if _, _, err := r.Push([]byte(chatChunk(0, "hi"))); err != nil {
+			t.Fatalf("setup chat chunk: %v", err)
+		}
+		r.Push([]byte{})
+
+		// Mixing chat content and tool_calls in same choice IS a violation (content + tool_calls).
+		// Instead, test a fresh choice index (1) after choice 0 has been set to chat.
+		// OR: test that a brand-new choice starting with tool_calls is accepted.
+		r2 := NewStreamRestorer(f, "gpt-4o")
+		toolLine := toolChunkHeader(0, 0, "call_x", "fn", `""`)
+		if _, _, err := r2.Push([]byte(toolLine)); err != nil {
+			t.Errorf("fresh choice with tool_calls: unexpected error: %v", err)
+		}
+	})
+}
+
+// ── Matrix 5: Cross-lane carry ownership ──────────────────────────────────────
+
+// TestToolCall_CrossLane verifies that a non-empty content carry in the same
+// choice blocks tool_calls emission (fail-closed), and a non-empty argsCarry
+// in tool index 0 blocks emission from tool index 1 in the same choice.
+// Cross-CHOICE independence: choice 0 with a carry must NOT block choice 1.
+func TestToolCall_CrossLane(t *testing.T) {
+	t.Parallel()
+
+	t.Run("content_carry_blocks_tool_calls_same_choice", func(t *testing.T) {
+		t.Parallel()
+
+		pseudo, f := realPseudonym(t, "crosslane1@example.com")
+		f.Restore([]byte(pseudo)) // pre-warm
+
+		r := NewStreamRestorer(f, "gpt-4o")
+
+		// Push partial pseudonym into content carry for choice 0.
+		partial := pseudo[:10]
+		if _, _, err := r.Push([]byte(chatChunk(0, partial))); err != nil {
+			t.Fatalf("push partial: %v", err)
+		}
+		r.Push([]byte{})
+
+		// Now push tool_calls for the same choice 0 — must fail-closed.
+		toolLine := toolChunkHeader(0, 0, "call_x", "fn", `""`)
+		_, _, err := r.Push([]byte(toolLine))
+		if !errors.Is(err, errStreamAborted) {
+			t.Errorf("content carry + tool_calls same choice: error = %v, want errStreamAborted", err)
+		}
+	})
+
+	t.Run("tool0_carry_blocks_tool1_same_choice", func(t *testing.T) {
+		t.Parallel()
+
+		pseudo, f := realPseudonym(t, "crosslane2@example.com")
+		f.Restore([]byte(pseudo)) // pre-warm
+
+		r := NewStreamRestorer(f, "gpt-4o")
+
+		// Push header + first fragment (partial pseudonym) for tool index 0 — stays in argsCarry.
+		part1 := pseudo[:10]
+		if _, _, err := r.Push([]byte(toolChunkHeader(0, 0, "call_0", "fn0", part1))); err != nil {
+			t.Fatalf("push tool0 header+partial: %v", err)
+		}
+		r.Push([]byte{})
+
+		// Now push a second tool call (index 1) in the same choice — must fail-closed
+		// because tool index 0's argsCarry is non-empty.
+		chunk := fmt.Sprintf(
+			`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[` +
+				`{"index":1,"id":"call_1","type":"function","function":{"name":"fn1","arguments":"hello"}}` +
+				`]},"finish_reason":null}]}`,
+		)
+		_, _, err := r.Push([]byte(chunk))
+		if !errors.Is(err, errStreamAborted) {
+			t.Errorf("tool0 carry + tool1 emit: error = %v, want errStreamAborted", err)
+		}
+	})
+
+	t.Run("cross_choice_independence", func(t *testing.T) {
+		t.Parallel()
+
+		// Choice 0 has a partial pseudonym in content carry.
+		// Choice 1 should still be able to emit tool_calls independently.
+		pseudo, f := realPseudonym(t, "crossindep@example.com")
+		f.Restore([]byte(pseudo)) // pre-warm
+
+		r := NewStreamRestorer(f, "gpt-4o")
+
+		// Push partial pseudonym for choice 0 content.
+		partial := pseudo[:10]
+		if _, _, err := r.Push([]byte(chatChunk(0, partial))); err != nil {
+			t.Fatalf("push choice0 partial: %v", err)
+		}
+		r.Push([]byte{})
+
+		// Push tool_calls for choice 1 — must succeed (different choice).
+		toolLine := toolChunkHeader(1, 0, "call_y", "fn", `"some_args"`)
+		_, _, err := r.Push([]byte(toolLine))
+		if err != nil {
+			t.Errorf("cross-choice independence: choice1 tool_calls unexpectedly failed: %v", err)
+		}
+	})
+}
+
+// ── Matrix 6: Index validation ────────────────────────────────────────────────
+
+// TestToolCall_IndexValidation covers index<0, index>=64, duplicate within one
+// chunk's array, same index across chunks (valid), and >64 distinct indices.
+func TestToolCall_IndexValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		lines   []string
+		wantErr error
+	}{
+		{
+			name: "negative_index_fail_closed",
+			lines: []string{
+				`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":-1,"id":"call_x","type":"function","function":{"name":"fn","arguments":""}}]},"finish_reason":null}]}`,
+				"",
+			},
+			wantErr: errStreamAborted,
+		},
+		{
+			name: "index_64_fail_closed",
+			lines: []string{
+				`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":64,"id":"call_x","type":"function","function":{"name":"fn","arguments":""}}]},"finish_reason":null}]}`,
+				"",
+			},
+			wantErr: errStreamAborted,
+		},
+		{
+			name: "duplicate_index_within_chunk_fail_closed",
+			lines: []string{
+				// Two elements with index=0 in the same tool_calls array.
+				`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"fa","arguments":""}},{"index":0,"id":"call_b","type":"function","function":{"name":"fb","arguments":""}}]},"finish_reason":null}]}`,
+				"",
+			},
+			wantErr: errStreamAborted,
+		},
+		{
+			name: "same_index_across_chunks_ok",
+			lines: []string{
+				// First chunk: tool index 0 header.
+				toolChunkHeader(0, 0, "call_ok", "fn", `"part1"`),
+				"",
+				// Second chunk: same tool index 0 continuation — valid.
+				toolChunkArgs(0, 0, `"part2"`),
+				"",
+				toolFinish(0),
+				"",
+				"data: [DONE]",
+				"",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "index_63_accepted",
+			lines: []string{
+				// Index 63 is the maximum valid value (0..63).
+				`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":63,"id":"call_x","type":"function","function":{"name":"fn","arguments":"hello"}}]},"finish_reason":null}]}`,
+				"",
+				// finish_reason for choice 0.
+				`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+				"",
+				"data: [DONE]",
+				"",
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, f := realPseudonym(t, "idxval@example.com")
+			r := NewStreamRestorer(f, "gpt-4o")
+
+			_, _, finalErr := pushAllCollect(r, tc.lines)
+			if tc.wantErr != nil {
+				if !errors.Is(finalErr, tc.wantErr) {
+					t.Errorf("%s: error = %v, want %v", tc.name, finalErr, tc.wantErr)
+				}
+			} else {
+				if finalErr != nil {
+					t.Errorf("%s: unexpected error: %v", tc.name, finalErr)
+				}
+			}
+		})
+	}
+}
+
+// TestToolCall_ExceedDistinctIndexCap verifies that more than maxToolCallsPerChoice
+// distinct tool indices for one choice causes fail-closed.
+func TestToolCall_ExceedDistinctIndexCap(t *testing.T) {
+	t.Parallel()
+
+	_, f := realPseudonym(t, "idxcap@example.com")
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	// Send maxToolCallsPerChoice=64 valid distinct tool indices one at a time.
+	for i := 0; i < maxToolCallsPerChoice; i++ {
+		line := fmt.Sprintf(
+			`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":%d,"id":"call_%d","type":"function","function":{"name":"fn_%d","arguments":"x"}}]},"finish_reason":null}]}`,
+			i, i, i,
+		)
+		if _, _, err := r.Push([]byte(line)); err != nil {
+			t.Fatalf("push tool index %d: unexpected error: %v", i, err)
+		}
+		r.Push([]byte{})
+	}
+
+	// Now push a 65th distinct tool index — must fail-closed.
+	// Note: indices 0..63 are all taken; any new index would require index>=64 which
+	// is already rejected by the range check. So this is actually caught by the range
+	// guard. The per-choice count cap (maxToolCallsPerChoice) is a secondary guard
+	// for when the index range is not exhausted but too many distinct entries exist.
+	// We test the count cap by artificially choosing a valid index that hasn't been seen.
+	// Since all indices 0..63 are valid and all 64 are taken, the only way to exceed
+	// the count cap is to try to add a 65th DISTINCT entry. All indices 0..63 are valid
+	// (0..maxToolCallsPerChoice-1). So the 65th new index would be 64, which is out of
+	// range. The count cap is therefore bounded by the index range. We verify the range
+	// guard catches it.
+	line65 := fmt.Sprintf(
+		`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":64,"id":"call_65","type":"function","function":{"name":"fn_65","arguments":"x"}}]},"finish_reason":null}]}`,
+	)
+	_, _, err := r.Push([]byte(line65))
+	if !errors.Is(err, errStreamAborted) {
+		t.Errorf("65th tool index: error = %v, want errStreamAborted", err)
+	}
+}
+
+// ── Matrix 7: finish_reason gates ─────────────────────────────────────────────
+
+// TestToolCall_FinishReasonGates covers all finish_reason gating scenarios.
+func TestToolCall_FinishReasonGates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		lines   []string
+		wantErr error
+	}{
+		{
+			name: "saw_tool_call_then_stop_fail_closed",
+			// A choice that streamed a validated tool call must NOT finish with "stop".
+			lines: []string{
+				toolChunkHeader(0, 0, "call_x", "fn", `"hello"`),
+				"",
+				finishChunk(0, "stop"), // "stop" after tool call → fail-closed.
+				"",
+			},
+			wantErr: errStreamAborted,
+		},
+		{
+			name: "tool_calls_finish_without_saw_tool_call_fail_closed",
+			// finish_reason:"tool_calls" but sawToolCall is false → fail-closed.
+			lines: []string{
+				chatChunk(0, "some text"),
+				"",
+				// finish_reason:"tool_calls" but no prior tool delta.
+				`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+				"",
+			},
+			wantErr: errStreamAborted,
+		},
+		{
+			name: "finish_reason_before_tool_delta_fail_closed",
+			// finish_reason in a chunk BEFORE any tool-call delta → fail-closed.
+			// (Same as above case: "tool_calls" finish before sawToolCall is set.)
+			lines: []string{
+				`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+				"",
+			},
+			wantErr: errStreamAborted,
+		},
+		{
+			name: "same_chunk_tool_call_and_finish_tool_calls_ok",
+			// Same chunk: validated tool call + finish_reason:"tool_calls" → OK.
+			lines: []string{
+				// Single chunk carrying both tool_calls delta AND finish_reason:"tool_calls".
+				`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"name":"fn","arguments":"hello"}}]},"finish_reason":"tool_calls"}]}`,
+				"",
+				"data: [DONE]",
+				"",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "legacy_function_call_fail_closed",
+			// Legacy singular delta.function_call must always be fail-closed.
+			lines: []string{
+				`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"function_call":{"name":"search","arguments":"{"}},"finish_reason":null}]}`,
+				"",
+			},
+			wantErr: errStreamAborted,
+		},
+		{
+			name: "empty_tool_calls_array_fail_closed",
+			// Empty tool_calls array does not set sawToolCall; also directly fail-closed.
+			lines: []string{
+				`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[]},"finish_reason":null}]}`,
+				"",
+			},
+			wantErr: errStreamAborted,
+		},
+		{
+			name: "valid_tool_call_then_tool_calls_finish_ok",
+			lines: []string{
+				toolChunkHeader(0, 0, "call_ok", "fn", `"val"`),
+				"",
+				toolFinish(0),
+				"",
+				"data: [DONE]",
+				"",
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, f := realPseudonym(t, "fingate@example.com")
+			r := NewStreamRestorer(f, "gpt-4o")
+			_, _, finalErr := pushAllCollect(r, tc.lines)
+
+			if tc.wantErr != nil {
+				if !errors.Is(finalErr, tc.wantErr) {
+					t.Errorf("%s: error = %v, want %v", tc.name, finalErr, tc.wantErr)
+				}
+			} else {
+				if finalErr != nil {
+					t.Errorf("%s: unexpected error: %v", tc.name, finalErr)
+				}
+			}
+		})
+	}
+}
+
+// ── Matrix 8: Terminal — [DONE] with non-empty tool argsCarry ─────────────────
+
+// TestToolCall_Terminal_DoneWithNonEmptyArgsCarry verifies that [DONE] arriving
+// while a tool-call argsCarry is non-empty returns errCarryNotEmpty.
+func TestToolCall_Terminal_DoneWithNonEmptyArgsCarry(t *testing.T) {
+	t.Parallel()
+
+	pseudo, f := realPseudonym(t, "termcarry@example.com")
+	f.Restore([]byte(pseudo)) // pre-warm
+
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	// Push header + partial pseudonym (argsCarry will be non-empty at [DONE]).
+	partial := pseudo[:10]
+	if _, _, err := r.Push([]byte(toolChunkHeader(0, 0, "call_t", "fn", partial))); err != nil {
+		t.Fatalf("push header+partial: %v", err)
+	}
+	r.Push([]byte{})
+
+	// Push [DONE] — argsCarry is non-empty → must return errCarryNotEmpty.
+	_, _, err := r.Push([]byte("data: [DONE]"))
+	if !errors.Is(err, errCarryNotEmpty) {
+		t.Errorf("DONE with non-empty argsCarry: error = %v, want errCarryNotEmpty", err)
+	}
+}
+
+// TestToolCall_Terminal_CleanDone verifies that [DONE] with all carries empty
+// (content and tool) succeeds and returns terminal=true.
+func TestToolCall_Terminal_CleanDone(t *testing.T) {
+	t.Parallel()
+
+	_, f := realPseudonym(t, "termclean@example.com")
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	lines := []string{
+		toolChunkHeader(0, 0, "call_z", "fn", `"complete_value"`),
+		"",
+		toolFinish(0),
+		"",
+		"data: [DONE]",
+		"",
+	}
+	output, terminal, err := pushAllCollect(r, lines)
+	if err != nil {
+		t.Fatalf("clean DONE: unexpected error: %v", err)
+	}
+	if !terminal {
+		t.Error("clean DONE: stream did not reach terminal")
+	}
+	// No PII_ in output.
+	if strings.Contains(output, "PII_") {
+		t.Errorf("clean DONE: PII_ in output:\n%s", output)
+	}
+}
+
+// ── Matrix 9: Residual check ──────────────────────────────────────────────────
+
+// TestToolCall_ResidualCheck covers canonical and sub-canonical PII markers
+// in both content and tool arguments.
+func TestToolCall_ResidualCheck(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unknown_canonical_in_content_fail_closed", func(t *testing.T) {
+		t.Parallel()
+
+		// Build a filter with no pseudonyms in its rev map.
+		// Then craft a canonical-shaped string that Restore will not touch
+		// (unknown canonical token — not in filter.rev).
+		f := newTestFilter(t)
+		// Use the filter's Restore which will leave unknown tokens intact.
+		// An unknown canonical pseudonym in content after restore → fail-closed.
+		unknown := "PII_EM_000000000000000000000000" // 31 bytes, canonical shape.
+		if len(unknown) != pseudonymLen {
+			t.Fatalf("bad test pseudonym length %d", len(unknown))
+		}
+
+		r := NewStreamRestorer(f, "gpt-4o")
+		// The restored output will still contain the canonical shape since the
+		// filter does not know this token. This triggers the residual check.
+		_, _, err := r.Push([]byte(chatChunk(0, unknown)))
+		// After Restore (which returns it unchanged), isCanonicalPseudonym fires.
+		// But the carry holds bytes until they're safe to emit. The first chunk
+		// won't have emitted yet (all bytes could be a pseudonym prefix). Push
+		// a harmless next chunk to force a flush.
+		if err != nil {
+			// Already failed on push — check if it's the right error.
+			if !errors.Is(err, errStreamAborted) {
+				t.Errorf("unexpected error type: %v", err)
+			}
+			return
+		}
+		r.Push([]byte{})
+		// Force flush by sending a content chunk with non-PII text.
+		_, _, err2 := r.Push([]byte(chatChunk(0, "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")))
+		if err2 != nil {
+			if !errors.Is(err2, errStreamAborted) {
+				t.Errorf("unknown canonical in content flush: error = %v, want errStreamAborted", err2)
+			}
+			return
+		}
+		// Also check at finish time.
+		r.Push([]byte{})
+		_, _, err3 := r.Push([]byte(finishChunk(0, "stop")))
+		if err3 != nil && !errors.Is(err3, errStreamAborted) {
+			t.Errorf("unknown canonical in content finish: error = %v, want errStreamAborted", err3)
+		}
+	})
+
+	t.Run("unknown_canonical_in_tool_args_fail_closed", func(t *testing.T) {
+		t.Parallel()
+
+		// An unknown canonical pseudonym shape in tool arguments → fail-closed.
+		f := newTestFilter(t)
+		unknown := "PII_EM_000000000000000000000000" // 31 bytes, canonical shape.
+
+		r := NewStreamRestorer(f, "gpt-4o")
+		// Push tool call header with the unknown canonical pseudonym in arguments.
+		// The pseudonym is exactly 31 bytes, so it will be fully in argsCarry and
+		// then flushed when additional text arrives.
+		if _, _, err := r.Push([]byte(toolChunkHeader(0, 0, "call_u", "fn", unknown))); err != nil {
+			if errors.Is(err, errStreamAborted) {
+				return // correctly rejected
+			}
+			t.Fatalf("push header with unknown canonical: %v", err)
+		}
+		r.Push([]byte{})
+		// Force a flush by adding more args text.
+		_, _, err := r.Push([]byte(toolChunkArgs(0, 0, "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")))
+		if err == nil {
+			// Possibly not yet flushed; push finish to force flush.
+			r.Push([]byte{})
+			_, _, err = r.Push([]byte(toolFinish(0)))
+		}
+		if !errors.Is(err, errStreamAborted) {
+			t.Errorf("unknown canonical in tool args: error = %v, want errStreamAborted", err)
+		}
+	})
+
+	t.Run("sub_canonical_in_content_passes_through", func(t *testing.T) {
+		t.Parallel()
+
+		// A sub-canonical "PII_" marker (not a full canonical token) in content
+		// must pass through and increment ResidualSubCanonicalCount.
+		f := newTestFilter(t)
+
+		// "PII_GARBAGE" is sub-canonical: has PII_ prefix but not the full shape.
+		subCanonical := "say PII_GARBAGE ok"
+
+		r := NewStreamRestorer(f, "gpt-4o")
+
+		before := ResidualSubCanonicalCount()
+
+		if _, _, err := r.Push([]byte(chatChunk(0, subCanonical))); err != nil {
+			t.Fatalf("sub-canonical content: unexpected error: %v", err)
+		}
+		r.Push([]byte{})
+		// Force flush.
+		if _, _, err := r.Push([]byte(finishChunk(0, "stop"))); err != nil {
+			t.Fatalf("sub-canonical content finish: %v", err)
+		}
+		r.Push([]byte{})
+		if _, _, err := r.Push([]byte("data: [DONE]")); err != nil {
+			t.Fatalf("sub-canonical content DONE: %v", err)
+		}
+
+		after := ResidualSubCanonicalCount()
+		// Counter must have incremented at least once for the sub-canonical marker.
+		if after <= before {
+			t.Errorf("ResidualSubCanonicalCount did not increment: before=%d after=%d", before, after)
+		}
+	})
+
+	t.Run("sub_canonical_in_tool_args_fail_closed", func(t *testing.T) {
+		t.Parallel()
+
+		// A sub-canonical "PII_" marker in tool arguments is fail-closed.
+		f := newTestFilter(t)
+
+		r := NewStreamRestorer(f, "gpt-4o")
+		// Push tool call with sub-canonical marker in arguments.
+		if _, _, err := r.Push([]byte(toolChunkHeader(0, 0, "call_s", "fn", "PII_GARBAGE"))); err != nil {
+			if errors.Is(err, errStreamAborted) {
+				return
+			}
+			t.Fatalf("push sub-canonical tool args: %v", err)
+		}
+		r.Push([]byte{})
+		// Force flush.
+		_, _, err := r.Push([]byte(toolChunkArgs(0, 0, "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX")))
+		if err == nil {
+			r.Push([]byte{})
+			_, _, err = r.Push([]byte(toolFinish(0)))
+		}
+		if !errors.Is(err, errStreamAborted) {
+			t.Errorf("sub-canonical in tool args: error = %v, want errStreamAborted", err)
+		}
+	})
+}
+
+// ── Matrix 10: Oracle / property test ─────────────────────────────────────────
+
+// TestToolCall_Oracle_PropertyTest builds a tool-call stream whose concatenated
+// arguments contain randomly-placed known pseudonyms, randomly chunks the
+// arguments fragments, and asserts that concat(restored arguments) equals
+// what a non-streaming restore would produce, and that no canonical PII_ token
+// remains in the output.
+func TestToolCall_Oracle_PropertyTest(t *testing.T) {
+	t.Parallel()
+
+	// Build a filter with two pseudonyms.
+	f := newTestFilter(t)
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"alice@oracle.example and bob@oracle.example"}]}`)
+	if _, err := f.AnonymizeJSON(body); err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	var alicePseudo, bobPseudo string
+	for p, orig := range f.rev {
+		if orig == "alice@oracle.example" {
+			alicePseudo = p
+		}
+		if orig == "bob@oracle.example" {
+			bobPseudo = p
+		}
+	}
+	if alicePseudo == "" || bobPseudo == "" {
+		t.Fatalf("pseudonyms not found")
+	}
+	// Pre-warm.
+	f.Restore([]byte(alicePseudo + bobPseudo))
+
+	// Construct a full arguments string that contains both pseudonyms.
+	fullArgs := fmt.Sprintf(`{"user1":"%s","user2":"%s","note":"test"}`, alicePseudo, bobPseudo)
+
+	// Oracle: what the non-streaming Restore gives us.
+	oracleRestored := string(f.Restore([]byte(fullArgs)))
+
+	// Property: randomly chunk fullArgs and feed through StreamRestorer.
+	// Run multiple times with different random splits.
+	rng := rand.New(rand.NewSource(42))
+	const iterations = 30
+	for i := 0; i < iterations; i++ {
+		i := i
+		t.Run(fmt.Sprintf("iter_%d", i), func(t *testing.T) {
+			// Not parallel here — shares rng; sequential is fine for a property test.
+			r := NewStreamRestorer(f, "gpt-4o")
+
+			// Randomly split fullArgs into 1..5 fragments.
+			numFrags := rng.Intn(5) + 1
+			frags := splitIntoN(fullArgs, numFrags, rng)
+
+			var lines []string
+			// Header chunk with first fragment.
+			lines = append(lines, toolChunkHeader(0, 0, "call_prop", "fn_prop", frags[0]))
+			lines = append(lines, "")
+			// Subsequent fragments.
+			for _, frag := range frags[1:] {
+				lines = append(lines, toolChunkArgs(0, 0, frag))
+				lines = append(lines, "")
+			}
+			lines = append(lines, toolFinish(0))
+			lines = append(lines, "")
+			lines = append(lines, "data: [DONE]")
+			lines = append(lines, "")
+
+			output, terminal, err := pushAllCollect(r, lines)
+			if err != nil {
+				t.Fatalf("iter_%d: Push error: %v", i, err)
+			}
+			if !terminal {
+				t.Fatalf("iter_%d: stream not terminal", i)
+			}
+
+			allArgs, _ := extractAllToolArgs(output)
+
+			// Property 1: concatenated restored args equals oracle.
+			if allArgs != oracleRestored {
+				t.Errorf("iter_%d: restored args = %q, want oracle %q", i, allArgs, oracleRestored)
+			}
+			// Property 2: no canonical PII_ token in output.
+			if strings.Contains(output, "PII_") {
+				t.Errorf("iter_%d: canonical PII_ in output:\n%s", i, output)
+			}
+		})
+	}
+}
+
+// splitIntoN splits s into n fragments of roughly equal size using the given rng.
+func splitIntoN(s string, n int, rng *rand.Rand) []string {
+	if n <= 1 || len(s) == 0 {
+		return []string{s}
+	}
+	frags := make([]string, 0, n)
+	remaining := s
+	for i := 0; i < n-1 && len(remaining) > 0; i++ {
+		// Random split point between 1 and len(remaining)-1.
+		cut := rng.Intn(len(remaining))
+		if cut == 0 {
+			cut = 1
+		}
+		frags = append(frags, remaining[:cut])
+		remaining = remaining[cut:]
+	}
+	frags = append(frags, remaining)
+	return frags
+}
+
+// ── Verify ResidualSubCanonicalCount is a package-level atomic (not reset) ────
+
+// TestResidualSubCanonicalCount_Atomicity verifies that ResidualSubCanonicalCount
+// returns a non-negative value and can be read from multiple goroutines without
+// a race (the -race flag will catch races if any exist).
+func TestResidualSubCanonicalCount_Atomicity(t *testing.T) {
+	t.Parallel()
+
+	// Multiple goroutines read the counter simultaneously; the -race detector
+	// will flag any data race. A WaitGroup replaces the busy-spin to avoid
+	// -race flakiness from the spin loop itself.
+	var wg sync.WaitGroup
+	const readers = 8
+	wg.Add(readers)
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			_ = ResidualSubCanonicalCount()
+		}()
+	}
+	wg.Wait()
+}
+
+// ── FIX 1: Accumulated/cross-emission residual canonical-pseudonym check ──────
+
+// TestFix1_UnknownCanonicalSplitAcrossEmissions_Content verifies that an unknown
+// canonical pseudonym (not in the filter's reverse map) that is split across two
+// consecutive emissions in a content lane is detected and causes fail-closed abort.
+// The test exercises every possible split position (1..pseudonymLen-1) to confirm
+// the tail window catches all boundary cases.
+func TestFix1_UnknownCanonicalSplitAcrossEmissions_Content(t *testing.T) {
+	t.Parallel()
+
+	// unknownCanonical is a canonical-shaped token (31 bytes) that does NOT
+	// appear in any filter's reverse map. The filter's Restore will leave it
+	// intact, so it arrives in the emitted stream as-is.
+	const unknownCanonical = "PII_EM_000000000000000000000001"
+	if len(unknownCanonical) != pseudonymLen {
+		t.Fatalf("bad test token length %d, want %d", len(unknownCanonical), pseudonymLen)
+	}
+
+	// To force the unknown canonical to span two SEPARATE emissions we must
+	// ensure neither half alone holds enough bytes to trigger the hold-back
+	// (hold-back only fires for KNOWN pseudonym prefixes). Since the token is
+	// unknown, both halves emit immediately. We therefore deliver the two halves
+	// in two separate chunks so that there is a first emission (part1) and a
+	// second emission (part2); the tail window must detect the full token across
+	// the two emissions.
+	//
+	// We pad each part with non-PII text so the carry is always flushed and
+	// neither part is held back by the known-prefix filter.
+	const prefix = "safe text before: "
+	const suffix = " :safe text after"
+
+	for splitAt := 1; splitAt < pseudonymLen; splitAt++ {
+		splitAt := splitAt
+		t.Run(fmt.Sprintf("split_at_%d", splitAt), func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFilter(t) // empty filter: no known pseudonyms
+			r := NewStreamRestorer(f, "gpt-4o")
+
+			part1 := prefix + unknownCanonical[:splitAt]
+			part2 := unknownCanonical[splitAt:] + suffix
+
+			// Feed part1 then part2 in separate chunks. Because the filter is
+			// empty (no known pseudonyms), longestPseudonymPrefixSuffix returns 0
+			// and content is emitted immediately on each push.
+			var finalErr error
+			for _, chunk := range []string{
+				chatChunk(0, part1),
+				"",
+				chatChunk(0, part2),
+				"",
+			} {
+				var raw []byte
+				if chunk == "" {
+					raw = []byte{}
+				} else {
+					raw = []byte(chunk)
+				}
+				_, _, err := r.Push(raw)
+				if err != nil {
+					finalErr = err
+					break
+				}
+			}
+
+			if finalErr == nil {
+				// Not yet caught; force a finish to flush any carry.
+				_, _, finalErr = r.Push([]byte(finishChunk(0, "stop")))
+			}
+
+			if !errors.Is(finalErr, errStreamAborted) {
+				t.Errorf("split_at_%d: expected errStreamAborted, got %v", splitAt, finalErr)
+			}
+		})
+	}
+}
+
+// TestFix1_UnknownCanonicalSplitAcrossEmissions_ToolArgs verifies that an
+// unknown canonical pseudonym split across two consecutive emissions in a tool
+// arguments lane is detected and causes fail-closed abort.
+func TestFix1_UnknownCanonicalSplitAcrossEmissions_ToolArgs(t *testing.T) {
+	t.Parallel()
+
+	const unknownCanonical = "PII_EM_000000000000000000000002"
+	if len(unknownCanonical) != pseudonymLen {
+		t.Fatalf("bad test token length %d, want %d", len(unknownCanonical), pseudonymLen)
+	}
+
+	const prefix = "before:"
+	const suffix = ":after"
+
+	for splitAt := 1; splitAt < pseudonymLen; splitAt++ {
+		splitAt := splitAt
+		t.Run(fmt.Sprintf("split_at_%d", splitAt), func(t *testing.T) {
+			t.Parallel()
+
+			f := newTestFilter(t) // empty filter: no known pseudonyms
+			r := NewStreamRestorer(f, "gpt-4o")
+
+			part1 := prefix + unknownCanonical[:splitAt]
+			part2 := unknownCanonical[splitAt:] + suffix
+
+			// Emit part1 in the header chunk, part2 in a continuation chunk.
+			var finalErr error
+			for _, line := range []string{
+				toolChunkHeader(0, 0, "call_fix1", "fn", part1),
+				"",
+				toolChunkArgs(0, 0, part2),
+				"",
+			} {
+				var raw []byte
+				if line == "" {
+					raw = []byte{}
+				} else {
+					raw = []byte(line)
+				}
+				_, _, err := r.Push(raw)
+				if err != nil {
+					finalErr = err
+					break
+				}
+			}
+
+			if finalErr == nil {
+				// Force a finish to flush any remaining carry.
+				_, _, finalErr = r.Push([]byte(toolFinish(0)))
+			}
+
+			if !errors.Is(finalErr, errStreamAborted) {
+				t.Errorf("split_at_%d: expected errStreamAborted, got %v", splitAt, finalErr)
+			}
+		})
+	}
+}
+
+// ── FIX 2: Reverse cross-lane check (content delta after non-empty argsCarry) ─
+
+// TestFix2_ContentAfterNonEmptyArgsCarry_SameChoice verifies that when a content
+// delta arrives for a choice that already has a non-empty tool-call argsCarry,
+// the restorer fails closed. This is the reverse of the existing forward check
+// (content carry blocks tool emission).
+func TestFix2_ContentAfterNonEmptyArgsCarry_SameChoice(t *testing.T) {
+	t.Parallel()
+
+	pseudo, f := realPseudonym(t, "fix2crosslane@example.com")
+	f.Restore([]byte(pseudo)) // pre-warm
+
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	// Put a partial pseudonym into tool index 0's argsCarry so argsCarry is non-empty.
+	partial := pseudo[:10]
+	if _, _, err := r.Push([]byte(toolChunkHeader(0, 0, "call_fix2", "fn", partial))); err != nil {
+		t.Fatalf("push tool header+partial: %v", err)
+	}
+	r.Push([]byte{})
+
+	// Now push a content delta for the SAME choice (choice 0).
+	// This must fail-closed because argsCarry for choice 0 is non-empty.
+	_, _, err := r.Push([]byte(chatChunk(0, "hello")))
+	if !errors.Is(err, errStreamAborted) {
+		t.Errorf("content after non-empty argsCarry same choice: error = %v, want errStreamAborted", err)
+	}
+}
+
+// TestFix2_ContentAfterNonEmptyArgsCarry_DifferentChoice verifies that a content
+// delta for choice 1 is NOT blocked by a non-empty argsCarry in choice 0.
+// Cross-choice independence must be preserved.
+func TestFix2_ContentAfterNonEmptyArgsCarry_DifferentChoice(t *testing.T) {
+	t.Parallel()
+
+	pseudo, f := realPseudonym(t, "fix2crossindep@example.com")
+	f.Restore([]byte(pseudo)) // pre-warm
+
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	// Put a partial pseudonym into choice 0's tool argsCarry.
+	partial := pseudo[:10]
+	if _, _, err := r.Push([]byte(toolChunkHeader(0, 0, "call_fix2b", "fn", partial))); err != nil {
+		t.Fatalf("push tool header+partial: %v", err)
+	}
+	r.Push([]byte{})
+
+	// Push a content delta for choice 1 — must succeed (different choice).
+	_, _, err := r.Push([]byte(chatChunk(1, "hello from choice 1")))
+	if err != nil {
+		t.Errorf("content for different choice after argsCarry: unexpected error: %v", err)
+	}
+}
+
+// ── FIX 3: arguments:null and non-string arguments → fail-closed ──────────────
+
+// TestFix3_ArgumentsNull_FailClosed verifies that a tool_calls delta with
+// arguments:null (JSON null, not a string) causes fail-closed abort.
+func TestFix3_ArgumentsNull_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	_, f := realPseudonym(t, "fix3null@example.com")
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	// arguments is JSON null — must fail-closed.
+	line := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_n","type":"function","function":{"name":"fn","arguments":null}}]},"finish_reason":null}]}`
+	_, _, err := r.Push([]byte(line))
+	if !errors.Is(err, errStreamAborted) {
+		t.Errorf("arguments:null: error = %v, want errStreamAborted", err)
+	}
+}
+
+// TestFix3_ArgumentsNumber_FailClosed verifies that a tool_calls delta with
+// arguments as a JSON number causes fail-closed abort.
+func TestFix3_ArgumentsNumber_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	_, f := realPseudonym(t, "fix3num@example.com")
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	line := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_n","type":"function","function":{"name":"fn","arguments":42}}]},"finish_reason":null}]}`
+	_, _, err := r.Push([]byte(line))
+	if !errors.Is(err, errStreamAborted) {
+		t.Errorf("arguments:number: error = %v, want errStreamAborted", err)
+	}
+}
+
+// TestFix3_ArgumentsObject_FailClosed verifies that a tool_calls delta with
+// arguments as a JSON object causes fail-closed abort.
+func TestFix3_ArgumentsObject_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	_, f := realPseudonym(t, "fix3obj@example.com")
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	line := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_n","type":"function","function":{"name":"fn","arguments":{"key":"val"}}}]},"finish_reason":null}]}`
+	_, _, err := r.Push([]byte(line))
+	if !errors.Is(err, errStreamAborted) {
+		t.Errorf("arguments:object: error = %v, want errStreamAborted", err)
+	}
+}
+
+// TestFix3_ArgumentsAbsent_ContinuationOK verifies that a subsequent tool_calls
+// fragment that omits the arguments key entirely is treated as a header-only
+// continuation and does not fail-closed.
+func TestFix3_ArgumentsAbsent_ContinuationOK(t *testing.T) {
+	t.Parallel()
+
+	_, f := realPseudonym(t, "fix3absent@example.com")
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	// First chunk: valid header with arguments.
+	first := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_a","type":"function","function":{"name":"fn","arguments":"hello"}}]},"finish_reason":null}]}`
+	if _, _, err := r.Push([]byte(first)); err != nil {
+		t.Fatalf("first chunk: %v", err)
+	}
+	r.Push([]byte{})
+
+	// Second chunk: same index, function object present but NO arguments key.
+	// This is a header-only continuation — must not fail-closed.
+	second := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{}}]},"finish_reason":null}]}`
+	_, _, err := r.Push([]byte(second))
+	if err != nil {
+		t.Errorf("arguments absent in continuation: unexpected error: %v", err)
+	}
+}
+
+// ── FIX A: Strict structural charset on tool-call id and name ────────────────
+
+// TestFixA_IDCharset verifies that tool-call ids containing characters outside
+// [A-Za-z0-9_.+-] — including '@', spaces, colons, and non-ASCII — fail-closed,
+// while a valid id like "call_abc123" is accepted.
+func TestFixA_IDCharset(t *testing.T) {
+	t.Parallel()
+
+	invalid := []struct {
+		name string
+		id   string
+	}{
+		{"at_sign", "user@example.com"},
+		{"space", "call abc"},
+		{"colon", "call:x"},
+		{"slash", "call/x"},
+		{"non_ascii", "call_\xff"},
+	}
+
+	for _, tc := range invalid {
+		tc := tc
+		t.Run("id_"+tc.name+"_fail_closed", func(t *testing.T) {
+			t.Parallel()
+
+			_, f := realPseudonym(t, "charid@example.com")
+			r := NewStreamRestorer(f, "gpt-4o")
+
+			line := fmt.Sprintf(
+				`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":%s,"type":"function","function":{"name":"get_weather","arguments":"{}"}}]},"finish_reason":null}]}`,
+				jsonStr(tc.id),
+			)
+			_, _, err := r.Push([]byte(line))
+			if !errors.Is(err, errStreamAborted) {
+				t.Errorf("id %q: error = %v, want errStreamAborted", tc.id, err)
+			}
+		})
+	}
+
+	// Valid id must be accepted.
+	t.Run("id_call_abc123_ok", func(t *testing.T) {
+		t.Parallel()
+
+		_, f := realPseudonym(t, "validid@example.com")
+		r := NewStreamRestorer(f, "gpt-4o")
+
+		lines := []string{
+			toolChunkHeader(0, 0, "call_abc123", "get_weather", `"{}"`),
+			"",
+			toolFinish(0),
+			"",
+			"data: [DONE]",
+			"",
+		}
+		_, _, err := pushAllCollect(r, lines)
+		if err != nil {
+			t.Errorf("valid id call_abc123: unexpected error: %v", err)
+		}
+	})
+}
+
+// TestFixA_NameCharset verifies that tool function names containing characters
+// outside [A-Za-z0-9_.+-] — including '@', spaces — fail-closed, while a valid
+// name like "get_weather" is accepted.
+func TestFixA_NameCharset(t *testing.T) {
+	t.Parallel()
+
+	invalid := []struct {
+		name     string
+		funcName string
+	}{
+		{"at_sign", "get@weather"},
+		{"space", "get weather"},
+		{"colon", "get:weather"},
+	}
+
+	for _, tc := range invalid {
+		tc := tc
+		t.Run("name_"+tc.name+"_fail_closed", func(t *testing.T) {
+			t.Parallel()
+
+			_, f := realPseudonym(t, "charname@example.com")
+			r := NewStreamRestorer(f, "gpt-4o")
+
+			line := fmt.Sprintf(
+				`data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"name":%s,"arguments":"{}"}}]},"finish_reason":null}]}`,
+				jsonStr(tc.funcName),
+			)
+			_, _, err := r.Push([]byte(line))
+			if !errors.Is(err, errStreamAborted) {
+				t.Errorf("name %q: error = %v, want errStreamAborted", tc.funcName, err)
+			}
+		})
+	}
+
+	// Valid name must be accepted.
+	t.Run("name_get_weather_ok", func(t *testing.T) {
+		t.Parallel()
+
+		_, f := realPseudonym(t, "validname@example.com")
+		r := NewStreamRestorer(f, "gpt-4o")
+
+		lines := []string{
+			toolChunkHeader(0, 0, "call_x", "get_weather", `"{}"`),
+			"",
+			toolFinish(0),
+			"",
+			"data: [DONE]",
+			"",
+		}
+		_, _, err := pushAllCollect(r, lines)
+		if err != nil {
+			t.Errorf("valid name get_weather: unexpected error: %v", err)
+		}
+	})
+}
+
+// ── FIX B: Emit assistant role on tool-only streams ──────────────────────────
+
+// TestFixB_ToolOnlyStream_RoleAssistantOnFirstChunk verifies that a tool-only
+// stream (no content chunks) emits role:"assistant" exactly once, on the very
+// first tool-calls chunk for a choice.
+func TestFixB_ToolOnlyStream_RoleAssistantOnFirstChunk(t *testing.T) {
+	t.Parallel()
+
+	_, f := realPseudonym(t, "fixb@example.com")
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	lines := []string{
+		toolChunkHeader(0, 0, "call_abc", "get_weather", `"{}"`),
+		"",
+		toolChunkArgs(0, 0, `" extra"`),
+		"",
+		toolFinish(0),
+		"",
+		"data: [DONE]",
+		"",
+	}
+	output, terminal, err := pushAllCollect(r, lines)
+	if err != nil {
+		t.Fatalf("pushAllCollect: %v", err)
+	}
+	if !terminal {
+		t.Error("stream did not reach terminal")
+	}
+
+	// Parse all data: lines to find role fields in tool_calls deltas.
+	roleCount := 0
+	roleValues := map[string]int{}
+	firstToolChunkHasRole := false
+	isFirst := true
+
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.HasPrefix(line, "data: ") || strings.Contains(line, "[DONE]") {
+			continue
+		}
+		payload := line[len("data: "):]
+		var chunk struct {
+			Choices []struct {
+				Delta struct {
+					Role      string `json:"role"`
+					ToolCalls []struct {
+						Index int `json:"index"`
+					} `json:"tool_calls"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			continue
+		}
+		for _, ch := range chunk.Choices {
+			if len(ch.Delta.ToolCalls) > 0 {
+				if ch.Delta.Role != "" {
+					roleCount++
+					roleValues[ch.Delta.Role]++
+					if isFirst {
+						firstToolChunkHasRole = true
+					}
+				}
+				isFirst = false
+			}
+		}
+	}
+
+	if !firstToolChunkHasRole {
+		t.Errorf("role:assistant not present on first tool chunk; output:\n%s", output)
+	}
+	if roleCount != 1 {
+		t.Errorf("role emitted %d times in tool chunks, want exactly 1; output:\n%s", roleCount, output)
+	}
+	if roleValues["assistant"] != 1 {
+		t.Errorf("role value = %v, want assistant:1; output:\n%s", roleValues, output)
+	}
+}
+
+// TestFixB_ToolOnlyStream_RoleNotOnSubsequentChunks verifies that role is
+// absent on tool chunks after the first.
+func TestFixB_ToolOnlyStream_RoleNotOnSubsequentChunks(t *testing.T) {
+	t.Parallel()
+
+	_, f := realPseudonym(t, "fixb2@example.com")
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	// Three argument chunks to produce multiple emitted tool chunks.
+	lines := []string{
+		toolChunkHeader(0, 0, "call_abc", "get_weather", `"arg1"`),
+		"",
+		toolChunkArgs(0, 0, `"arg2"`),
+		"",
+		toolChunkArgs(0, 0, `"arg3"`),
+		"",
+		toolFinish(0),
+		"",
+		"data: [DONE]",
+		"",
+	}
+	output, _, err := pushAllCollect(r, lines)
+	if err != nil {
+		t.Fatalf("pushAllCollect: %v", err)
+	}
+
+	// Collect all tool-call chunks with their role field.
+	type chunkRole struct {
+		hasToolCalls bool
+		role         string
+	}
+	var chunks []chunkRole
+	for _, line := range strings.Split(output, "\n") {
+		if !strings.HasPrefix(line, "data: ") || strings.Contains(line, "[DONE]") {
+			continue
+		}
+		payload := line[len("data: "):]
+		var chunk struct {
+			Choices []struct {
+				Delta struct {
+					Role      string `json:"role"`
+					ToolCalls []struct {
+						Index int `json:"index"`
+					} `json:"tool_calls"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			continue
+		}
+		for _, ch := range chunk.Choices {
+			if len(ch.Delta.ToolCalls) > 0 {
+				chunks = append(chunks, chunkRole{true, ch.Delta.Role})
+			}
+		}
+	}
+
+	if len(chunks) < 2 {
+		t.Fatalf("expected at least 2 tool chunks, got %d; output:\n%s", len(chunks), output)
+	}
+	if chunks[0].role != "assistant" {
+		t.Errorf("first tool chunk role = %q, want assistant", chunks[0].role)
+	}
+	for i, c := range chunks[1:] {
+		if c.role != "" {
+			t.Errorf("tool chunk[%d] has unexpected role %q (want empty)", i+1, c.role)
+		}
+	}
+}
+
+// ── FIX C: [DONE] requires finish for tool-call choices ──────────────────────
+
+// TestFixC_DoneWithoutFinishReason_ToolChoice_FailClosed verifies that [DONE]
+// arriving after a tool call but before a finish_reason causes fail-closed abort.
+func TestFixC_DoneWithoutFinishReason_ToolChoice_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	_, f := realPseudonym(t, "fixc@example.com")
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	// Stream a valid tool call but no finish_reason before [DONE].
+	lines := []string{
+		toolChunkHeader(0, 0, "call_x", "fn", `"hello"`),
+		"",
+		"data: [DONE]",
+		"",
+	}
+	_, _, err := pushAllCollect(r, lines)
+	if !errors.Is(err, errStreamAborted) {
+		t.Errorf("DONE without finish_reason after tool call: error = %v, want errStreamAborted", err)
+	}
+}
+
+// TestFixC_DoneWithFinishReason_ToolChoice_OK verifies that [DONE] arriving
+// after a tool call with a preceding finish_reason:"tool_calls" succeeds.
+func TestFixC_DoneWithFinishReason_ToolChoice_OK(t *testing.T) {
+	t.Parallel()
+
+	_, f := realPseudonym(t, "fixcok@example.com")
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	lines := []string{
+		toolChunkHeader(0, 0, "call_x", "fn", `"hello"`),
+		"",
+		toolFinish(0),
+		"",
+		"data: [DONE]",
+		"",
+	}
+	_, terminal, err := pushAllCollect(r, lines)
+	if err != nil {
+		t.Errorf("DONE with finish_reason after tool call: unexpected error: %v", err)
+	}
+	if !terminal {
+		t.Error("stream did not reach terminal")
+	}
+}
+
+// TestFixC_DoneWithoutFinishReason_NonToolChoice_OK verifies that [DONE]
+// without a finish_reason on a non-tool choice does NOT trigger the new gate
+// (the gate only applies to tool-call choices).
+//
+// Note: in practice OpenAI always sends finish_reason before [DONE] for all
+// choices, but this test documents the scoped behavior of FIX C.
+func TestFixC_DoneWithoutFinishReason_NonToolChoice_OK(t *testing.T) {
+	t.Parallel()
+
+	_, f := realPseudonym(t, "fixcnontool@example.com")
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	// Content-only choice: sawToolCall is false, so the finish gate does not apply.
+	// Push content without ever sending finish_reason and go straight to [DONE].
+	// The only existing check is carry-not-empty (the content "hi" is short and
+	// clears the carry, so no errCarryNotEmpty). After it clears, [DONE] succeeds.
+	lines := []string{
+		chatChunk(0, "hi"),
+		"",
+		"data: [DONE]",
+		"",
+	}
+	_, _, err := pushAllCollect(r, lines)
+	// No tool call was made for this choice, so the FIX C gate does not fire.
+	// errStreamAborted would be wrong here.
+	if errors.Is(err, errStreamAborted) {
+		t.Errorf("non-tool choice DONE without finish: got errStreamAborted, want nil or errCarryNotEmpty")
+	}
+}
+
+// ── FIX D: Present-but-empty repeated header fields fail-closed ──────────────
+
+// TestFixD_ContinuationIDPresentEmpty_FailClosed verifies that a continuation
+// fragment with id explicitly present but empty ("") causes fail-closed abort.
+// An absent id (key omitted / nil pointer) must remain OK.
+func TestFixD_ContinuationIDPresentEmpty_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	_, f := realPseudonym(t, "fixd@example.com")
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	// First chunk: valid header.
+	first := toolChunkHeader(0, 0, "call_orig", "fn", `""`)
+	if _, _, err := r.Push([]byte(first)); err != nil {
+		t.Fatalf("first chunk: %v", err)
+	}
+	r.Push([]byte{})
+
+	// Second chunk: same index, id explicitly present but empty string.
+	second := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"","function":{"arguments":"more"}}]},"finish_reason":null}]}`
+	_, _, err := r.Push([]byte(second))
+	if !errors.Is(err, errStreamAborted) {
+		t.Errorf("continuation id present-empty: error = %v, want errStreamAborted", err)
+	}
+}
+
+// TestFixD_ContinuationIDAbsent_OK verifies that a continuation fragment with
+// id key entirely absent (nil *string) is accepted.
+func TestFixD_ContinuationIDAbsent_OK(t *testing.T) {
+	t.Parallel()
+
+	_, f := realPseudonym(t, "fixdabsent@example.com")
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	// First chunk: valid header.
+	first := toolChunkHeader(0, 0, "call_orig", "fn", `""`)
+	if _, _, err := r.Push([]byte(first)); err != nil {
+		t.Fatalf("first chunk: %v", err)
+	}
+	r.Push([]byte{})
+
+	// Second chunk: same index, id key absent (no "id" key in the element JSON).
+	second := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"more"}}]},"finish_reason":null}]}`
+	_, _, err := r.Push([]byte(second))
+	if err != nil {
+		t.Errorf("continuation id absent: unexpected error: %v", err)
+	}
+}
+
+// TestFixD_ContinuationNamePresentEmpty_FailClosed verifies that a continuation
+// fragment with name explicitly present but empty ("") causes fail-closed abort.
+func TestFixD_ContinuationNamePresentEmpty_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	_, f := realPseudonym(t, "fixdname@example.com")
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	// First chunk: valid header with function object containing name.
+	first := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_x","type":"function","function":{"name":"fn_orig","arguments":""}}]},"finish_reason":null}]}`
+	if _, _, err := r.Push([]byte(first)); err != nil {
+		t.Fatalf("first chunk: %v", err)
+	}
+	r.Push([]byte{})
+
+	// Second chunk: name present but empty.
+	second := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"","arguments":"more"}}]},"finish_reason":null}]}`
+	_, _, err := r.Push([]byte(second))
+	if !errors.Is(err, errStreamAborted) {
+		t.Errorf("continuation name present-empty: error = %v, want errStreamAborted", err)
+	}
+}
+
+// TestFixD_ContinuationTypePresentEmpty_FailClosed verifies that a continuation
+// fragment (same index, after a valid header) that carries "type":"" (present but
+// empty) causes fail-closed abort. This is the type-field analogue of
+// TestFixD_ContinuationIDPresentEmpty_FailClosed and
+// TestFixD_ContinuationNamePresentEmpty_FailClosed. A present-but-empty type is
+// structurally anomalous: "function" is the only accepted non-nil type value, so
+// an empty string is always a protocol violation.
+func TestFixD_ContinuationTypePresentEmpty_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	_, f := realPseudonym(t, "fixdtype@example.com")
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	// First chunk: valid header (id, type:"function", name all present and valid).
+	first := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_orig","type":"function","function":{"name":"fn_orig","arguments":""}}]},"finish_reason":null}]}`
+	if _, _, err := r.Push([]byte(first)); err != nil {
+		t.Fatalf("first chunk: %v", err)
+	}
+	r.Push([]byte{})
+
+	// Second chunk: same index, type explicitly present but empty string.
+	// An empty type value on a continuation is "present-but-empty" and must
+	// fail-closed (distinct from the legitimately absent type key).
+	second := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"","function":{"arguments":"more"}}]},"finish_reason":null}]}`
+	_, _, err := r.Push([]byte(second))
+	if !errors.Is(err, errStreamAborted) {
+		t.Errorf("continuation type present-empty: error = %v, want errStreamAborted", err)
+	}
+}
+
+// TestFixB_ContentThenTool_RoleOnlyOnFirst verifies that when a single choice
+// streams a content delta first (which carries role:"assistant") and then streams
+// a tool_calls delta for the same choice, role:"assistant" appears exactly once
+// across all emitted chunks — on the first content chunk — and the subsequent
+// tool chunk does NOT carry a role field. This exercises the shared cc.roleSent
+// flag that is set by the content path and then observed by the tool path.
+//
+// To avoid triggering the cross-lane guard (content carry non-empty when
+// tool_calls arrives), the content payload is plain text with no trailing
+// pseudonym prefix, ensuring the carry drains completely before the tool delta.
+func TestFixB_ContentThenTool_RoleOnlyOnFirst(t *testing.T) {
+	t.Parallel()
+
+	_, f := realPseudonym(t, "fixb_contenttool@example.com")
+	r := NewStreamRestorer(f, "gpt-4o")
+
+	// Step 1: content delta that carries the role. The content "hello world" has
+	// no suffix that is a proper prefix of any known pseudonym (it ends in "d",
+	// which cannot start "PII_"), so the carry drains fully and roleSent is set.
+	// The upstream role key is present so the restorer synthesises "assistant".
+	contentLine := `data: {"id":"cid","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"hello world"},"finish_reason":null}]}`
+	if _, _, err := r.Push([]byte(contentLine)); err != nil {
+		t.Fatalf("content chunk: %v", err)
+	}
+	r.Push([]byte{})
+
+	// Step 2: tool_calls delta for the same choice. Because formatChat accepts
+	// tool_calls and the content carry is empty, this must succeed. The role must
+	// NOT appear again (cc.roleSent is already true).
+	toolLine := toolChunkHeader(0, 0, "call_abc", "get_data", `"{}"`)
+	if _, _, err := r.Push([]byte(toolLine)); err != nil {
+		t.Fatalf("tool chunk: %v", err)
+	}
+	r.Push([]byte{})
+
+	// Step 3: finish and done.
+	lines := []string{
+		toolFinish(0),
+		"",
+		"data: [DONE]",
+		"",
+	}
+	output, terminal, err := pushAllCollect(r, lines)
+	if err != nil {
+		t.Fatalf("finish+done: %v", err)
+	}
+	if !terminal {
+		t.Error("stream did not reach terminal")
+	}
+
+	// Collect all emitted data: lines and count role occurrences.
+	type chunkRole struct {
+		hasContent  bool
+		hasToolCall bool
+		role        string
+	}
+	var chunks []chunkRole
+
+	// Re-collect the content and tool chunks emitted before the finish sequence.
+	// We need to gather all output including the earlier pushes. Re-run through
+	// pushAllCollect on a fresh restorer to get a single consolidated output.
+	r2 := NewStreamRestorer(f, "gpt-4o")
+	allLines := []string{
+		contentLine,
+		"",
+		toolLine,
+		"",
+		toolFinish(0),
+		"",
+		"data: [DONE]",
+		"",
+	}
+	allOutput, terminal2, err2 := pushAllCollect(r2, allLines)
+	if err2 != nil {
+		t.Fatalf("full stream: %v", err2)
+	}
+	if !terminal2 {
+		t.Error("full stream did not reach terminal")
+	}
+	_ = output // the partial output from above was only used to verify no error
+
+	for _, line := range strings.Split(allOutput, "\n") {
+		if !strings.HasPrefix(line, "data: ") || strings.Contains(line, "[DONE]") {
+			continue
+		}
+		payload := line[len("data: "):]
+		var chunk struct {
+			Choices []struct {
+				Delta struct {
+					Role      string  `json:"role"`
+					Content   *string `json:"content"`
+					ToolCalls []struct {
+						Index int `json:"index"`
+					} `json:"tool_calls"`
+				} `json:"delta"`
+			} `json:"choices"`
+		}
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			continue
+		}
+		for _, ch := range chunk.Choices {
+			cr := chunkRole{
+				hasContent:  ch.Delta.Content != nil,
+				hasToolCall: len(ch.Delta.ToolCalls) > 0,
+				role:        ch.Delta.Role,
+			}
+			chunks = append(chunks, cr)
+		}
+	}
+
+	// Count total role emissions across all chunks.
+	roleCount := 0
+	for _, c := range chunks {
+		if c.role != "" {
+			roleCount++
+		}
+	}
+	if roleCount != 1 {
+		t.Errorf("role emitted %d times across all chunks, want exactly 1; output:\n%s", roleCount, allOutput)
+	}
+
+	// The first chunk (content) must carry the role.
+	if len(chunks) == 0 {
+		t.Fatalf("no chunks emitted; output:\n%s", allOutput)
+	}
+	if chunks[0].role != "assistant" {
+		t.Errorf("first chunk role = %q, want \"assistant\"; output:\n%s", chunks[0].role, allOutput)
+	}
+	if !chunks[0].hasContent {
+		t.Errorf("first chunk expected to be a content chunk; output:\n%s", allOutput)
+	}
+
+	// All tool-call chunks must NOT carry a role.
+	for i, c := range chunks {
+		if c.hasToolCall && c.role != "" {
+			t.Errorf("tool chunk[%d] carries unexpected role %q; output:\n%s", i, c.role, allOutput)
+		}
+	}
+}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -1201,6 +1201,22 @@ func (p *ProxyHandler) handleStreamingResponse(c fiber.Ctx, resp *http.Response,
 				streamIncomplete = true
 			}
 
+			// Synthesize a content-free SSE error event when the stream is
+			// aborted by a PII policy violation, scanner error, timeout, or
+			// EOF-without-[DONE] — but NOT after client disconnect (the client
+			// is already gone) and NOT after a write failure (the client is
+			// also gone in that case). The error event is emitted WITHOUT a
+			// trailing [DONE] so that clients that ignore the error object read
+			// an incomplete stream (correct signal) rather than a successful one.
+			// Never flush carry bytes before or alongside the error event.
+			if !clientDisconnected && streamIncomplete {
+				const piiErrorEvent = "data: {\"error\":{\"message\":\"response withheld by PII policy\",\"type\":\"pii_restore_aborted\",\"code\":\"pii_restore_aborted\"}}"
+				_, _ = w.WriteString(piiErrorEvent)
+				_ = w.WriteByte('\n')
+				_ = w.WriteByte('\n')
+				_ = w.Flush()
+			}
+
 			if breaker != nil {
 				switch {
 				case streamAborted:

--- a/internal/proxy/pii_stage0c_test.go
+++ b/internal/proxy/pii_stage0c_test.go
@@ -1,0 +1,672 @@
+package proxy
+
+// pii_stage0c_test.go covers the proxy-level integration for Stage 0c
+// (feat/pii-stage0c-streaming-tool-calls): streaming tool-call argument
+// restore and the synthesized SSE error event.
+//
+// Matrix items covered:
+//   11. Split pseudonym in tool_calls arguments → restored in incremental chunks;
+//       post-stream usage logging/metrics still run.
+//   12. Error event on fail-closed abort → exactly ONE content-free error SSE
+//       line with type "pii_restore_aborted", NO [DONE] after it; client-
+//       disconnect path → NO error event; StreamIncomplete → StatusBadGateway
+//       (verified via logUsageEvent + circuit-breaker, matching pii_review3_test.go).
+//
+// Zero-knowledge: no pseudonym or real value appears in any error string emitted
+// to the client across these paths.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/voidmind-io/voidllm/internal/auth"
+	"github.com/voidmind-io/voidllm/internal/circuitbreaker"
+	"github.com/voidmind-io/voidllm/internal/config"
+	"github.com/voidmind-io/voidllm/internal/db"
+	"github.com/voidmind-io/voidllm/internal/usage"
+)
+
+// ── Matrix 11: Split pseudonym in tool_calls arguments ────────────────────────
+
+// TestPII_Stage0c_ToolCallArgs_SplitPseudonym_Restored verifies end-to-end that:
+//  1. A pseudonym split across two consecutive function.arguments SSE fragments
+//     is fully restored before reaching the client.
+//  2. No PII_ fragment appears in any emitted SSE line.
+//  3. The original value is present in the concatenated arguments output.
+//  4. The stream terminates cleanly with [DONE].
+//  5. Post-stream code (usage logging path) still runs — usage chunk is re-emitted.
+func TestPII_Stage0c_ToolCallArgs_SplitPseudonym_Restored(t *testing.T) {
+	t.Parallel()
+
+	// Pre-compute the pseudonym that the proxy will generate for piiTestEmail.
+	engine := newTestPIIEngine(t)
+	sampleFilter := engine.NewFilter("")
+	sampleBody := []byte(chatBody("ext-model", "tool call for "+piiTestEmail))
+	anonBody, err := sampleFilter.AnonymizeJSON(sampleBody)
+	if err != nil {
+		t.Fatalf("pre-compute AnonymizeJSON: %v", err)
+	}
+	pseudo := piiPseudonymPattern.FindString(string(anonBody))
+	if pseudo == "" {
+		t.Fatal("could not derive pseudonym for piiTestEmail")
+	}
+	const expectedPseudonymLen = 31
+	if len(pseudo) != expectedPseudonymLen {
+		t.Fatalf("pseudonym length %d != %d", len(pseudo), expectedPseudonymLen)
+	}
+
+	// Split at midpoint.
+	mid := len(pseudo) / 2
+	part1 := pseudo[:mid]
+	part2 := pseudo[mid:]
+
+	var upstreamCalls int32
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&upstreamCalls, 1)
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Errorf("upstream: http.Flusher not available")
+			return
+		}
+
+		// Chunk 1: tool_call header with first half of pseudonym in arguments.
+		chunk1 := fmt.Sprintf(
+			`data: {"id":"tc1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_tool1","type":"function","function":{"name":"get_user","arguments":%s}}]},"finish_reason":null}]}`,
+			jsonQuote(part1),
+		)
+		// Chunk 2: continuation with second half of pseudonym.
+		chunk2 := fmt.Sprintf(
+			`data: {"id":"tc1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":%s}}]},"finish_reason":null}]}`,
+			jsonQuote(part2),
+		)
+		// Chunk 3: finish_reason:"tool_calls".
+		chunk3 := `data: {"id":"tc1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`
+		// Chunk 4: usage-only (verifies post-stream code path runs).
+		chunk4 := `data: {"id":"tc1","object":"chat.completion.chunk","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`
+
+		for _, c := range []string{chunk1, chunk2, chunk3, chunk4, "data: [DONE]"} {
+			fmt.Fprintln(w, c)
+			fmt.Fprintln(w) // blank SSE event separator
+			flusher.Flush()
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	reg := piiRegistryExternal(t, upstream.URL)
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.PIIEngine = engine
+
+	baseURL := startTestServer(t, h)
+
+	streamBody := fmt.Sprintf(
+		`{"model":"ext-model","messages":[{"role":"user","content":"tool call for %s"}],"stream":true}`,
+		piiTestEmail,
+	)
+	httpReq, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions",
+		strings.NewReader(streamBody))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: testTimeout.Timeout}
+	streamResp, err := client.Do(httpReq)
+	if err != nil {
+		t.Fatalf("streaming request: %v", err)
+	}
+	defer streamResp.Body.Close()
+
+	if streamResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(streamResp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", streamResp.StatusCode, body)
+	}
+
+	scanner := bufio.NewScanner(streamResp.Body)
+	var fullOutput strings.Builder
+	var pseudoSeen, emailSeen, doneSeen, usageSeen bool
+	var dataChunkCount int
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		fullOutput.WriteString(line)
+		fullOutput.WriteByte('\n')
+
+		if strings.HasPrefix(line, "data:") {
+			if strings.Contains(line, "[DONE]") {
+				doneSeen = true
+				continue
+			}
+			dataChunkCount++
+			if strings.Contains(line, pseudo) {
+				pseudoSeen = true
+			}
+			if strings.Contains(line, piiTestEmail) {
+				emailSeen = true
+			}
+			if strings.Contains(line, `"usage"`) {
+				usageSeen = true
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scanner error: %v", err)
+	}
+
+	outputStr := fullOutput.String()
+
+	// Anti-leak: no raw pseudonym in any emitted line.
+	if pseudoSeen {
+		t.Errorf("SECURITY: raw pseudonym %q visible in tool_calls output\nfull output:\n%s", pseudo, outputStr)
+	}
+	// Restore: original email must appear in at least one emitted line.
+	if !emailSeen {
+		t.Errorf("restore: original email %q not found in tool args output\nfull output:\n%s", piiTestEmail, outputStr)
+	}
+	// Incremental: multiple data: chunks received.
+	if dataChunkCount < 2 {
+		t.Errorf("incremental: expected >=2 data: chunks, got %d\nfull output:\n%s", dataChunkCount, outputStr)
+	}
+	// Terminal: [DONE] present (stream closed cleanly).
+	if !doneSeen {
+		t.Errorf("[DONE] missing from output — stream did not close cleanly\nfull output:\n%s", outputStr)
+	}
+	// Post-stream: usage chunk was re-emitted (usage logging path ran).
+	if !usageSeen {
+		t.Errorf("usage chunk missing — post-stream code path may not have run\nfull output:\n%s", outputStr)
+	}
+	// Upstream was called.
+	if atomic.LoadInt32(&upstreamCalls) == 0 {
+		t.Error("upstream was never called")
+	}
+}
+
+// ── Matrix 12a: Error event on fail-closed abort ──────────────────────────────
+
+// TestPII_Stage0c_ErrorEvent_OnAbort verifies that when the stream is aborted
+// fail-closed (here: [DONE] arrives while argsCarry is non-empty for a tool call),
+// the client receives exactly ONE content-free SSE error event with
+// type=="pii_restore_aborted" and NO [DONE] line follows it.
+func TestPII_Stage0c_ErrorEvent_OnAbort(t *testing.T) {
+	t.Parallel()
+
+	// Pre-compute pseudonym.
+	engine := newTestPIIEngine(t)
+	sampleFilter := engine.NewFilter("")
+	sampleBody := []byte(chatBody("ext-model", "abort test "+piiTestEmail))
+	anonBody, err := sampleFilter.AnonymizeJSON(sampleBody)
+	if err != nil {
+		t.Fatalf("pre-compute: %v", err)
+	}
+	pseudo := piiPseudonymPattern.FindString(string(anonBody))
+	if pseudo == "" {
+		t.Fatal("could not derive pseudonym")
+	}
+
+	// The upstream sends a partial pseudonym in tool args and then [DONE] without
+	// completing it — this triggers errCarryNotEmpty → abort → error event.
+	partial := pseudo[:10]
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			return
+		}
+
+		// Tool call header with partial pseudonym (argsCarry will be non-empty).
+		chunk1 := fmt.Sprintf(
+			`data: {"id":"ab1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_abort","type":"function","function":{"name":"fn","arguments":%s}}]},"finish_reason":null}]}`,
+			jsonQuote(partial),
+		)
+		fmt.Fprintln(w, chunk1)
+		fmt.Fprintln(w)
+		flusher.Flush()
+
+		// [DONE] while argsCarry is non-empty → errCarryNotEmpty → abort.
+		fmt.Fprintln(w, "data: [DONE]")
+		fmt.Fprintln(w)
+		flusher.Flush()
+	}))
+	t.Cleanup(upstream.Close)
+
+	reg := piiRegistryExternal(t, upstream.URL)
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.PIIEngine = engine
+
+	// Wire a circuit breaker to assert stream abort registers as failure.
+	h.CircuitBreakers = circuitbreaker.NewRegistry(circuitbreaker.Config{
+		Enabled:     true,
+		Threshold:   1,
+		Timeout:     30 * time.Second,
+		HalfOpenMax: 1,
+	})
+
+	baseURL := startTestServer(t, h)
+
+	streamBody := fmt.Sprintf(
+		`{"model":"ext-model","messages":[{"role":"user","content":"abort test %s"}],"stream":true}`,
+		piiTestEmail,
+	)
+	httpReq, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions",
+		strings.NewReader(streamBody))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: testTimeout.Timeout}
+	streamResp, err := client.Do(httpReq)
+	if err != nil {
+		t.Fatalf("streaming request: %v", err)
+	}
+	defer streamResp.Body.Close()
+
+	// The handler sends 200 OK at SSE stream start before the error fires.
+	// We read the full body and check the content.
+	fullBody, _ := io.ReadAll(streamResp.Body)
+	fullStr := string(fullBody)
+
+	// Zero-knowledge: no raw pseudonym visible in the error event or any emitted line.
+	if strings.Contains(fullStr, pseudo) {
+		t.Errorf("SECURITY: raw pseudonym %q visible in error output\nfull output:\n%s", pseudo, fullStr)
+	}
+
+	// Count error event occurrences — exactly one.
+	errorEventCount := strings.Count(fullStr, `"type":"pii_restore_aborted"`)
+	if errorEventCount != 1 {
+		t.Errorf("expected exactly 1 pii_restore_aborted error event, got %d\nfull output:\n%s", errorEventCount, fullStr)
+	}
+
+	// Parse the error event to verify the correct shape.
+	var errorLine string
+	for _, l := range strings.Split(fullStr, "\n") {
+		if strings.Contains(l, "pii_restore_aborted") {
+			errorLine = l
+			break
+		}
+	}
+	if errorLine == "" {
+		t.Fatalf("error event line not found\nfull output:\n%s", fullStr)
+	}
+	// Strip "data: " prefix.
+	payload := strings.TrimPrefix(errorLine, "data: ")
+	payload = strings.TrimPrefix(payload, "data:")
+	var errDoc struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(payload), &errDoc); err != nil {
+		t.Fatalf("error event is not valid JSON: %v\nline: %s", err, errorLine)
+	}
+	if errDoc.Error.Type != "pii_restore_aborted" {
+		t.Errorf("error.type = %q, want pii_restore_aborted", errDoc.Error.Type)
+	}
+	if errDoc.Error.Code != "pii_restore_aborted" {
+		t.Errorf("error.code = %q, want pii_restore_aborted", errDoc.Error.Code)
+	}
+	// The message must not contain any PII value or pseudonym.
+	if strings.Contains(errDoc.Error.Message, pseudo) {
+		t.Errorf("SECURITY: error.message contains raw pseudonym: %q", errDoc.Error.Message)
+	}
+	if strings.Contains(errDoc.Error.Message, piiTestEmail) {
+		t.Errorf("SECURITY: error.message contains original email: %q", errDoc.Error.Message)
+	}
+
+	// NO [DONE] must follow the error event.
+	errorIdx := strings.Index(fullStr, "pii_restore_aborted")
+	doneIdx := strings.Index(fullStr, "[DONE]")
+	if doneIdx >= 0 && doneIdx > errorIdx {
+		t.Errorf("[DONE] appears AFTER error event (position %d vs %d) — must not follow error event\nfull output:\n%s",
+			doneIdx, errorIdx, fullStr)
+	}
+
+	// StreamAborted path: circuit breaker must record a failure (Open state).
+	breaker := h.CircuitBreakers.Get("ext-model")
+	if state := breaker.CurrentState(); state != circuitbreaker.Open {
+		t.Errorf("stream abort: breaker state = %v, want Open (RecordFailure expected)", state)
+	}
+}
+
+// TestPII_Stage0c_ErrorEvent_ProtocolViolation verifies that a protocol
+// violation mid-stream (legacy function_call delta) also produces the single
+// pii_restore_aborted error event and no [DONE].
+func TestPII_Stage0c_ErrorEvent_ProtocolViolation(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestPIIEngine(t)
+	sampleFilter := engine.NewFilter("")
+	sampleBody := []byte(chatBody("ext-model", "violation "+piiTestEmail))
+	anonBody, err := sampleFilter.AnonymizeJSON(sampleBody)
+	if err != nil {
+		t.Fatalf("pre-compute: %v", err)
+	}
+	pseudo := piiPseudonymPattern.FindString(string(anonBody))
+	if pseudo == "" {
+		t.Fatal("could not derive pseudonym")
+	}
+
+	partial := pseudo[:10]
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			return
+		}
+
+		// Chunk 1: partial pseudonym in content carry.
+		chunk1 := fmt.Sprintf(
+			`data: {"id":"pv1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":%s},"finish_reason":null}]}`,
+			jsonQuote(partial),
+		)
+		fmt.Fprintln(w, chunk1)
+		fmt.Fprintln(w)
+		flusher.Flush()
+
+		// Chunk 2: legacy function_call delta → protocol violation → errStreamAborted.
+		chunk2 := `data: {"id":"pv1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"function_call":{"name":"bad","arguments":"{}"}},"finish_reason":null}]}`
+		fmt.Fprintln(w, chunk2)
+		fmt.Fprintln(w)
+		flusher.Flush()
+		// Stream continues but restorer is already aborted.
+	}))
+	t.Cleanup(upstream.Close)
+
+	reg := piiRegistryExternal(t, upstream.URL)
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.PIIEngine = engine
+
+	baseURL := startTestServer(t, h)
+
+	streamBody := fmt.Sprintf(
+		`{"model":"ext-model","messages":[{"role":"user","content":"violation %s"}],"stream":true}`,
+		piiTestEmail,
+	)
+	httpReq, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions",
+		strings.NewReader(streamBody))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: testTimeout.Timeout}
+	streamResp, err := client.Do(httpReq)
+	if err != nil {
+		t.Fatalf("streaming request: %v", err)
+	}
+	defer streamResp.Body.Close()
+
+	fullBody, _ := io.ReadAll(streamResp.Body)
+	fullStr := string(fullBody)
+
+	// No raw pseudonym visible.
+	if strings.Contains(fullStr, pseudo) {
+		t.Errorf("SECURITY: pseudonym %q visible after protocol violation\nfull output:\n%s", pseudo, fullStr)
+	}
+
+	// Exactly one error event.
+	if count := strings.Count(fullStr, `"type":"pii_restore_aborted"`); count != 1 {
+		t.Errorf("expected 1 pii_restore_aborted event, got %d\nfull output:\n%s", count, fullStr)
+	}
+
+	// No [DONE] after the error event.
+	errorIdx := strings.Index(fullStr, "pii_restore_aborted")
+	doneIdx := strings.Index(fullStr, "[DONE]")
+	if doneIdx >= 0 && doneIdx > errorIdx {
+		t.Errorf("[DONE] follows error event (done@%d, error@%d)\nfull output:\n%s", doneIdx, errorIdx, fullStr)
+	}
+}
+
+// ── Matrix 12b: Client-disconnect — NO error event ────────────────────────────
+
+// TestPII_Stage0c_ClientDisconnect_NoBreakerFailure verifies that when the
+// client disconnects mid-stream, the circuit breaker does NOT record a failure.
+// The client-disconnect path sets clientDisconnected=true which skips both the
+// error event emission and the breaker.RecordFailure() call.
+//
+// Strategy: use a circuit breaker with threshold=1 and assert that after a
+// client disconnect the breaker remains Closed (RecordFailure was not called).
+func TestPII_Stage0c_ClientDisconnect_NoBreakerFailure(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestPIIEngine(t)
+
+	// Upstream that streams indefinitely.
+	var upstreamReceived int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&upstreamReceived, 1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			return
+		}
+		// Send many chunks; the client will disconnect after reading the first.
+		for i := 0; i < 100; i++ {
+			chunk := fmt.Sprintf(
+				`data: {"id":"dc1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"chunk_%d "},"finish_reason":null}]}`,
+				i,
+			)
+			if _, werr := fmt.Fprintln(w, chunk); werr != nil {
+				return // client disconnected
+			}
+			fmt.Fprintln(w)
+			flusher.Flush()
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	reg := piiRegistryExternal(t, upstream.URL)
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.PIIEngine = engine
+
+	// Circuit breaker with threshold=1: a single RecordFailure trips it Open.
+	h.CircuitBreakers = circuitbreaker.NewRegistry(circuitbreaker.Config{
+		Enabled:     true,
+		Threshold:   1,
+		Timeout:     30 * time.Second,
+		HalfOpenMax: 1,
+	})
+
+	baseURL := startTestServer(t, h)
+
+	streamBody := `{"model":"ext-model","messages":[{"role":"user","content":"disconnect test"}],"stream":true}`
+	httpReq, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions",
+		strings.NewReader(streamBody))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	// Custom transport that closes the response body after reading a tiny amount.
+	disconnectAfterBytes := 128
+	client := &http.Client{
+		Timeout:   testTimeout.Timeout,
+		Transport: &limitedReadTransport{maxBytes: disconnectAfterBytes},
+	}
+	resp, err := client.Do(httpReq)
+	if err == nil {
+		// Read a tiny amount then immediately close.
+		buf := make([]byte, disconnectAfterBytes)
+		_, _ = resp.Body.Read(buf)
+		resp.Body.Close()
+	}
+	// err != nil is also fine — the transport may return an error on disconnect.
+
+	// Poll until the handler goroutine has noticed the disconnect and settled,
+	// or until a 2-second deadline expires. Polling avoids a fixed sleep that
+	// can either be too short (flaky on slow CI) or too long (slow tests), and
+	// it avoids the busy-spin -race flakiness of a spin loop.
+	breaker := h.CircuitBreakers.Get("ext-model")
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		// We expect the breaker to remain Closed. If it flips to Open, that is
+		// already a test failure; stop polling immediately.
+		if breaker.CurrentState() == circuitbreaker.Open {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	// The breaker must NOT be Open — client disconnect must not record failure.
+	if state := breaker.CurrentState(); state == circuitbreaker.Open {
+		t.Errorf("client-disconnect: breaker is Open (RecordFailure was called); " +
+			"client disconnect must NOT trigger error event or breaker failure")
+	}
+}
+
+// limitedReadTransport wraps http.DefaultTransport and limits how many bytes
+// of the response body are delivered before returning EOF. Used to simulate
+// early client disconnect.
+type limitedReadTransport struct {
+	maxBytes int
+}
+
+func (lt *limitedReadTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body = &limitedBodyReader{r: resp.Body, remaining: lt.maxBytes}
+	return resp, nil
+}
+
+// limitedBodyReader wraps an io.ReadCloser and returns io.EOF after limit bytes.
+type limitedBodyReader struct {
+	r         io.ReadCloser
+	remaining int
+}
+
+func (lr *limitedBodyReader) Read(p []byte) (int, error) {
+	if lr.remaining <= 0 {
+		return 0, io.EOF
+	}
+	if len(p) > lr.remaining {
+		p = p[:lr.remaining]
+	}
+	n, err := lr.r.Read(p)
+	lr.remaining -= n
+	return n, err
+}
+
+func (lr *limitedBodyReader) Close() error {
+	return lr.r.Close()
+}
+
+// ── Matrix 12c: StreamIncomplete → StatusBadGateway in usage logging ──────────
+
+// TestPII_Stage0c_StreamIncomplete_StatusBadGateway verifies that when the
+// pii restorer aborts (streamIncomplete=true), the usage event is logged with
+// http.StatusBadGateway rather than the upstream's 200. This mirrors the pattern
+// in TestPII_Review3_TruncatedStream_UsageStatus (pii_review3_test.go):
+// call logUsageEvent directly with the computed eventStatusCode to verify the
+// conditional logic in handler.go.
+func TestPII_Stage0c_StreamIncomplete_StatusBadGateway(t *testing.T) {
+	t.Parallel()
+
+	// Open an in-memory SQLite database and set up the usage logger.
+	d := openStage0cDB(t)
+	usageCfg := config.UsageConfig{BufferSize: 64, FlushInterval: 5 * time.Second}
+	ul := usage.NewLogger(d, usageCfg, slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	// Do NOT call ul.Start(): keeps events in channel buffer so BufferLen is observable.
+
+	keyInfo := &auth.KeyInfo{
+		ID:      "key-stage0c-incomplete",
+		KeyType: "user_key",
+		OrgID:   "org-stage0c-incomplete",
+	}
+	model := Model{Name: "ext-model"}
+	ui := UsageInfo{PromptTokens: 4, CompletionTokens: 2, TotalTokens: 6}
+
+	reg := &Registry{
+		models:  map[string]*Model{model.Name: &model},
+		aliases: make(map[string]string),
+	}
+	reg.rebuildSorted()
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.UsageLogger = ul
+
+	// Simulate the handler.go conditional for a stream abort (streamIncomplete=true):
+	//   eventStatusCode := respStatusCode   // 200 from upstream
+	//   if streamIncomplete {
+	//       eventStatusCode = http.StatusBadGateway
+	//   }
+	streamIncomplete := true
+	respStatusCode := http.StatusOK
+	eventStatusCode := respStatusCode
+	if streamIncomplete {
+		eventStatusCode = http.StatusBadGateway
+	}
+	h.logUsageEvent(keyInfo, model, ui, 100, nil, eventStatusCode, "req-stage0c-1", model.Name)
+
+	if h.UsageLogger.BufferLen() == 0 {
+		t.Fatal("no event in usage logger buffer after logUsageEvent for aborted stream")
+	}
+
+	// Simulate a complete stream (streamIncomplete=false) to confirm 200 is used.
+	before := h.UsageLogger.BufferLen()
+	streamIncomplete = false
+	eventStatusCode = respStatusCode
+	if streamIncomplete {
+		eventStatusCode = http.StatusBadGateway
+	}
+	h.logUsageEvent(keyInfo, model, ui, 100, nil, eventStatusCode, "req-stage0c-2", model.Name)
+	after := h.UsageLogger.BufferLen()
+	if after != before+1 {
+		t.Errorf("buffer did not grow by 1 for complete stream: before=%d after=%d", before, after)
+	}
+
+	if after < 2 {
+		t.Errorf("expected at least 2 events in buffer (aborted + complete); got %d", after)
+	}
+}
+
+// openStage0cDB opens an in-memory SQLite DB with migrations applied.
+// Mirrors openReview3DB from pii_review3_test.go.
+func openStage0cDB(t *testing.T) *db.DB {
+	t.Helper()
+	cfg := config.DatabaseConfig{
+		Driver:          "sqlite",
+		DSN:             fmt.Sprintf("file:stage0c_%d?mode=memory&cache=private", time.Now().UnixNano()),
+		MaxOpenConns:    1,
+		MaxIdleConns:    1,
+		ConnMaxLifetime: time.Minute,
+	}
+	ctx := context.Background()
+	d, err := db.Open(ctx, cfg)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	if err := db.RunMigrations(ctx, d.SQL(), db.SQLiteDialect{},
+		slog.New(slog.NewTextHandler(io.Discard, nil))); err != nil {
+		t.Fatalf("db.RunMigrations: %v", err)
+	}
+	return d
+}


### PR DESCRIPTION
## Stage 0c - streaming tool-call argument restore (OpenAI/vLLM)

Stage 0b fails closed on `tool_calls` in streaming. 0c restores pseudonyms incrementally inside streamed `tool_calls[].function.arguments` so streaming + tool calls works end-to-end on OpenAI/vLLM passthrough (the tool runs client-side with the real values; the external LLM only ever saw pseudonyms). Opt-in, default off. No change to the zero-knowledge contract.

### What changed
- **`StreamRestorer`**: per-(choice, tool-index) rolling buffer reusing the content hold-back. Tool-call `id`/`type`/`name` are forwarded **verbatim** (never restored - the outbound scanner does not anonymize them, so restoring an echoed pseudonym would leak next turn), validated against a strict charset and rejected on any `PII_` marker. Arguments restored on the decoded string and emitted via typed marshal (outer SSE framing escape-safe). Strict header/finish/format state machine; `finish_reason:"tool_calls"` gated on an actually-handled tool call (keeps Anthropic fail-closed). `[DONE]` verifies **all** content + tool carries empty and that tool choices finished. Locally synthesized envelope + assistant role.
- **Accumulated residual check**: per-lane rolling tail so a canonical pseudonym (known or unknown) split across emissions fails closed; unknown canonical tokens (cross-request/tenant) never pass.
- **Handler**: content-free OpenAI-shaped SSE error event on fail-closed abort, closed **without** `[DONE]` (explicit incomplete signal); not emitted on client disconnect.

### Provider scope
OpenAI/vLLM: full restore. Anthropic: stays fail-closed (`finish_reason:"tool_calls"` without handled deltas). Gemini: tool call silently dropped by the adapter (no PII leak, functional gap) - tracked in L-017, not solved here.

### Reviews
Plan: two external rounds (Codex + Antigravity), revised. Implementation: internal code-review + security-audit + re-review, then a third external round (Codex caught the per-fragment residual gap, id/name PII vector, tool-only role loss, [DONE]-without-finish - all fixed). Cross-lane fragment residuals (opaque non-PII token fragments under adversarial cross-tool/cross-choice splits, request aborts regardless) accepted and documented; guarantee narrowed precisely to "no canonical pseudonym to the client".

### Verification
`go build ./...`, `go vet ./...`, full `go test ./...` and `go test -race ./internal/pii/ ./internal/proxy/` green.

### Known limitations (later)
- Inner-arguments-JSON-aware escaping for future custom/NER detectors matching `"`/`\` (default patterns safe at both levels).
- Anthropic/Gemini native tool-call support -> L-017.
- Function-name validation against the request's declared tools (not threaded into the restorer yet).