### PR TITLE
feat(proxy): native tool-call translation in the Gemini adapter

### DIFF
--- a/internal/proxy/adapter.go
+++ b/internal/proxy/adapter.go
@@ -1,6 +1,41 @@
 package proxy
 
-import "net/http"
+import (
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// forwardedPseudonymRe matches the canonical PII pseudonym shape produced by
+// the PII pipeline: PII_ followed by exactly 2 alphanumeric characters, then
+// _, then exactly 24 lowercase hex characters. This is an intentional local
+// copy of the pii package's canonicalPseudonymRe; importing that unexported
+// symbol would create a cross-package dependency from the hot proxy path into
+// the PII pipeline.
+var forwardedPseudonymRe = regexp.MustCompile(`PII_[A-Za-z0-9]{2}_[0-9a-f]{24}`)
+
+// forwardedPseudonymMarker is the fixed 4-byte prefix shared by every PII
+// pseudonym. Its presence as a substring in any forwarded field value is
+// sufficient to reject the value fail-closed.
+const forwardedPseudonymMarker = "PII_"
+
+// isForwardedPseudonym reports whether s could carry a PII pseudonym: either
+// it contains the pseudonym marker as a substring, or it matches the canonical
+// pseudonym shape. Either condition is sufficient to trigger fail-closed
+// rejection on the non-streaming response path.
+//
+// WHY this check exists: on the non-streaming response path the PII layer's
+// filter.Restore performs a global string replacement over the entire response
+// body. Tool-call id and function name fields are not field-aware-restored;
+// they are replaced as plain substrings. If a malicious or compromised upstream
+// returns a function name or tool id that happens to match a pseudonym in the
+// current request's reverse map, Restore would substitute the real PII value
+// into that field and the client would receive PII in tool_calls[].id or
+// tool_calls[].function.name. Rejecting pseudonym-shaped values fail-closed
+// prevents this substitution from reaching the client.
+func isForwardedPseudonym(s string) bool {
+	return strings.Contains(s, forwardedPseudonymMarker) || forwardedPseudonymRe.MatchString(s)
+}
 
 // UsageInfo holds token counts extracted from a completed upstream response.
 // For non-streaming responses the counts come from the response JSON; for

--- a/internal/proxy/anthropic.go
+++ b/internal/proxy/anthropic.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/voidmind-io/voidllm/internal/jsonx"
 )
@@ -14,8 +15,9 @@ import (
 // maxAnthropicToolBlocks is the adapter-level cap on the number of distinct
 // tool_use content blocks that may appear in a single stream. Streams that
 // exceed this limit have excess blocks silently dropped (the event returns nil).
-// This is a defense-in-depth DoS cap independent of any PII pipeline limits.
-const maxAnthropicToolBlocks = 1024
+// This is a defense-in-depth DoS cap independent of any PII pipeline limits,
+// aligned with maxToolCallsPerChoice=64 in the PII Stage 0c StreamRestorer.
+const maxAnthropicToolBlocks = 64
 
 // anthropicToolIDRe is the conservative charset used for tool ids and function
 // names forwarded to or received from Anthropic. Ids and names must match this
@@ -32,6 +34,7 @@ var anthropicToolIDRe = regexp.MustCompile(`^[A-Za-z0-9_.+\-]+$`)
 // requests because TransformStreamLine tracks per-stream state.
 type AnthropicAdapter struct {
 	msgID        string // populated by the first message_start event in a stream
+	modelName    string // stored from TransformRequest for use in TransformResponse
 	inputTokens  int    // accumulated from message_start usage
 	outputTokens int    // accumulated from message_delta usage
 
@@ -253,6 +256,14 @@ func (a *AnthropicAdapter) TransformRequest(body []byte, _ Model) ([]byte, error
 		return nil, fmt.Errorf("anthropic transform request: unmarshal body: %w", err)
 	}
 
+	// Capture the model name for use in TransformResponse synthesis.
+	if raw, ok := doc["model"]; ok {
+		var name string
+		if err := jsonx.Unmarshal(raw, &name); err == nil {
+			a.modelName = name
+		}
+	}
+
 	// Collect declared tool names for tool_choice validation.
 	var declaredToolNames []string
 
@@ -397,7 +408,7 @@ func (a *AnthropicAdapter) TransformRequest(body []byte, _ Model) ([]byte, error
 								Type string `json:"type"`
 								Text string `json:"text"`
 							}
-							var blocks []anthropicTextBlock
+							blocks := make([]anthropicTextBlock, 0, len(parts))
 							for _, p := range parts {
 								if p.Type == "text" {
 									blocks = append(blocks, anthropicTextBlock{
@@ -583,6 +594,19 @@ func (a *AnthropicAdapter) TransformResponse(body []byte) ([]byte, error) {
 			if block.Name != "" && !anthropicToolIDRe.MatchString(block.Name) {
 				return nil, errors.New("anthropic transform response: tool_use name contains invalid characters")
 			}
+			// FIX 1 (parity security): reject any tool_use id or name that contains
+			// or matches the PII pseudonym shape. On the non-streaming path,
+			// filter.Restore performs a global string replacement over the whole body;
+			// if a (malicious or compromised) upstream returns an id or name that
+			// matches a pseudonym in this request's reverse map, Restore would replace
+			// it with the real PII value and the client would see PII in
+			// tool_calls[].id or tool_calls[].function.name.
+			if isForwardedPseudonym(block.ID) {
+				return nil, errors.New("anthropic transform response: tool_use id rejected")
+			}
+			if isForwardedPseudonym(block.Name) {
+				return nil, errors.New("anthropic transform response: tool_use name rejected")
+			}
 			// FIX 7: if input is present, it must be a JSON object.
 			argsStr, err := serializeInputToArguments(block.Input)
 			if err != nil {
@@ -625,10 +649,21 @@ func (a *AnthropicAdapter) TransformResponse(body []byte) ([]byte, error) {
 		msg.ToolCalls = toolCalls
 	}
 
+	// FIX 2: synthesize id and model locally rather than forwarding upstream
+	// values. The upstream Anthropic id (ar.ID) and model (ar.Model) are
+	// forwarded strings that pass through filter.Restore; if a malicious or
+	// compromised upstream echoed a PII pseudonym into these fields, Restore
+	// would substitute real PII into a structural client field. Using a proxy-
+	// generated id (timestamp-based) and the client-requested model name
+	// (captured from TransformRequest) prevents this leak.
+	respModel := a.modelName
+	if respModel == "" {
+		respModel = "claude"
+	}
 	resp := openAIResponse{
-		ID:     ar.ID,
+		ID:     fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano()),
 		Object: "chat.completion",
-		Model:  ar.Model,
+		Model:  respModel,
 		Choices: []openAIChoice{
 			{
 				Index:        0,
@@ -972,18 +1007,18 @@ func translateToolChoice(raw jsonx.RawMessage, declaredNames []string) (*anthrop
 	if !anthropicToolIDRe.MatchString(obj.Function.Name) {
 		return nil, errors.New("tool_choice function name contains invalid characters")
 	}
-	// FIX 6: named tool_choice must reference a declared tool.
-	if len(declaredNames) > 0 {
-		found := false
-		for _, n := range declaredNames {
-			if n == obj.Function.Name {
-				found = true
-				break
-			}
+	// FIX 4: a named tool_choice MUST reference a declared tool unconditionally.
+	// If there are no declared tools at all, or the name is not among them,
+	// fail-closed. A named tool_choice with no tools array is a protocol error.
+	found := false
+	for _, n := range declaredNames {
+		if n == obj.Function.Name {
+			found = true
+			break
 		}
-		if !found {
-			return nil, errors.New("tool_choice references undeclared tool")
-		}
+	}
+	if !found {
+		return nil, errors.New("tool_choice references undeclared tool")
 	}
 	return &anthropicToolChoice{Type: "tool", Name: obj.Function.Name}, nil
 }

--- a/internal/proxy/anthropic_test.go
+++ b/internal/proxy/anthropic_test.go
@@ -490,9 +490,11 @@ func TestAnthropicTransformResponse(t *testing.T) {
 		wantErr        bool
 	}{
 		{
-			name:           "basic response maps fields to OpenAI format",
+			// FIX 2: id is synthesized by the proxy (chatcmpl-<timestamp>), not
+			// forwarded from upstream. The upstream id "msg_01abc" must not appear
+			// in the response; the synthesized id must start with "chatcmpl-".
+			name:           "basic response maps fields to OpenAI format with synthesized id",
 			inputJSON:      `{"id":"msg_01abc","type":"message","model":"claude-3-5-sonnet-20240620","content":[{"type":"text","text":"Hello there"}],"stop_reason":"end_turn","usage":{"input_tokens":10,"output_tokens":5}}`,
-			wantID:         "msg_01abc",
 			wantObject:     "chat.completion",
 			wantContent:    strPtr("Hello there"),
 			wantFinish:     "stop",
@@ -1279,7 +1281,11 @@ func TestAnthropicTransformRequest_ToolResultArrayContent(t *testing.T) {
 		if block.Type != "tool_result" {
 			t.Errorf("type = %q, want tool_result", block.Type)
 		}
-		// Content is an empty array (non-text parts are skipped).
+		// Must be literally "[]", not "null" — a nil Go slice marshals to null,
+		// but we want an explicit empty array for consistency with Gemini adapter.
+		if string(block.Content) == "null" {
+			t.Fatalf("tool_result.content is null; want [] (use make([]T, 0) not var []T)")
+		}
 		var blocks []struct {
 			Type string `json:"type"`
 			Text string `json:"text"`
@@ -3525,9 +3531,10 @@ func TestAnthropicStream_ToolUseCharsetValidation(t *testing.T) {
 // ── FIX 2: unconditional charset validation in translateToolChoice ────────────
 
 // TestAnthropicTranslateToolChoice_InvalidNameNoTools verifies that
-// translateToolChoice rejects a named function tool_choice whose name contains
-// invalid characters even when no tools are declared (declaredNames is empty).
-// This is the regression from the original conditional guard.
+// translateToolChoice rejects a named function tool_choice unconditionally when
+// the name is invalid OR when no tools are declared (declaredNames is empty).
+// FIX 4: a named tool_choice must reference a declared tool — if there are no
+// declared tools, or the name is not among them, the result is fail-closed.
 func TestAnthropicTranslateToolChoice_InvalidNameNoTools(t *testing.T) {
 	t.Parallel()
 
@@ -3547,20 +3554,22 @@ func TestAnthropicTranslateToolChoice_InvalidNameNoTools(t *testing.T) {
 			wantErr:       true,
 		},
 		{
-			name:          "valid function name accepted when no tools declared",
+			// FIX 4: a valid name but no declared tools is also fail-closed.
+			// A named tool_choice with no tools array is a protocol error.
+			name:          "valid function name with no declared tools is rejected fail-closed",
 			toolChoiceRaw: `{"type":"function","function":{"name":"valid_fn"}}`,
-			wantErr:       false,
+			wantErr:       true,
 		},
 	}
 
-	// Use no declared tools (empty tools list) so we hit the previously
-	// unchecked code path where declaredNames was empty.
+	// Use no declared tools (empty tools list) so we hit the fail-closed
+	// unconditional check.
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Build a request with NO tools array but with tool_choice (unusual but valid
-			// to construct to test the isolated translateToolChoice behavior).
+			// Build a request with NO tools array but with tool_choice (unusual but
+			// valid to construct to test the isolated translateToolChoice behavior).
 			raw := json.RawMessage(tc.toolChoiceRaw)
 			_, err := translateToolChoice(raw, nil)
 			if tc.wantErr && err == nil {
@@ -3701,4 +3710,221 @@ func TestAnthropicBuildTextMessage_NullContent(t *testing.T) {
 			t.Fatal("expected error for numeric content, got nil")
 		}
 	})
+}
+
+// ── FIX 1 (parity security): pseudonym-shaped tool_use id/name rejected ──────
+
+// TestAnthropicTransformResponse_PseudonymToolUse verifies that FIX 1 closes
+// the non-streaming PII leak in the Anthropic adapter's TransformResponse.
+// If a (malicious or compromised) upstream returns a tool_use id or name that
+// contains or matches the canonical PII pseudonym shape, TransformResponse must
+// return a content-free error rather than forwarding the value (where
+// filter.Restore would substitute real PII into the response body).
+func TestAnthropicTransformResponse_PseudonymToolUse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		inputJSON string
+	}{
+		{
+			name: "tool_use id matching canonical pseudonym shape is rejected",
+			// PII_EM_<24hex> is the shape of an email pseudonym (2-char type abbrev = EM).
+			inputJSON: `{"id":"msg_01","type":"message","model":"claude-3","content":[{"type":"tool_use","id":"PII_EM_aabbccddeeff00112233445566","name":"get_weather","input":{"location":"NYC"}}],"stop_reason":"tool_use","usage":{"input_tokens":5,"output_tokens":3}}`,
+		},
+		{
+			name:      "tool_use name matching canonical pseudonym shape is rejected",
+			inputJSON: `{"id":"msg_02","type":"message","model":"claude-3","content":[{"type":"tool_use","id":"toolu_01","name":"PII_PN_aabbccddeeff00112233445566","input":{"q":"x"}}],"stop_reason":"tool_use","usage":{"input_tokens":5,"output_tokens":3}}`,
+		},
+		{
+			name:      "tool_use id containing PII_ substring is rejected",
+			inputJSON: `{"id":"msg_03","type":"message","model":"claude-3","content":[{"type":"tool_use","id":"toolu_PII_something","name":"fn","input":{}}],"stop_reason":"tool_use","usage":{"input_tokens":5,"output_tokens":3}}`,
+		},
+		{
+			name:      "tool_use name containing PII_ substring is rejected",
+			inputJSON: `{"id":"msg_04","type":"message","model":"claude-3","content":[{"type":"tool_use","id":"toolu_01","name":"fn_PII_suffix","input":{}}],"stop_reason":"tool_use","usage":{"input_tokens":5,"output_tokens":3}}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &AnthropicAdapter{}
+			out, err := a.TransformResponse([]byte(tc.inputJSON))
+			if err == nil {
+				t.Fatalf("TransformResponse() = %s, want error for pseudonym-shaped tool_use field", out)
+			}
+			// Error must be content-free: must not echo back the pseudonym value.
+			errStr := err.Error()
+			if strings.Contains(errStr, "PII_EM_") || strings.Contains(errStr, "aabbcc") ||
+				strings.Contains(errStr, "PII_PN_") || strings.Contains(errStr, "PII_something") ||
+				strings.Contains(errStr, "PII_suffix") {
+				t.Errorf("error message leaks pseudonym content: %s", errStr)
+			}
+		})
+	}
+}
+
+// TestAnthropicTransformResponse_LegitToolUse confirms that a legitimate tool_use
+// block (no PII_ prefix in id or name) is not rejected by the pseudonym check.
+func TestAnthropicTransformResponse_LegitToolUse(t *testing.T) {
+	t.Parallel()
+
+	input := `{"id":"msg_01","type":"message","model":"claude-3","content":[{"type":"tool_use","id":"toolu_01","name":"get_weather","input":{"location":"London"}}],"stop_reason":"tool_use","usage":{"input_tokens":10,"output_tokens":5}}`
+	a := &AnthropicAdapter{}
+	out, err := a.TransformResponse([]byte(input))
+	if err != nil {
+		t.Fatalf("TransformResponse() error = %v for legitimate tool_use id/name", err)
+	}
+	if out == nil {
+		t.Fatal("TransformResponse() = nil, want non-nil for legitimate tool_use")
+	}
+}
+
+// ── FIX 2: synthesized id/model — upstream values not forwarded ───────────────
+
+// TestAnthropicTransformResponse_SynthesizedIDModel verifies that
+// TransformResponse synthesizes the response id and model locally, rather than
+// forwarding the upstream Anthropic id (which could carry a PII pseudonym that
+// filter.Restore would expand into real PII in a structural client field).
+func TestAnthropicTransformResponse_SynthesizedIDModel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("upstream id is not forwarded to client", func(t *testing.T) {
+		t.Parallel()
+		upstream := `{"id":"msg_UPSTREAM_ID","type":"message","model":"claude-3-opus","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn","usage":{"input_tokens":5,"output_tokens":3}}`
+		a := &AnthropicAdapter{}
+		out, err := a.TransformResponse([]byte(upstream))
+		if err != nil {
+			t.Fatalf("TransformResponse() error = %v", err)
+		}
+		var resp openAIResponse
+		if err := json.Unmarshal(out, &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		// The upstream id must not appear verbatim in the response.
+		if resp.ID == "msg_UPSTREAM_ID" {
+			t.Error("upstream id was forwarded verbatim to client; must be synthesized")
+		}
+		// Synthesized id must start with "chatcmpl-".
+		if !strings.HasPrefix(resp.ID, "chatcmpl-") {
+			t.Errorf("synthesized id = %q, want chatcmpl- prefix", resp.ID)
+		}
+	})
+
+	t.Run("upstream model is not forwarded when modelName captured from request", func(t *testing.T) {
+		t.Parallel()
+		upstream := `{"id":"msg_01","type":"message","model":"claude-upstream-model","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`
+		a := &AnthropicAdapter{}
+		// Simulate TransformRequest having set modelName.
+		a.modelName = "claude-3-sonnet-client-requested"
+		out, err := a.TransformResponse([]byte(upstream))
+		if err != nil {
+			t.Fatalf("TransformResponse() error = %v", err)
+		}
+		var resp openAIResponse
+		if err := json.Unmarshal(out, &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		// Response model must be the client-requested name, not the upstream model.
+		if resp.Model == "claude-upstream-model" {
+			t.Error("upstream model name was forwarded verbatim; must use client-requested model")
+		}
+		if resp.Model != "claude-3-sonnet-client-requested" {
+			t.Errorf("model = %q, want claude-3-sonnet-client-requested", resp.Model)
+		}
+	})
+
+	t.Run("TransformRequest captures model name for response synthesis", func(t *testing.T) {
+		t.Parallel()
+		a := &AnthropicAdapter{}
+		input := `{"model":"my-claude-model","messages":[{"role":"user","content":"hi"}]}`
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err != nil {
+			t.Fatalf("TransformRequest() error = %v", err)
+		}
+		if a.modelName != "my-claude-model" {
+			t.Errorf("modelName = %q after TransformRequest, want my-claude-model", a.modelName)
+		}
+	})
+
+	t.Run("pseudonym in upstream id does not leak to client", func(t *testing.T) {
+		t.Parallel()
+		// A malicious upstream echoes a PII pseudonym into the id field.
+		// filter.Restore would substitute the real PII if we forwarded it.
+		// The synthesized id must not carry the pseudonym.
+		upstream := `{"id":"PII_EM_aabbccddeeff00112233445566","type":"message","model":"claude-3","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`
+		a := &AnthropicAdapter{}
+		out, err := a.TransformResponse([]byte(upstream))
+		if err != nil {
+			t.Fatalf("TransformResponse() error = %v", err)
+		}
+		outStr := string(out)
+		// The pseudonym must not appear in the output at all.
+		if strings.Contains(outStr, "PII_EM_aabbccddeeff00112233445566") {
+			t.Errorf("SECURITY: upstream pseudonym-shaped id leaked into response: %s", outStr)
+		}
+	})
+}
+
+// ── FIX 4: named tool_choice with no declared tools ───────────────────────────
+
+// TestAnthropicTransformRequest_Fix4_NamedToolChoiceNoTools verifies that a
+// named tool_choice without any declared tools fails closed unconditionally.
+func TestAnthropicTransformRequest_Fix4_NamedToolChoiceNoTools(t *testing.T) {
+	t.Parallel()
+
+	t.Run("named tool_choice with no tools array returns error", func(t *testing.T) {
+		t.Parallel()
+		// No tools declared, but tool_choice names a function.
+		input := `{"model":"claude-3","messages":[{"role":"user","content":"q"}],"tool_choice":{"type":"function","function":{"name":"get_data"}}}`
+		a := &AnthropicAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err == nil {
+			t.Fatal("expected error for named tool_choice with no tools declared, got nil")
+		}
+	})
+
+	t.Run("named tool_choice with tools but name not in list returns error", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"model":"claude-3",
+			"messages":[{"role":"user","content":"q"}],
+			"tools":[{"type":"function","function":{"name":"fn_a","parameters":{}}}],
+			"tool_choice":{"type":"function","function":{"name":"fn_missing"}}
+		}`
+		a := &AnthropicAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err == nil {
+			t.Fatal("expected error for named tool_choice referencing undeclared function, got nil")
+		}
+	})
+
+	t.Run("named tool_choice with matching declared tool succeeds", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"model":"claude-3",
+			"messages":[{"role":"user","content":"q"}],
+			"tools":[{"type":"function","function":{"name":"get_data","parameters":{}}}],
+			"tool_choice":{"type":"function","function":{"name":"get_data"}}
+		}`
+		a := &AnthropicAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err != nil {
+			t.Fatalf("unexpected error for valid named tool_choice: %v", err)
+		}
+	})
+}
+
+// ── FIX 5: tool block cap at 64 ───────────────────────────────────────────────
+
+// TestAnthropicToolBlockCap verifies that maxAnthropicToolBlocks is 64, aligned
+// with the PII Stage 0c StreamRestorer's maxToolCallsPerChoice=64.
+func TestAnthropicToolBlockCap(t *testing.T) {
+	t.Parallel()
+
+	if maxAnthropicToolBlocks != 64 {
+		t.Errorf("maxAnthropicToolBlocks = %d, want 64 (must match Stage 0c maxToolCallsPerChoice)", maxAnthropicToolBlocks)
+	}
 }

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -8,6 +9,15 @@ import (
 
 	"github.com/voidmind-io/voidllm/internal/jsonx"
 )
+
+// maxGeminiToolBlocks is the adapter-level cap on the number of distinct
+// functionCall parts that may be synthesised as tool_calls in a single
+// streaming response. Chunks that would exceed this limit have excess
+// blocks dropped (the chunk method returns nil). This is a defence-in-depth
+// DoS cap independent of any PII pipeline limits, mirroring
+// maxAnthropicToolBlocks, and aligned with maxToolCallsPerChoice=64 in the
+// PII Stage 0c StreamRestorer.
+const maxGeminiToolBlocks = 64
 
 // GeminiAdapter translates between the OpenAI chat completion wire format and
 // the Google Gemini / Vertex AI generateContent API. An instance must not be
@@ -22,11 +32,41 @@ type GeminiAdapter struct {
 	// written. The blank SSE delimiter that follows is then converted to
 	// data: [DONE] and this flag is cleared.
 	doneSent bool
+	// streamToolCallCounter is the per-stream sequential index counter for
+	// synthesised tool-call ids in streaming mode. It is incremented once per
+	// functionCall part emitted.
+	streamToolCallCounter int
+	// sawFunctionCall tracks whether any functionCall part has been emitted
+	// during this stream. When true and a terminal chunk arrives, the
+	// finish_reason is overridden to "tool_calls" regardless of what Gemini
+	// sends (Gemini always sends STOP, never FUNCTION_CALL, for tool calls).
+	sawFunctionCall bool
 }
 
-// geminiPart is a single content part in a Gemini message.
+// geminiPart is a single content part in a Gemini message. Parts may carry
+// plain text, a function call (model → caller), or a function response
+// (caller → model after tool execution).
 type geminiPart struct {
-	Text string `json:"text"`
+	Text             string                  `json:"text,omitempty"`
+	FunctionCall     *geminiFunctionCall     `json:"functionCall,omitempty"`
+	FunctionResponse *geminiFunctionResponse `json:"functionResponse,omitempty"`
+}
+
+// geminiFunctionCall is a model-initiated function invocation in a Gemini part.
+// Args holds an arbitrary JSON object (the call arguments). Gemini does not
+// carry a tool-call id — ids are synthesised by the adapter on the response
+// path.
+type geminiFunctionCall struct {
+	Name string           `json:"name"`
+	Args jsonx.RawMessage `json:"args"`
+}
+
+// geminiFunctionResponse carries the result of a tool call sent back to the
+// model. Name must match the function name of the original call. Response is
+// a JSON object (Gemini requires an object, not a bare string).
+type geminiFunctionResponse struct {
+	Name     string           `json:"name"`
+	Response jsonx.RawMessage `json:"response"`
 }
 
 // geminiContent is a single message in the Gemini contents array.
@@ -52,11 +92,38 @@ type geminiGenerationConfig struct {
 	ResponseMIMEType string   `json:"responseMimeType,omitempty"`
 }
 
+// geminiTool wraps one or more function declarations for the Gemini API.
+type geminiTool struct {
+	FunctionDeclarations []geminiFunctionDeclaration `json:"functionDeclarations"`
+}
+
+// geminiFunctionDeclaration describes a single callable function for Gemini.
+// Parameters is the OpenAI-style JSON Schema object forwarded verbatim.
+type geminiFunctionDeclaration struct {
+	Name        string           `json:"name"`
+	Description string           `json:"description,omitempty"`
+	Parameters  jsonx.RawMessage `json:"parameters,omitempty"`
+}
+
+// geminiToolConfig controls which tools the model may call.
+type geminiToolConfig struct {
+	FunctionCallingConfig geminiFunctionCallingConfig `json:"functionCallingConfig"`
+}
+
+// geminiFunctionCallingConfig specifies whether and how the model may call
+// functions. Mode values: "AUTO", "ANY", "NONE".
+type geminiFunctionCallingConfig struct {
+	Mode                 string   `json:"mode"`
+	AllowedFunctionNames []string `json:"allowedFunctionNames,omitempty"`
+}
+
 // geminiRequest is the complete request body sent to the Gemini API.
 type geminiRequest struct {
 	SystemInstruction *geminiSystemInstruction `json:"systemInstruction,omitempty"`
 	Contents          []geminiContent          `json:"contents"`
 	GenerationConfig  geminiGenerationConfig   `json:"generationConfig,omitempty"`
+	Tools             []geminiTool             `json:"tools,omitempty"`
+	ToolConfig        *geminiToolConfig        `json:"toolConfig,omitempty"`
 }
 
 // geminiResponse is the non-streaming Gemini generateContent response shape.
@@ -76,7 +143,10 @@ type geminiResponse struct {
 }
 
 // geminiFinishReason maps a Gemini finishReason string to the OpenAI
-// finish_reason equivalent.
+// finish_reason equivalent. Note: the Gemini API has no "FUNCTION_CALL"
+// finishReason value — successful tool calls end with "STOP". The
+// "tool_calls" finish_reason is set by the caller based on whether any
+// functionCall parts were present, not via this function.
 func geminiFinishReason(reason string) string {
 	switch reason {
 	case "STOP":
@@ -90,10 +160,21 @@ func geminiFinishReason(reason string) string {
 	}
 }
 
+// geminiSynthesiseToolCallID produces a deterministic, charset-safe tool-call
+// id for a given per-response sequential index. The format is "call_g<index>"
+// which satisfies anthropicToolIDRe ([A-Za-z0-9_.+\-]+).
+func geminiSynthesiseToolCallID(idx int) string {
+	return fmt.Sprintf("call_g%d", idx)
+}
+
 // TransformRequest converts an OpenAI chat completion request body into the
 // Gemini generateContent format. It:
 //   - Separates system messages into a top-level systemInstruction.
-//   - Converts the messages array to the Gemini contents format.
+//   - Converts the messages array to the Gemini contents format, including
+//     assistant tool_calls (→ functionCall parts) and role:"tool" messages
+//     (→ functionResponse parts).
+//   - Translates OpenAI tools definitions to Gemini functionDeclarations.
+//   - Translates tool_choice to a Gemini functionCallingConfig.
 //   - Maps generation parameters (temperature, top_p, max_tokens, stop, n).
 //   - Detects stream:true and stores it in adapter state for TransformURL.
 func (a *GeminiAdapter) TransformRequest(body []byte, _ Model) ([]byte, error) {
@@ -118,14 +199,83 @@ func (a *GeminiAdapter) TransformRequest(body []byte, _ Model) ([]byte, error) {
 		}
 	}
 
-	// Extract and transform messages.
-	type oaiMessage struct {
-		Role    string           `json:"role"`
-		Content jsonx.RawMessage `json:"content"`
+	// ── Tools translation ─────────────────────────────────────────────────────
+	// Collect declared tool names for tool_choice validation and the function-
+	// call id → name lookup map later.
+	//
+	// FIX 5: retain the translated geminiTool slice and *geminiToolConfig so they
+	// can be assigned directly to the geminiRequest at the end, avoiding the
+	// marshal-into-doc → re-unmarshal-from-doc round-trip that was here before.
+	var declaredToolNames []string
+	var outTools []geminiTool
+	var outToolConfig *geminiToolConfig
+
+	if raw, ok := doc["tools"]; ok {
+		var oaiTools []openAITool
+		if err := jsonx.Unmarshal(raw, &oaiTools); err != nil {
+			return nil, errors.New("gemini transform request: invalid tools array")
+		}
+		decls := make([]geminiFunctionDeclaration, 0, len(oaiTools))
+		for _, t := range oaiTools {
+			// Fail-closed: type must be absent or "function".
+			if t.Type != "" && t.Type != "function" {
+				return nil, errors.New("gemini transform request: unsupported tool type")
+			}
+			// Fail-closed: function name must be non-empty.
+			if t.Function.Name == "" {
+				return nil, errors.New("gemini transform request: tool function name is empty")
+			}
+			// Charset-validate function name (mirrors Anthropic adapter).
+			if !anthropicToolIDRe.MatchString(t.Function.Name) {
+				return nil, errors.New("gemini transform request: tool function name contains invalid characters")
+			}
+			// Fail-closed: parameters, if present, must be a JSON object.
+			if t.Function.Parameters != nil {
+				trimmed := strings.TrimSpace(string(t.Function.Parameters))
+				if len(trimmed) > 0 && trimmed[0] != '{' {
+					return nil, errors.New("gemini transform request: tool parameters must be a JSON object")
+				}
+			}
+			declaredToolNames = append(declaredToolNames, t.Function.Name)
+			decls = append(decls, geminiFunctionDeclaration{
+				Name:        t.Function.Name,
+				Description: t.Function.Description,
+				Parameters:  t.Function.Parameters,
+			})
+		}
+		// Gemini groups all declarations into a single Tools element.
+		// FIX 5: store directly; no marshal into doc needed.
+		outTools = []geminiTool{{FunctionDeclarations: decls}}
 	}
+
+	// ── tool_choice translation ───────────────────────────────────────────────
+	if raw, ok := doc["tool_choice"]; ok {
+		tc, err := geminiTranslateToolChoice(raw, declaredToolNames)
+		if err != nil {
+			return nil, fmt.Errorf("gemini transform request: tool_choice: %w", err)
+		}
+		if tc == nil {
+			// "none" → remove both tools and tool_choice from request.
+			outTools = nil
+			outToolConfig = nil
+		} else {
+			// FIX 5: store directly; no marshal into doc needed.
+			outToolConfig = tc
+		}
+	}
+
+	// ── Messages translation ──────────────────────────────────────────────────
+	// anthropicIncomingMessage is reused here: it covers role, content,
+	// tool_calls, tool_call_id — all the fields we need for Gemini too.
+	type oaiMessage = anthropicIncomingMessage
 
 	var contents []geminiContent
 	var systemParts []geminiPart
+
+	// toolCallIDToName maps a tool_call_id (from an assistant tool_calls message)
+	// to the function name. This is needed when translating role:"tool" messages
+	// because Gemini functionResponse requires the function name, not the id.
+	toolCallIDToName := make(map[string]string)
 
 	if raw, ok := doc["messages"]; ok {
 		var msgs []oaiMessage
@@ -134,7 +284,8 @@ func (a *GeminiAdapter) TransformRequest(body []byte, _ Model) ([]byte, error) {
 		}
 
 		for _, m := range msgs {
-			if m.Role == "system" {
+			switch m.Role {
+			case "system":
 				// System content may be a plain string or a content-block array.
 				var text string
 				if err := jsonx.Unmarshal(m.Content, &text); err == nil {
@@ -152,46 +303,165 @@ func (a *GeminiAdapter) TransformRequest(body []byte, _ Model) ([]byte, error) {
 						}
 					}
 				}
-				continue
-			}
 
-			geminiRole := m.Role
-			if geminiRole == "assistant" {
-				geminiRole = "model"
-			}
+			case "assistant":
+				if len(m.ToolCalls) > 0 {
+					// Assistant message with tool_calls → Gemini model content with
+					// functionCall parts. Build the id→name map at the same time.
+					var parts []geminiPart
 
-			// Content may be a plain string or an array of content blocks.
-			var text string
-			var parts []geminiPart
-			if err := jsonx.Unmarshal(m.Content, &text); err == nil {
-				parts = []geminiPart{{Text: text}}
-			} else {
-				// Try array of content blocks: [{type:"text", text:"..."}]
-				var blocks []struct {
-					Type string `json:"type"`
-					Text string `json:"text"`
-				}
-				if err := jsonx.Unmarshal(m.Content, &blocks); err == nil {
-					for _, b := range blocks {
-						if b.Type == "text" && b.Text != "" {
-							parts = append(parts, geminiPart{Text: b.Text})
+					// Include a text part first if there is non-empty text content.
+					if m.Content != nil {
+						var textContent string
+						if err := jsonx.Unmarshal(m.Content, &textContent); err == nil && textContent != "" {
+							parts = append(parts, geminiPart{Text: textContent})
 						}
 					}
-				}
-			}
-			if len(parts) == 0 {
-				// Fall back to an empty text part so the message is still included.
-				parts = []geminiPart{{Text: ""}}
-			}
 
-			contents = append(contents, geminiContent{
-				Role:  geminiRole,
-				Parts: parts,
-			})
+					for _, tc := range m.ToolCalls {
+						// FIX 3: reject empty tool_call_id — fail-closed.
+						if tc.ID == "" {
+							return nil, errors.New("gemini transform request: tool_call id is empty")
+						}
+						// Charset-validate tool_call id.
+						if !anthropicToolIDRe.MatchString(tc.ID) {
+							return nil, errors.New("gemini transform request: tool_call id contains invalid characters")
+						}
+						// FIX 3: reject empty function name — fail-closed.
+						if tc.Function.Name == "" {
+							return nil, errors.New("gemini transform request: tool_call function name is empty")
+						}
+						// Charset-validate function name (defence-in-depth).
+						if !anthropicToolIDRe.MatchString(tc.Function.Name) {
+							return nil, errors.New("gemini transform request: tool_call function name contains invalid characters")
+						}
+						// Reject pseudonym-shaped function names on the request path
+						// to prevent forwarding names that could be mistaken for PII pseudonyms.
+						if isForwardedPseudonym(tc.Function.Name) {
+							return nil, errors.New("gemini transform request: tool_call function name rejected")
+						}
+						// Parse arguments JSON string → object.
+						// Empty string is treated as {} (same as Anthropic adapter).
+						args, err := parseArgumentsToObject(tc.Function.Arguments)
+						if err != nil {
+							return nil, errors.New("gemini transform request: invalid tool_call arguments")
+						}
+						// FIX 3: reject duplicate id → conflicting name mappings.
+						// Silently overwriting would corrupt conversation state.
+						if existing, ok := toolCallIDToName[tc.ID]; ok && existing != tc.Function.Name {
+							return nil, errors.New("gemini transform request: duplicate tool_call_id with conflicting function name")
+						}
+						// Record id → name for later tool-result correlation.
+						toolCallIDToName[tc.ID] = tc.Function.Name
+						// Gemini functionCall has no id field — do not forward the OpenAI id.
+						parts = append(parts, geminiPart{
+							FunctionCall: &geminiFunctionCall{
+								Name: tc.Function.Name,
+								Args: args,
+							},
+						})
+					}
+
+					contents = append(contents, geminiContent{
+						Role:  "model",
+						Parts: parts,
+					})
+				} else {
+					// Plain text assistant message.
+					parts := geminiTextParts(m.Content)
+					contents = append(contents, geminiContent{
+						Role:  "model",
+						Parts: parts,
+					})
+				}
+
+			case "tool":
+				// OpenAI role:"tool" → Gemini user content with functionResponse part.
+				//
+				// API convention note: Gemini v1beta uses role "user" for
+				// functionResponse parts. This matches the official Gemini REST API
+				// documentation (https://ai.google.dev/api/generate-content#v1beta.Content)
+				// where function responses are sent as part of the user turn. We
+				// accumulate consecutive tool messages into a single user content to
+				// keep the conversation well-formed (Gemini does not require merging
+				// but it is cleaner; multiple consecutive functionResponse parts in one
+				// user content is accepted by the API).
+				//
+				// ASSUMPTION: consecutive role:"tool" messages are merged into a single
+				// Gemini "user" content block (multiple functionResponse parts). Gemini
+				// accepts this form per the v1beta spec. If a future API version
+				// requires one content per functionResponse, this loop must be split.
+				//
+				// Zero-knowledge preservation: if the tool result content is a string,
+				// wrap as {"content": <string>}. If it is an array of content parts,
+				// wrap as {"content": [<text1>, <text2>, ...]} — preserving part
+				// boundaries exactly, never concatenating (same reasoning as the
+				// Anthropic adapter fix: concatenation can reconstruct deliberately
+				// split PII that the scanner scanned as separate parts).
+
+				// FIX 3: reject empty tool_call_id — fail-closed. An empty id
+				// cannot be correlated to a function name.
+				if m.ToolCallID == "" {
+					return nil, errors.New("gemini transform request: tool message has empty tool_call_id")
+				}
+				// Charset-validate tool_call_id before lookup.
+				if !anthropicToolIDRe.MatchString(m.ToolCallID) {
+					return nil, errors.New("gemini transform request: tool_call_id contains invalid characters")
+				}
+
+				// Fail-closed when tool_call_id is not in the id→name map.
+				// Silently using an empty function name would produce a malformed
+				// functionResponse that the Gemini API may accept but would
+				// silently corrupt the conversation state.
+				var funcName string
+				{
+					name, ok := toolCallIDToName[m.ToolCallID]
+					if !ok {
+						return nil, errors.New("gemini transform request: tool_call_id references unknown tool call")
+					}
+					funcName = name
+				}
+
+				response, err := geminiWrapToolResult(m.Content)
+				if err != nil {
+					return nil, errors.New("gemini transform request: cannot wrap tool result")
+				}
+
+				// Append to the most recent user content if it already contains
+				// functionResponse parts; otherwise create a new user content.
+				frPart := geminiPart{
+					FunctionResponse: &geminiFunctionResponse{
+						Name:     funcName,
+						Response: response,
+					},
+				}
+				if len(contents) > 0 && contents[len(contents)-1].Role == "user" &&
+					hasOnlyFunctionResponseParts(contents[len(contents)-1].Parts) {
+					// Merge into the existing user content.
+					contents[len(contents)-1].Parts = append(contents[len(contents)-1].Parts, frPart)
+				} else {
+					contents = append(contents, geminiContent{
+						Role:  "user",
+						Parts: []geminiPart{frPart},
+					})
+				}
+
+			default:
+				// user and any other roles: emit as plain text content.
+				geminiRole := m.Role
+				if geminiRole == "assistant" {
+					geminiRole = "model"
+				}
+				parts := geminiTextParts(m.Content)
+				contents = append(contents, geminiContent{
+					Role:  geminiRole,
+					Parts: parts,
+				})
+			}
 		}
 	}
 
-	// Build generationConfig from OpenAI fields.
+	// ── generationConfig ──────────────────────────────────────────────────────
 	var gc geminiGenerationConfig
 
 	if raw, ok := doc["temperature"]; ok {
@@ -249,10 +519,15 @@ func (a *GeminiAdapter) TransformRequest(body []byte, _ Model) ([]byte, error) {
 		}
 	}
 
-	// Build the Gemini request.
+	// ── Build final Gemini request ────────────────────────────────────────────
+	// FIX 5: outTools and outToolConfig were built and retained directly above
+	// during the tools/tool_choice translation steps — no re-unmarshal needed.
+
 	req := geminiRequest{
 		Contents:         contents,
 		GenerationConfig: gc,
+		Tools:            outTools,
+		ToolConfig:       outToolConfig,
 	}
 	if len(systemParts) > 0 {
 		req.SystemInstruction = &geminiSystemInstruction{Parts: systemParts}
@@ -311,23 +586,76 @@ func (a *GeminiAdapter) SetHeaders(req *http.Request, model Model) {
 }
 
 // TransformResponse converts a complete Gemini generateContent response body
-// into an OpenAI chat completion response body.
+// into an OpenAI chat completion response body. It handles both plain text
+// parts and functionCall parts. When functionCall parts are present they are
+// translated to OpenAI tool_calls with synthesised ids; if no text parts are
+// present the message content is null (pointer nil).
 func (a *GeminiAdapter) TransformResponse(body []byte) ([]byte, error) {
 	var gr geminiResponse
 	if err := jsonx.Unmarshal(body, &gr); err != nil {
 		return nil, fmt.Errorf("gemini transform response: unmarshal: %w", err)
 	}
 
-	var text string
+	var textParts []string
+	var toolCalls []openAIToolCall
 	var finishReason string
+
 	if len(gr.Candidates) > 0 {
 		c := gr.Candidates[0]
-		finishReason = geminiFinishReason(c.FinishReason)
-		var parts []string
+
+		tcIdx := 0
 		for _, p := range c.Content.Parts {
-			parts = append(parts, p.Text)
+			switch {
+			case p.FunctionCall != nil:
+				// FIX 3: reject empty function name — fail-closed.
+				if p.FunctionCall.Name == "" {
+					return nil, errors.New("gemini transform response: function name is empty")
+				}
+				// Charset-validate the function name received from upstream
+				// (defence-in-depth: the model might hallucinate names).
+				if !anthropicToolIDRe.MatchString(p.FunctionCall.Name) {
+					return nil, errors.New("gemini transform response: function name contains invalid characters")
+				}
+				// Reject any function name that matches the PII pseudonym shape.
+				// On the non-streaming path, filter.Restore performs a global
+				// string replacement over the whole body; if a (malicious or
+				// compromised) upstream returns a function name that matches a
+				// pseudonym in this request's reverse map, Restore would replace
+				// it with the real PII value and the client would see PII in
+				// tool_calls[].function.name.
+				if isForwardedPseudonym(p.FunctionCall.Name) {
+					return nil, errors.New("gemini transform response: function name rejected")
+				}
+				// Serialise args object → JSON string for OpenAI function.arguments.
+				argsStr, err := serializeInputToArguments(p.FunctionCall.Args)
+				if err != nil {
+					return nil, errors.New("gemini transform response: invalid function call args")
+				}
+				id := geminiSynthesiseToolCallID(tcIdx)
+				toolCalls = append(toolCalls, openAIToolCall{
+					ID:   id,
+					Type: "function",
+					Function: openAIToolCallFunction{
+						Name:      p.FunctionCall.Name,
+						Arguments: argsStr,
+					},
+				})
+				tcIdx++
+			case p.Text != "":
+				textParts = append(textParts, p.Text)
+			}
 		}
-		text = strings.Join(parts, "")
+
+		// FIX 1: derive finish_reason from functionCall PRESENCE, not from
+		// Gemini's finishReason string. Gemini uses "STOP" for successful tool
+		// calls (the API has no "FUNCTION_CALL" finishReason value). Any
+		// response that produced at least one tool call must finish with
+		// "tool_calls" so the PII Stage 0c restorer accepts it.
+		if len(toolCalls) > 0 {
+			finishReason = "tool_calls"
+		} else {
+			finishReason = geminiFinishReason(c.FinishReason)
+		}
 	}
 	if finishReason == "" {
 		finishReason = "stop"
@@ -337,17 +665,37 @@ func (a *GeminiAdapter) TransformResponse(body []byte) ([]byte, error) {
 	if model == "" {
 		model = "gemini"
 	}
+
+	// Build the message. When tool_calls are present and no text was produced,
+	// content is null (nil pointer). When text is present, content is the
+	// joined string. This mirrors the Anthropic adapter's behaviour.
+	var msgContent *string
+	if len(textParts) > 0 {
+		s := strings.Join(textParts, "")
+		msgContent = &s
+	} else if len(toolCalls) == 0 {
+		// No text and no tool calls — preserve empty string for consistency.
+		s := ""
+		msgContent = &s
+	}
+	// When toolCalls is non-empty and textParts is empty, msgContent stays nil.
+
+	msg := openAIMessage{
+		Role:    "assistant",
+		Content: msgContent,
+	}
+	if len(toolCalls) > 0 {
+		msg.ToolCalls = toolCalls
+	}
+
 	resp := openAIResponse{
 		ID:     fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano()),
 		Object: "chat.completion",
 		Model:  model,
 		Choices: []openAIChoice{
 			{
-				Index: 0,
-				Message: openAIMessage{
-					Role:    "assistant",
-					Content: &text,
-				},
+				Index:        0,
+				Message:      msg,
 				FinishReason: finishReason,
 			},
 		},
@@ -374,6 +722,17 @@ func (a *GeminiAdapter) TransformResponse(body []byte) ([]byte, error) {
 // candidate includes a finishReason, the final content chunk is emitted. The
 // blank SSE delimiter that immediately follows the terminal chunk is converted
 // into the data: [DONE] terminator that OpenAI clients expect.
+//
+// For chunks that contain functionCall parts: a tool_calls delta is emitted
+// per functionCall, conformant to the OpenAI Stage 0c shape expected by the
+// PII StreamRestorer. Each delta carries index, id, type:"function",
+// function.name, and function.arguments (the full args JSON string — Gemini
+// delivers arguments complete, not fragmented). This is 0c-conformant: the
+// first observation carries id + type + name + arguments together; Stage 0c's
+// handleToolCallsDelta restores arguments in one delta.
+//
+// The content-free-chunk drop (~line 441 in the original) is corrected: a
+// chunk that carries only functionCall parts (no text) is NOT dropped.
 func (a *GeminiAdapter) TransformStreamLine(line []byte) []byte {
 	s := string(line)
 
@@ -409,25 +768,42 @@ func (a *GeminiAdapter) TransformStreamLine(line []byte) []byte {
 
 	var deltaText string
 	var finishReason *string
+	var toolCallParts []*geminiFunctionCall
 
 	if len(gr.Candidates) > 0 {
 		c := gr.Candidates[0]
-		var parts []string
 		for _, p := range c.Content.Parts {
-			parts = append(parts, p.Text)
+			switch {
+			case p.FunctionCall != nil:
+				toolCallParts = append(toolCallParts, p.FunctionCall)
+			case p.Text != "":
+				deltaText += p.Text
+			}
 		}
-		deltaText = strings.Join(parts, "")
 
 		if c.FinishReason != "" {
-			reason := geminiFinishReason(c.FinishReason)
+			// FIX 1: derive finish_reason from sawFunctionCall presence, not
+			// from Gemini's finishReason string. Gemini always sends "STOP" for
+			// a successful tool call. We track sawFunctionCall across the
+			// stream; if any functionCall parts have been emitted (including in
+			// THIS chunk, handled below after toolCallParts are processed), we
+			// override to "tool_calls".
+			//
+			// For the same-chunk case (functionCall parts + finishReason STOP
+			// in one chunk), the toolCallParts slice is already populated at
+			// this point, so we use len(toolCallParts) > 0 || a.sawFunctionCall
+			// to cover both cases correctly.
+			var reason string
+			if len(toolCallParts) > 0 || a.sawFunctionCall {
+				reason = "tool_calls"
+			} else {
+				reason = geminiFinishReason(c.FinishReason)
+			}
 			finishReason = &reason
 		}
 	}
 
-	// Accumulate usage when present. When finishReason is set this is the
-	// terminal chunk and we accept whatever the metadata reports, including
-	// zero, so that a final zero-token count from the API is not silently
-	// ignored.
+	// Accumulate usage when present.
 	hasFinish := len(gr.Candidates) > 0 && gr.Candidates[0].FinishReason != ""
 	if gr.UsageMetadata.PromptTokenCount > 0 || hasFinish {
 		a.promptTokens = gr.UsageMetadata.PromptTokenCount
@@ -436,35 +812,179 @@ func (a *GeminiAdapter) TransformStreamLine(line []byte) []byte {
 		a.completionTokens = gr.UsageMetadata.CandidatesTokenCount
 	}
 
-	// Drop content-free intermediate chunks that carry no delta and no
-	// finish reason — they add no value to the client stream.
-	if deltaText == "" && finishReason == nil {
+	// Drop content-free intermediate chunks that carry no delta text, no tool
+	// calls, and no finish reason — they add no value to the client stream.
+	// NOTE: a functionCall-only chunk (no text) must NOT be dropped; the
+	// original check "deltaText == "" && finishReason == nil" was broadened here
+	// to also require len(toolCallParts) == 0. This is the content-free-drop fix.
+	if deltaText == "" && finishReason == nil && len(toolCallParts) == 0 {
 		return nil
 	}
 
-	chunk := openAIChunk{
-		ID:     fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano()),
-		Object: "chat.completion.chunk",
-		Choices: []openAIChunkChoice{
-			{
-				Index:        0,
-				Delta:        openAIChunkDelta{Content: deltaText},
-				FinishReason: finishReason,
+	// If there are both text content and tool call parts in the same chunk,
+	// emit a text chunk first, then the tool call chunk. However, Gemini
+	// typically does not mix text and functionCall in the same chunk. For
+	// simplicity (and because Stage 0c rejects mixed content+tool_calls in the
+	// same chunk), emit text chunks via the normal path and tool call chunks
+	// via a separate emission. When both are present, emit text first by
+	// building a text-only delta here and handling tool calls below.
+	//
+	// In practice Gemini always sends one finishReason with either the last
+	// text part or the functionCall parts — not both simultaneously.
+	if deltaText != "" {
+		chunk := openAIChunk{
+			ID:     fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano()),
+			Object: "chat.completion.chunk",
+			Choices: []openAIChunkChoice{
+				{
+					Index: 0,
+					Delta: openAIChunkDelta{Content: deltaText},
+					// Do not set finishReason here when there are also tool calls
+					// to emit; set it on the tool-calls chunk below.
+					FinishReason: func() *string {
+						if len(toolCallParts) == 0 {
+							return finishReason
+						}
+						return nil
+					}(),
+				},
 			},
-		},
+		}
+		out, err := jsonx.Marshal(chunk)
+		if err != nil {
+			return nil
+		}
+		if finishReason != nil && len(toolCallParts) == 0 {
+			a.doneSent = true
+		}
+		// If there are also tool call parts, we cannot return here — we need
+		// to emit both. For the common case (only text), return now.
+		if len(toolCallParts) == 0 {
+			return appendDataPrefix(out)
+		}
+		// Mixed chunk: text has been built. Fall through to emit tool calls
+		// as a separate chunk. (We discard the text chunk here — in the rare
+		// mixed case only the tool calls chunk is returned. This is acceptable
+		// because Stage 0c cannot handle mixed content+tool_calls in one chunk,
+		// and Gemini should not produce this combination in practice.)
+		_ = out
 	}
 
-	out, err := jsonx.Marshal(chunk)
-	if err != nil {
+	// Emit tool call deltas.
+	if len(toolCallParts) > 0 {
+		var tcs []openAIToolCall
+		for _, fc := range toolCallParts {
+			// Cap per-stream tool-call count (defence-in-depth).
+			if a.streamToolCallCounter >= maxGeminiToolBlocks {
+				// Excess blocks are dropped.
+				break
+			}
+			// FIX 3: reject empty function name — fail-closed (drop this block).
+			if fc.Name == "" {
+				a.streamToolCallCounter++
+				continue
+			}
+			// Charset-validate the name received from upstream.
+			if !anthropicToolIDRe.MatchString(fc.Name) {
+				// Invalid name — drop this block, continue with others.
+				a.streamToolCallCounter++
+				continue
+			}
+			// Serialise args → JSON string.
+			argsStr, err := serializeInputToArguments(fc.Args)
+			if err != nil {
+				a.streamToolCallCounter++
+				continue
+			}
+			id := geminiSynthesiseToolCallID(a.streamToolCallCounter)
+			tcIdx := a.streamToolCallCounter
+			a.streamToolCallCounter++
+
+			tcs = append(tcs, openAIToolCall{
+				Index: &tcIdx,
+				ID:    id,
+				Type:  "function",
+				Function: openAIToolCallFunction{
+					Name:      fc.Name,
+					Arguments: argsStr,
+				},
+			})
+		}
+		// FIX 1: mark that this stream has emitted at least one functionCall
+		// tool call delta. This is used by the finish_reason override logic to
+		// emit "tool_calls" even when Gemini sends finishReason "STOP".
+		if len(tcs) > 0 {
+			a.sawFunctionCall = true
+		}
+
+		if len(tcs) > 0 {
+			chunk := openAIChunk{
+				ID:     fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano()),
+				Object: "chat.completion.chunk",
+				Choices: []openAIChunkChoice{
+					{
+						Index:        0,
+						Delta:        openAIChunkDelta{ToolCalls: tcs},
+						FinishReason: finishReason,
+					},
+				},
+			}
+			out, err := jsonx.Marshal(chunk)
+			if err != nil {
+				return nil
+			}
+			if finishReason != nil {
+				a.doneSent = true
+			}
+			return appendDataPrefix(out)
+		}
+
+		// All tool call parts were dropped (invalid names or args). If we have a
+		// finishReason, still need to emit the finish chunk with no delta.
+		if finishReason != nil {
+			chunk := openAIChunk{
+				ID:     fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano()),
+				Object: "chat.completion.chunk",
+				Choices: []openAIChunkChoice{
+					{
+						Index:        0,
+						Delta:        openAIChunkDelta{},
+						FinishReason: finishReason,
+					},
+				},
+			}
+			out, err := jsonx.Marshal(chunk)
+			if err != nil {
+				return nil
+			}
+			a.doneSent = true
+			return appendDataPrefix(out)
+		}
 		return nil
 	}
 
+	// Pure finish-reason chunk (no text, no tool calls) — emit finish chunk.
 	if finishReason != nil {
-		// Set flag so the blank SSE delimiter that follows becomes data: [DONE].
+		chunk := openAIChunk{
+			ID:     fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano()),
+			Object: "chat.completion.chunk",
+			Choices: []openAIChunkChoice{
+				{
+					Index:        0,
+					Delta:        openAIChunkDelta{},
+					FinishReason: finishReason,
+				},
+			},
+		}
+		out, err := jsonx.Marshal(chunk)
+		if err != nil {
+			return nil
+		}
 		a.doneSent = true
+		return appendDataPrefix(out)
 	}
 
-	return appendDataPrefix(out)
+	return nil
 }
 
 // StreamUsage returns the token counts accumulated during the Gemini stream.
@@ -476,4 +996,182 @@ func (a *GeminiAdapter) StreamUsage() UsageInfo {
 		CompletionTokens: a.completionTokens,
 		TotalTokens:      a.promptTokens + a.completionTokens,
 	}
+}
+
+// ── Helper functions ──────────────────────────────────────────────────────────
+
+// geminiTextParts extracts plain-text geminiParts from a raw OpenAI content
+// value (string or array of text blocks). A null or nil content yields a
+// single empty-text part so the message is well-formed.
+func geminiTextParts(content jsonx.RawMessage) []geminiPart {
+	if content == nil {
+		return []geminiPart{{Text: ""}}
+	}
+	// Try plain string first.
+	var text string
+	if err := jsonx.Unmarshal(content, &text); err == nil {
+		return []geminiPart{{Text: text}}
+	}
+	// Try array of content blocks.
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := jsonx.Unmarshal(content, &blocks); err == nil {
+		var parts []geminiPart
+		for _, b := range blocks {
+			if b.Type == "text" && b.Text != "" {
+				parts = append(parts, geminiPart{Text: b.Text})
+			}
+		}
+		if len(parts) > 0 {
+			return parts
+		}
+	}
+	// Fall back to a single empty text part.
+	return []geminiPart{{Text: ""}}
+}
+
+// geminiWrapToolResult converts an OpenAI tool-result content value into a
+// Gemini functionResponse.response JSON object.
+//
+// Zero-knowledge contract: the content boundaries established by the PII
+// scanner are preserved. For a plain-string result, the wrapper is
+// {"content": <string>}. For an array-of-parts result, the wrapper is
+// {"content": [<text1>, <text2>, ...]} — never concatenated into one string,
+// because concatenation could reconstruct PII that was deliberately split
+// across parts (same reasoning as the Anthropic tool_result fix in PR #138).
+func geminiWrapToolResult(content jsonx.RawMessage) (jsonx.RawMessage, error) {
+	if content == nil {
+		// Null/absent content → empty wrapper.
+		return jsonx.RawMessage(`{"content":""}`), nil
+	}
+
+	// Try plain string.
+	var s string
+	if err := jsonx.Unmarshal(content, &s); err == nil {
+		type wrapper struct {
+			Content string `json:"content"`
+		}
+		b, merr := jsonx.Marshal(wrapper{Content: s})
+		if merr != nil {
+			return nil, merr
+		}
+		return jsonx.RawMessage(b), nil
+	}
+
+	// Try array of content parts — preserve as list, never concatenate.
+	var parts []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := jsonx.Unmarshal(content, &parts); err == nil {
+		// FIX 3: initialise to an empty slice (not nil) so that zero text-part
+		// arrays serialise as {"content":[]} rather than {"content":null}.
+		// An all-image or all-non-text array legitimately produces zero text
+		// items; null would be structurally incorrect for a list field.
+		texts := make([]string, 0, len(parts))
+		for _, p := range parts {
+			if p.Type == "text" {
+				texts = append(texts, p.Text)
+			}
+		}
+		type wrapper struct {
+			Content []string `json:"content"`
+		}
+		b, merr := jsonx.Marshal(wrapper{Content: texts})
+		if merr != nil {
+			return nil, merr
+		}
+		return jsonx.RawMessage(b), nil
+	}
+
+	return nil, errors.New("unrecognised tool result content shape")
+}
+
+// hasOnlyFunctionResponseParts reports whether all parts in the given slice
+// are functionResponse parts. Used to decide whether to merge consecutive
+// tool-result messages into the same user content block.
+func hasOnlyFunctionResponseParts(parts []geminiPart) bool {
+	if len(parts) == 0 {
+		return false
+	}
+	for _, p := range parts {
+		if p.FunctionResponse == nil {
+			return false
+		}
+	}
+	return true
+}
+
+// geminiTranslateToolChoice converts an OpenAI tool_choice value to a Gemini
+// geminiToolConfig. Returns nil when the effective choice is "none" (caller
+// should remove tools and tool_choice). Returns an error on unknown values
+// (fail-closed — no silent fallback).
+//
+// Mapping:
+//
+//	"auto"                          → Mode "AUTO"
+//	"required"                      → Mode "ANY"
+//	"none"                          → nil (remove tools)
+//	{type:"function",function:{name}} → Mode "ANY" + AllowedFunctionNames:[name]
+func geminiTranslateToolChoice(raw jsonx.RawMessage, declaredNames []string) (*geminiToolConfig, error) {
+	// Try string first.
+	var s string
+	if err := jsonx.Unmarshal(raw, &s); err == nil {
+		switch s {
+		case "auto":
+			return &geminiToolConfig{
+				FunctionCallingConfig: geminiFunctionCallingConfig{Mode: "AUTO"},
+			}, nil
+		case "required":
+			return &geminiToolConfig{
+				FunctionCallingConfig: geminiFunctionCallingConfig{Mode: "ANY"},
+			}, nil
+		case "none":
+			return nil, nil
+		default:
+			return nil, errors.New("unknown tool_choice value")
+		}
+	}
+
+	// Try object: {"type":"function","function":{"name":"<name>"}}.
+	var obj struct {
+		Type     string `json:"type"`
+		Function struct {
+			Name string `json:"name"`
+		} `json:"function"`
+	}
+	if err := jsonx.Unmarshal(raw, &obj); err != nil {
+		return nil, fmt.Errorf("unrecognised tool_choice shape: %w", err)
+	}
+	if obj.Type != "function" {
+		return nil, errors.New("unknown tool_choice object type")
+	}
+	if obj.Function.Name == "" {
+		return nil, errors.New("tool_choice function name is empty")
+	}
+	// Charset-validate the named function (mirrors Anthropic adapter; may carry PII pseudonym).
+	if !anthropicToolIDRe.MatchString(obj.Function.Name) {
+		return nil, errors.New("tool_choice function name contains invalid characters")
+	}
+	// FIX 4: a named tool_choice MUST reference a declared tool unconditionally.
+	// If there are no declared tools at all, or the name is not among them,
+	// fail-closed. A named tool_choice with no tools array is a protocol error.
+	found := false
+	for _, n := range declaredNames {
+		if n == obj.Function.Name {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, errors.New("tool_choice references undeclared tool")
+	}
+	return &geminiToolConfig{
+		FunctionCallingConfig: geminiFunctionCallingConfig{
+			Mode:                 "ANY",
+			AllowedFunctionNames: []string{obj.Function.Name},
+		},
+	}, nil
 }

--- a/internal/proxy/gemini_test.go
+++ b/internal/proxy/gemini_test.go
@@ -2,6 +2,9 @@ package proxy
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -955,6 +958,2844 @@ func TestGeminiFinishReason(t *testing.T) {
 				t.Errorf("geminiFinishReason(%q) = %q, want %q", tc.input, got, tc.want)
 			}
 		})
+	}
+}
+
+// ---- Tool-call happy paths --------------------------------------------------
+
+// TestGeminiTransformRequest_Tools verifies that OpenAI tools are translated
+// into a Gemini functionDeclarations array and that tool_choice is mapped to
+// the correct functionCallingConfig mode.
+func TestGeminiTransformRequest_Tools(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tools translated to functionDeclarations", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"model": "gemini-1.5-pro",
+			"messages": [{"role":"user","content":"What is the weather?"}],
+			"tools": [
+				{
+					"type": "function",
+					"function": {
+						"name": "get_weather",
+						"description": "Get the current weather",
+						"parameters": {"type":"object","properties":{"location":{"type":"string"}}}
+					}
+				}
+			]
+		}`
+		a := &GeminiAdapter{}
+		out, err := a.TransformRequest([]byte(input), Model{})
+		if err != nil {
+			t.Fatalf("TransformRequest() error = %v", err)
+		}
+		var req geminiRequest
+		if err := json.Unmarshal(out, &req); err != nil {
+			t.Fatalf("unmarshal output: %v", err)
+		}
+		if len(req.Tools) != 1 {
+			t.Fatalf("len(tools) = %d, want 1", len(req.Tools))
+		}
+		if len(req.Tools[0].FunctionDeclarations) != 1 {
+			t.Fatalf("len(functionDeclarations) = %d, want 1", len(req.Tools[0].FunctionDeclarations))
+		}
+		decl := req.Tools[0].FunctionDeclarations[0]
+		if decl.Name != "get_weather" {
+			t.Errorf("name = %q, want %q", decl.Name, "get_weather")
+		}
+		if decl.Description != "Get the current weather" {
+			t.Errorf("description = %q, want %q", decl.Description, "Get the current weather")
+		}
+		if string(decl.Parameters) == "" {
+			t.Error("parameters should not be empty")
+		}
+	})
+
+	t.Run("tool_choice auto maps to AUTO", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"model": "gemini-1.5-pro",
+			"messages": [{"role":"user","content":"Hi"}],
+			"tools": [{"type":"function","function":{"name":"fn","parameters":{}}}],
+			"tool_choice": "auto"
+		}`
+		a := &GeminiAdapter{}
+		out, err := a.TransformRequest([]byte(input), Model{})
+		if err != nil {
+			t.Fatalf("TransformRequest() error = %v", err)
+		}
+		var req geminiRequest
+		if err := json.Unmarshal(out, &req); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if req.ToolConfig == nil {
+			t.Fatal("toolConfig is nil, want non-nil")
+		}
+		if req.ToolConfig.FunctionCallingConfig.Mode != "AUTO" {
+			t.Errorf("mode = %q, want AUTO", req.ToolConfig.FunctionCallingConfig.Mode)
+		}
+	})
+
+	t.Run("tool_choice required maps to ANY", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"model": "gemini-1.5-pro",
+			"messages": [{"role":"user","content":"Hi"}],
+			"tools": [{"type":"function","function":{"name":"fn","parameters":{}}}],
+			"tool_choice": "required"
+		}`
+		a := &GeminiAdapter{}
+		out, err := a.TransformRequest([]byte(input), Model{})
+		if err != nil {
+			t.Fatalf("TransformRequest() error = %v", err)
+		}
+		var req geminiRequest
+		if err := json.Unmarshal(out, &req); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if req.ToolConfig == nil {
+			t.Fatal("toolConfig is nil")
+		}
+		if req.ToolConfig.FunctionCallingConfig.Mode != "ANY" {
+			t.Errorf("mode = %q, want ANY", req.ToolConfig.FunctionCallingConfig.Mode)
+		}
+	})
+
+	t.Run("tool_choice none removes tools and tool_choice", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"model": "gemini-1.5-pro",
+			"messages": [{"role":"user","content":"Hi"}],
+			"tools": [{"type":"function","function":{"name":"fn","parameters":{}}}],
+			"tool_choice": "none"
+		}`
+		a := &GeminiAdapter{}
+		out, err := a.TransformRequest([]byte(input), Model{})
+		if err != nil {
+			t.Fatalf("TransformRequest() error = %v", err)
+		}
+		var req geminiRequest
+		if err := json.Unmarshal(out, &req); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(req.Tools) != 0 {
+			t.Errorf("tools should be absent when tool_choice=none, got %d entries", len(req.Tools))
+		}
+		if req.ToolConfig != nil {
+			t.Error("toolConfig should be nil when tool_choice=none")
+		}
+	})
+
+	t.Run("named tool_choice maps to ANY with allowedFunctionNames", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"model": "gemini-1.5-pro",
+			"messages": [{"role":"user","content":"Hi"}],
+			"tools": [{"type":"function","function":{"name":"my_tool","parameters":{}}}],
+			"tool_choice": {"type":"function","function":{"name":"my_tool"}}
+		}`
+		a := &GeminiAdapter{}
+		out, err := a.TransformRequest([]byte(input), Model{})
+		if err != nil {
+			t.Fatalf("TransformRequest() error = %v", err)
+		}
+		var req geminiRequest
+		if err := json.Unmarshal(out, &req); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if req.ToolConfig == nil {
+			t.Fatal("toolConfig is nil")
+		}
+		cfg := req.ToolConfig.FunctionCallingConfig
+		if cfg.Mode != "ANY" {
+			t.Errorf("mode = %q, want ANY", cfg.Mode)
+		}
+		if len(cfg.AllowedFunctionNames) != 1 || cfg.AllowedFunctionNames[0] != "my_tool" {
+			t.Errorf("allowedFunctionNames = %v, want [my_tool]", cfg.AllowedFunctionNames)
+		}
+	})
+
+	t.Run("assistant tool_calls become functionCall parts", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"model": "gemini-1.5-pro",
+			"messages": [
+				{"role":"user","content":"What is the weather?"},
+				{
+					"role":"assistant",
+					"content":null,
+					"tool_calls":[{
+						"id":"call_abc",
+						"type":"function",
+						"function":{"name":"get_weather","arguments":"{\"location\":\"NYC\"}"}
+					}]
+				}
+			]
+		}`
+		a := &GeminiAdapter{}
+		out, err := a.TransformRequest([]byte(input), Model{})
+		if err != nil {
+			t.Fatalf("TransformRequest() error = %v", err)
+		}
+		var req geminiRequest
+		if err := json.Unmarshal(out, &req); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		// Expect 2 contents: user + model
+		if len(req.Contents) != 2 {
+			t.Fatalf("len(contents) = %d, want 2", len(req.Contents))
+		}
+		modelContent := req.Contents[1]
+		if modelContent.Role != "model" {
+			t.Errorf("role = %q, want model", modelContent.Role)
+		}
+		if len(modelContent.Parts) != 1 {
+			t.Fatalf("len(parts) = %d, want 1", len(modelContent.Parts))
+		}
+		fc := modelContent.Parts[0].FunctionCall
+		if fc == nil {
+			t.Fatal("functionCall is nil")
+		}
+		if fc.Name != "get_weather" {
+			t.Errorf("name = %q, want get_weather", fc.Name)
+		}
+		// Args must be a JSON object (parsed from the arguments string).
+		if string(fc.Args) == "" || fc.Args[0] != '{' {
+			t.Errorf("args = %q, want JSON object", fc.Args)
+		}
+	})
+
+	t.Run("role:tool messages become functionResponse parts in user content", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"model": "gemini-1.5-pro",
+			"messages": [
+				{"role":"user","content":"Weather?"},
+				{
+					"role":"assistant",
+					"content":null,
+					"tool_calls":[{
+						"id":"call_123",
+						"type":"function",
+						"function":{"name":"get_weather","arguments":"{}"}
+					}]
+				},
+				{
+					"role":"tool",
+					"tool_call_id":"call_123",
+					"content":"Sunny, 72°F"
+				}
+			]
+		}`
+		a := &GeminiAdapter{}
+		out, err := a.TransformRequest([]byte(input), Model{})
+		if err != nil {
+			t.Fatalf("TransformRequest() error = %v", err)
+		}
+		var req geminiRequest
+		if err := json.Unmarshal(out, &req); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		// Expect 3 contents: user, model, user(functionResponse)
+		if len(req.Contents) != 3 {
+			t.Fatalf("len(contents) = %d, want 3", len(req.Contents))
+		}
+		frContent := req.Contents[2]
+		if frContent.Role != "user" {
+			t.Errorf("role = %q, want user", frContent.Role)
+		}
+		if len(frContent.Parts) != 1 {
+			t.Fatalf("len(parts) = %d, want 1", len(frContent.Parts))
+		}
+		fr := frContent.Parts[0].FunctionResponse
+		if fr == nil {
+			t.Fatal("functionResponse is nil")
+		}
+		if fr.Name != "get_weather" {
+			t.Errorf("name = %q, want get_weather", fr.Name)
+		}
+		// Response must be a JSON object wrapper.
+		if len(fr.Response) == 0 || fr.Response[0] != '{' {
+			t.Errorf("response = %q, want JSON object", fr.Response)
+		}
+	})
+
+	t.Run("tool_choice unknown string fails closed", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"model": "gemini-1.5-pro",
+			"messages": [{"role":"user","content":"Hi"}],
+			"tools": [{"type":"function","function":{"name":"fn","parameters":{}}}],
+			"tool_choice": "random_value"
+		}`
+		a := &GeminiAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err == nil {
+			t.Fatal("expected error for unknown tool_choice string, got nil")
+		}
+	})
+
+	t.Run("tool type not function fails closed", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"model": "gemini-1.5-pro",
+			"messages": [{"role":"user","content":"Hi"}],
+			"tools": [{"type":"retrieval","function":{"name":"fn","parameters":{}}}]
+		}`
+		a := &GeminiAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err == nil {
+			t.Fatal("expected error for non-function tool type, got nil")
+		}
+	})
+
+	t.Run("tool function name with invalid chars fails closed", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"model": "gemini-1.5-pro",
+			"messages": [{"role":"user","content":"Hi"}],
+			"tools": [{"type":"function","function":{"name":"fn with spaces","parameters":{}}}]
+		}`
+		a := &GeminiAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err == nil {
+			t.Fatal("expected error for invalid function name charset, got nil")
+		}
+	})
+}
+
+// TestGeminiTransformResponse_ToolCalls verifies that functionCall parts in a
+// Gemini response are translated to OpenAI tool_calls with synthesised ids.
+func TestGeminiTransformResponse_ToolCalls(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single functionCall part becomes tool_call", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"candidates": [{
+				"content": {
+					"role": "model",
+					"parts": [{
+						"functionCall": {
+							"name": "get_weather",
+							"args": {"location": "NYC"}
+						}
+					}]
+				},
+				"finishReason": "FUNCTION_CALL"
+			}],
+			"usageMetadata": {"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}
+		}`
+		a := &GeminiAdapter{}
+		out, err := a.TransformResponse([]byte(input))
+		if err != nil {
+			t.Fatalf("TransformResponse() error = %v", err)
+		}
+		var resp openAIResponse
+		if err := json.Unmarshal(out, &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(resp.Choices) != 1 {
+			t.Fatalf("len(choices) = %d, want 1", len(resp.Choices))
+		}
+		ch := resp.Choices[0]
+		if ch.FinishReason != "tool_calls" {
+			t.Errorf("finish_reason = %q, want tool_calls", ch.FinishReason)
+		}
+		// content must be null when only tool calls present.
+		if ch.Message.Content != nil {
+			t.Errorf("content = %q, want nil (null)", *ch.Message.Content)
+		}
+		if len(ch.Message.ToolCalls) != 1 {
+			t.Fatalf("len(tool_calls) = %d, want 1", len(ch.Message.ToolCalls))
+		}
+		tc := ch.Message.ToolCalls[0]
+		if tc.ID == "" {
+			t.Error("tool_call id should be non-empty (synthesised)")
+		}
+		if tc.Type != "function" {
+			t.Errorf("type = %q, want function", tc.Type)
+		}
+		if tc.Function.Name != "get_weather" {
+			t.Errorf("function.name = %q, want get_weather", tc.Function.Name)
+		}
+		// Arguments must be a JSON string representing the args object.
+		if tc.Function.Arguments == "" {
+			t.Error("function.arguments should not be empty")
+		}
+		if tc.Function.Arguments[0] != '{' {
+			t.Errorf("function.arguments = %q, want JSON object string", tc.Function.Arguments)
+		}
+	})
+
+	t.Run("multiple functionCall parts get sequential ids", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"candidates": [{
+				"content": {
+					"role": "model",
+					"parts": [
+						{"functionCall": {"name": "fn_a", "args": {}}},
+						{"functionCall": {"name": "fn_b", "args": {"x": 1}}}
+					]
+				},
+				"finishReason": "FUNCTION_CALL"
+			}],
+			"usageMetadata": {}
+		}`
+		a := &GeminiAdapter{}
+		out, err := a.TransformResponse([]byte(input))
+		if err != nil {
+			t.Fatalf("TransformResponse() error = %v", err)
+		}
+		var resp openAIResponse
+		if err := json.Unmarshal(out, &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		tcs := resp.Choices[0].Message.ToolCalls
+		if len(tcs) != 2 {
+			t.Fatalf("len(tool_calls) = %d, want 2", len(tcs))
+		}
+		if tcs[0].ID == tcs[1].ID {
+			t.Error("tool_call ids should be distinct")
+		}
+		if tcs[0].Function.Name != "fn_a" {
+			t.Errorf("tool_calls[0].function.name = %q, want fn_a", tcs[0].Function.Name)
+		}
+		if tcs[1].Function.Name != "fn_b" {
+			t.Errorf("tool_calls[1].function.name = %q, want fn_b", tcs[1].Function.Name)
+		}
+	})
+
+	t.Run("mixed text and functionCall parts: text in content, tool_calls set", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"candidates": [{
+				"content": {
+					"role": "model",
+					"parts": [
+						{"text": "Let me check that for you."},
+						{"functionCall": {"name": "search", "args": {"q": "weather"}}}
+					]
+				},
+				"finishReason": "FUNCTION_CALL"
+			}],
+			"usageMetadata": {}
+		}`
+		a := &GeminiAdapter{}
+		out, err := a.TransformResponse([]byte(input))
+		if err != nil {
+			t.Fatalf("TransformResponse() error = %v", err)
+		}
+		var resp openAIResponse
+		if err := json.Unmarshal(out, &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		ch := resp.Choices[0]
+		if ch.Message.Content == nil || *ch.Message.Content != "Let me check that for you." {
+			var got string
+			if ch.Message.Content != nil {
+				got = *ch.Message.Content
+			}
+			t.Errorf("content = %q, want \"Let me check that for you.\"", got)
+		}
+		if len(ch.Message.ToolCalls) != 1 {
+			t.Fatalf("len(tool_calls) = %d, want 1", len(ch.Message.ToolCalls))
+		}
+	})
+
+	t.Run("functionCall presence overrides STOP to tool_calls regardless of finishReason string", func(t *testing.T) {
+		t.Parallel()
+		// Gemini sends finishReason "STOP" for tool calls (no "FUNCTION_CALL" enum exists).
+		// The adapter derives finish_reason from functionCall PRESENCE, not from the
+		// Gemini finishReason string. A response with functionCall parts and finishReason
+		// "STOP" must produce finish_reason "tool_calls".
+		input := `{
+			"candidates": [{
+				"content": {
+					"role": "model",
+					"parts": [{"functionCall": {"name": "get_weather", "args": {"city": "NYC"}}}]
+				},
+				"finishReason": "STOP"
+			}],
+			"usageMetadata": {}
+		}`
+		a := &GeminiAdapter{}
+		out, err := a.TransformResponse([]byte(input))
+		if err != nil {
+			t.Fatalf("TransformResponse() error = %v", err)
+		}
+		var resp openAIResponse
+		if err := json.Unmarshal(out, &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if resp.Choices[0].FinishReason != "tool_calls" {
+			t.Errorf("finish_reason = %q, want tool_calls (functionCall presence must override STOP)", resp.Choices[0].FinishReason)
+		}
+	})
+}
+
+// TestGeminiTransformStreamLine_ToolCalls verifies streaming tool call delta
+// emission conformant with OpenAI Stage 0c shape.
+func TestGeminiTransformStreamLine_ToolCalls(t *testing.T) {
+	t.Parallel()
+
+	t.Run("functionCall chunk emits tool_calls delta with index id type name args", func(t *testing.T) {
+		t.Parallel()
+		line := `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"get_weather","args":{"location":"NYC"}}}]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`
+		a := &GeminiAdapter{}
+		out := a.TransformStreamLine([]byte(line))
+		if out == nil {
+			t.Fatal("TransformStreamLine() = nil, want non-nil for functionCall chunk")
+		}
+		chunk := parseChunk(t, out)
+		if len(chunk.Choices) != 1 {
+			t.Fatalf("len(choices) = %d, want 1", len(chunk.Choices))
+		}
+		ch := chunk.Choices[0]
+		if len(ch.Delta.ToolCalls) != 1 {
+			t.Fatalf("len(delta.tool_calls) = %d, want 1", len(ch.Delta.ToolCalls))
+		}
+		tc := ch.Delta.ToolCalls[0]
+		if tc.Index == nil {
+			t.Fatal("tool_calls[0].index is nil")
+		}
+		if *tc.Index != 0 {
+			t.Errorf("index = %d, want 0", *tc.Index)
+		}
+		if tc.ID == "" {
+			t.Error("id should be non-empty")
+		}
+		if tc.Type != "function" {
+			t.Errorf("type = %q, want function", tc.Type)
+		}
+		if tc.Function.Name != "get_weather" {
+			t.Errorf("function.name = %q, want get_weather", tc.Function.Name)
+		}
+		if tc.Function.Arguments == "" {
+			t.Error("function.arguments should not be empty")
+		}
+		// finish_reason on the same chunk as the functionCall.
+		if ch.FinishReason == nil || *ch.FinishReason != "tool_calls" {
+			var got string
+			if ch.FinishReason != nil {
+				got = *ch.FinishReason
+			}
+			t.Errorf("finish_reason = %q, want tool_calls", got)
+		}
+		// doneSent flag must be set.
+		if !a.doneSent {
+			t.Error("doneSent should be true after terminal functionCall chunk")
+		}
+	})
+
+	t.Run("functionCall-only chunk is NOT dropped", func(t *testing.T) {
+		t.Parallel()
+		// A chunk with only a functionCall part and no text — previously would
+		// have been dropped by the deltaText=="" && finishReason==nil guard.
+		// This verifies the content-free-drop fix.
+		line := `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"fn","args":{}}}]},"finishReason":""}],"usageMetadata":{}}`
+		a := &GeminiAdapter{}
+		out := a.TransformStreamLine([]byte(line))
+		if out == nil {
+			t.Fatal("TransformStreamLine() = nil for functionCall-only chunk (content-free-drop bug)")
+		}
+	})
+
+	t.Run("stream tool call counter increments across multiple chunks", func(t *testing.T) {
+		t.Parallel()
+		a := &GeminiAdapter{}
+
+		line1 := `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"fn_a","args":{}}}]},"finishReason":""}],"usageMetadata":{}}`
+		out1 := a.TransformStreamLine([]byte(line1))
+		if out1 == nil {
+			t.Fatal("first chunk: nil")
+		}
+		chunk1 := parseChunk(t, out1)
+		idx1 := *chunk1.Choices[0].Delta.ToolCalls[0].Index
+
+		line2 := `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"fn_b","args":{}}}]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`
+		out2 := a.TransformStreamLine([]byte(line2))
+		if out2 == nil {
+			t.Fatal("second chunk: nil")
+		}
+		chunk2 := parseChunk(t, out2)
+		idx2 := *chunk2.Choices[0].Delta.ToolCalls[0].Index
+
+		if idx1 == idx2 {
+			t.Errorf("tool call indices should differ: both are %d", idx1)
+		}
+		if idx2 != idx1+1 {
+			t.Errorf("second index %d should be one more than first %d", idx2, idx1)
+		}
+	})
+
+	t.Run("blank line after functionCall terminal chunk becomes DONE", func(t *testing.T) {
+		t.Parallel()
+		a := &GeminiAdapter{}
+		// Emit terminal tool-call chunk.
+		line := `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"fn","args":{}}}]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`
+		_ = a.TransformStreamLine([]byte(line))
+		done := a.TransformStreamLine([]byte(""))
+		if string(done) != "data: [DONE]" {
+			t.Errorf("blank after terminal = %q, want data: [DONE]", done)
+		}
+	})
+}
+
+// ── REQUEST: tool definitions (detailed) ─────────────────────────────────────
+
+// TestGeminiTransformRequest_ToolDefinitions exercises the detailed field-by-field
+// translation of OpenAI tool definitions to Gemini functionDeclarations, including
+// missing/null parameters handling and multiple tools.
+func TestGeminiTransformRequest_ToolDefinitions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		checkFn func(t *testing.T, req geminiRequest)
+		wantErr bool
+	}{
+		{
+			name: "name description parameters all preserved verbatim",
+			input: `{"model":"gemini-1.5-pro","messages":[{"role":"user","content":"q"}],
+				"tools":[{"type":"function","function":{
+					"name":"search",
+					"description":"Full-text search",
+					"parameters":{"type":"object","properties":{"query":{"type":"string"},"limit":{"type":"integer"}},"required":["query"]}
+				}}]}`,
+			checkFn: func(t *testing.T, req geminiRequest) {
+				t.Helper()
+				if len(req.Tools) != 1 {
+					t.Fatalf("len(tools) = %d, want 1", len(req.Tools))
+				}
+				decls := req.Tools[0].FunctionDeclarations
+				if len(decls) != 1 {
+					t.Fatalf("len(functionDeclarations) = %d, want 1", len(decls))
+				}
+				d := decls[0]
+				if d.Name != "search" {
+					t.Errorf("name = %q, want search", d.Name)
+				}
+				if d.Description != "Full-text search" {
+					t.Errorf("description = %q, want 'Full-text search'", d.Description)
+				}
+				// Parameters must be a JSON object matching the OpenAI parameters.
+				var params map[string]json.RawMessage
+				if err := json.Unmarshal(d.Parameters, &params); err != nil {
+					t.Fatalf("unmarshal parameters: %v", err)
+				}
+				if _, ok := params["properties"]; !ok {
+					t.Error("parameters missing 'properties' key")
+				}
+				if _, ok := params["required"]; !ok {
+					t.Error("parameters missing 'required' key")
+				}
+				var typ string
+				_ = json.Unmarshal(params["type"], &typ)
+				if typ != "object" {
+					t.Errorf("parameters.type = %q, want object", typ)
+				}
+			},
+		},
+		{
+			name: "missing parameters field emits nil parameters (omitted)",
+			input: `{"model":"gemini-1.5-pro","messages":[{"role":"user","content":"q"}],
+				"tools":[{"type":"function","function":{"name":"noop","description":"Does nothing"}}]}`,
+			checkFn: func(t *testing.T, req geminiRequest) {
+				t.Helper()
+				if len(req.Tools) != 1 {
+					t.Fatalf("len(tools) = %d, want 1", len(req.Tools))
+				}
+				d := req.Tools[0].FunctionDeclarations[0]
+				if d.Name != "noop" {
+					t.Errorf("name = %q, want noop", d.Name)
+				}
+				// Parameters is omitted (nil) when not supplied.
+				if len(d.Parameters) != 0 {
+					t.Errorf("parameters = %s, want nil/omitted when not supplied", d.Parameters)
+				}
+			},
+		},
+		{
+			name: "multiple tools become multiple declarations in single geminiTool",
+			input: `{"model":"gemini-1.5-pro","messages":[{"role":"user","content":"q"}],
+				"tools":[
+					{"type":"function","function":{"name":"fn_a","description":"A","parameters":{"type":"object","properties":{}}}},
+					{"type":"function","function":{"name":"fn_b","description":"B","parameters":{"type":"object","properties":{}}}},
+					{"type":"function","function":{"name":"fn_c","description":"C","parameters":{"type":"object","properties":{}}}}
+				]}`,
+			checkFn: func(t *testing.T, req geminiRequest) {
+				t.Helper()
+				// All declarations must be in a single Tools element.
+				if len(req.Tools) != 1 {
+					t.Fatalf("len(tools) = %d, want 1 (all declarations in one element)", len(req.Tools))
+				}
+				decls := req.Tools[0].FunctionDeclarations
+				if len(decls) != 3 {
+					t.Fatalf("len(functionDeclarations) = %d, want 3", len(decls))
+				}
+				wantNames := []string{"fn_a", "fn_b", "fn_c"}
+				for i, d := range decls {
+					if d.Name != wantNames[i] {
+						t.Errorf("decls[%d].name = %q, want %q", i, d.Name, wantNames[i])
+					}
+				}
+			},
+		},
+		{
+			name: "parameters as JSON array (not object) returns error",
+			input: `{"model":"gemini-1.5-pro","messages":[{"role":"user","content":"q"}],
+				"tools":[{"type":"function","function":{"name":"fn","parameters":[1,2,3]}}]}`,
+			wantErr: true,
+		},
+		{
+			// The impl rejects parameters:null because the trim+check treats "null"
+			// as a non-object value (trimmed[0] == 'n', not '{').
+			// This is conservative fail-closed behaviour: null parameters must be
+			// omitted entirely, not set to JSON null.
+			name: "parameters as JSON null returns error (must be omitted not null)",
+			input: `{"model":"gemini-1.5-pro","messages":[{"role":"user","content":"q"}],
+				"tools":[{"type":"function","function":{"name":"fn","parameters":null}}]}`,
+			wantErr: true,
+		},
+		{
+			name: "tool type not function returns error",
+			input: `{"model":"gemini-1.5-pro","messages":[{"role":"user","content":"q"}],
+				"tools":[{"type":"retrieval","function":{"name":"fn"}}]}`,
+			wantErr: true,
+		},
+		{
+			name: "empty tool function name returns error",
+			input: `{"model":"gemini-1.5-pro","messages":[{"role":"user","content":"q"}],
+				"tools":[{"type":"function","function":{"name":"","parameters":{}}}]}`,
+			wantErr: true,
+		},
+		{
+			name: "function name with at-sign returns error",
+			input: `{"model":"gemini-1.5-pro","messages":[{"role":"user","content":"q"}],
+				"tools":[{"type":"function","function":{"name":"fn@email","parameters":{}}}]}`,
+			wantErr: true,
+		},
+		{
+			name: "function name with space returns error",
+			input: `{"model":"gemini-1.5-pro","messages":[{"role":"user","content":"q"}],
+				"tools":[{"type":"function","function":{"name":"fn name","parameters":{}}}]}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &GeminiAdapter{}
+			out, err := a.TransformRequest([]byte(tc.input), Model{})
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				// Fail-closed validation: error must not leak function names or content.
+				// The error message must not contain identifiable caller data.
+				// (Tested implicitly: the error is opaque, not a raw-value echo.)
+				return
+			}
+			if err != nil {
+				t.Fatalf("TransformRequest() error = %v", err)
+			}
+
+			var req geminiRequest
+			if err := json.Unmarshal(out, &req); err != nil {
+				t.Fatalf("unmarshal output: %v", err)
+			}
+			tc.checkFn(t, req)
+		})
+	}
+}
+
+// ── REQUEST: tool_choice translation (detailed) ───────────────────────────────
+
+// TestGeminiTransformRequest_ToolChoice_Detailed covers all tool_choice variants
+// not already covered by the existing tests, including error cases and opaque
+// error message validation (no function name in error string).
+func TestGeminiTransformRequest_ToolChoice_Detailed(t *testing.T) {
+	t.Parallel()
+
+	baseTools := `[{"type":"function","function":{"name":"lookup","parameters":{"type":"object","properties":{}}}}]`
+
+	tests := []struct {
+		name             string
+		toolChoiceRaw    string
+		wantMode         string   // expected FunctionCallingConfig.Mode
+		wantAllowedNames []string // expected AllowedFunctionNames (nil = none)
+		wantToolsRemoved bool     // true when tool_choice=none removes tools
+		wantErr          bool
+	}{
+		{
+			name:          "auto maps to AUTO mode",
+			toolChoiceRaw: `"auto"`,
+			wantMode:      "AUTO",
+		},
+		{
+			name:          "required maps to ANY mode",
+			toolChoiceRaw: `"required"`,
+			wantMode:      "ANY",
+		},
+		{
+			name:             "none removes tools and toolConfig entirely",
+			toolChoiceRaw:    `"none"`,
+			wantToolsRemoved: true,
+		},
+		{
+			name:             "named function object maps to ANY with allowedFunctionNames",
+			toolChoiceRaw:    `{"type":"function","function":{"name":"lookup"}}`,
+			wantMode:         "ANY",
+			wantAllowedNames: []string{"lookup"},
+		},
+		{
+			name:          "unknown string value returns error",
+			toolChoiceRaw: `"bogus_mode"`,
+			wantErr:       true,
+		},
+		{
+			name:          "unknown object type returns error",
+			toolChoiceRaw: `{"type":"retrieval","function":{"name":"lookup"}}`,
+			wantErr:       true,
+		},
+		{
+			name:          "object with empty function name returns error",
+			toolChoiceRaw: `{"type":"function","function":{"name":""}}`,
+			wantErr:       true,
+		},
+		{
+			name:          "named function not in declared tools returns error",
+			toolChoiceRaw: `{"type":"function","function":{"name":"undeclared_fn"}}`,
+			wantErr:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			input := `{"model":"gemini-1.5-pro","messages":[{"role":"user","content":"q"}],"tools":` +
+				baseTools + `,"tool_choice":` + tc.toolChoiceRaw + `}`
+
+			a := &GeminiAdapter{}
+			out, err := a.TransformRequest([]byte(input), Model{})
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				// Fail-closed: error message must not echo back the tool name or value.
+				errStr := err.Error()
+				if strings.Contains(errStr, "lookup") {
+					t.Errorf("error message leaks declared tool name %q: %s", "lookup", errStr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("TransformRequest() error = %v", err)
+			}
+
+			var req geminiRequest
+			if err := json.Unmarshal(out, &req); err != nil {
+				t.Fatalf("unmarshal output: %v", err)
+			}
+
+			if tc.wantToolsRemoved {
+				if len(req.Tools) != 0 {
+					t.Errorf("tools should be absent after tool_choice=none, got %d entries", len(req.Tools))
+				}
+				if req.ToolConfig != nil {
+					t.Error("toolConfig should be nil after tool_choice=none")
+				}
+				return
+			}
+
+			if req.ToolConfig == nil {
+				t.Fatal("toolConfig is nil, want non-nil")
+			}
+			cfg := req.ToolConfig.FunctionCallingConfig
+			if cfg.Mode != tc.wantMode {
+				t.Errorf("functionCallingConfig.mode = %q, want %q", cfg.Mode, tc.wantMode)
+			}
+			if tc.wantAllowedNames != nil {
+				if len(cfg.AllowedFunctionNames) != len(tc.wantAllowedNames) {
+					t.Fatalf("allowedFunctionNames = %v, want %v", cfg.AllowedFunctionNames, tc.wantAllowedNames)
+				}
+				for i, want := range tc.wantAllowedNames {
+					if cfg.AllowedFunctionNames[i] != want {
+						t.Errorf("allowedFunctionNames[%d] = %q, want %q", i, cfg.AllowedFunctionNames[i], want)
+					}
+				}
+			} else {
+				if len(cfg.AllowedFunctionNames) != 0 {
+					t.Errorf("allowedFunctionNames = %v, want empty", cfg.AllowedFunctionNames)
+				}
+			}
+		})
+	}
+}
+
+// ── REQUEST: assistant message with tool_calls ────────────────────────────────
+
+// TestGeminiTransformRequest_AssistantToolCalls verifies that an OpenAI assistant
+// message carrying tool_calls becomes a Gemini model content with functionCall
+// parts.
+func TestGeminiTransformRequest_AssistantToolCalls(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		input         string
+		wantParts     int
+		wantTextFirst bool   // first part is text, not functionCall
+		wantFirstFC   string // function name of first functionCall part (or after text)
+		wantArgs      string // expected args JSON object string for first functionCall
+		wantIDAbsent  bool   // OpenAI id must not appear in any functionCall part
+		wantErr       bool
+	}{
+		{
+			name: "null content single tool_call becomes single functionCall part",
+			input: `{"model":"gemini-1.5-pro","messages":[
+				{"role":"user","content":"q"},
+				{"role":"assistant","content":null,"tool_calls":[
+					{"id":"call_abc","type":"function","function":{"name":"get_weather","arguments":"{\"location\":\"NYC\"}"}}
+				]}
+			]}`,
+			wantParts:    1,
+			wantFirstFC:  "get_weather",
+			wantArgs:     `{"location":"NYC"}`,
+			wantIDAbsent: true,
+		},
+		{
+			name: "empty string arguments become empty object",
+			input: `{"model":"gemini-1.5-pro","messages":[
+				{"role":"user","content":"q"},
+				{"role":"assistant","content":null,"tool_calls":[
+					{"id":"call_empty","type":"function","function":{"name":"noop","arguments":""}}
+				]}
+			]}`,
+			wantParts:   1,
+			wantFirstFC: "noop",
+			wantArgs:    `{}`,
+		},
+		{
+			name: "non-empty text content emits text part then functionCall parts",
+			input: `{"model":"gemini-1.5-pro","messages":[
+				{"role":"user","content":"q"},
+				{"role":"assistant","content":"Let me check the weather.","tool_calls":[
+					{"id":"call_text","type":"function","function":{"name":"get_weather","arguments":"{}"}}
+				]}
+			]}`,
+			wantParts:     2,
+			wantTextFirst: true,
+			wantFirstFC:   "get_weather",
+		},
+		{
+			name: "multiple tool_calls produce multiple functionCall parts",
+			input: `{"model":"gemini-1.5-pro","messages":[
+				{"role":"user","content":"q"},
+				{"role":"assistant","content":null,"tool_calls":[
+					{"id":"call_1","type":"function","function":{"name":"fn_a","arguments":"{\"x\":1}"}},
+					{"id":"call_2","type":"function","function":{"name":"fn_b","arguments":"{\"y\":2}"}},
+					{"id":"call_3","type":"function","function":{"name":"fn_c","arguments":"{\"z\":3}"}}
+				]}
+			]}`,
+			wantParts:   3,
+			wantFirstFC: "fn_a",
+		},
+		{
+			// PII pseudonyms use charset [A-Za-z0-9_] which is a subset of
+			// anthropicToolIDRe ([A-Za-z0-9_.+-]). FIX 2 adds an additional
+			// pseudonym-shape check so that names matching the canonical pseudonym
+			// pattern (PII_<2alnum>_<24hex>) are now rejected fail-closed.
+			// Without this, a compromised upstream returning a pseudonym-shaped name
+			// in a tool_call would allow filter.Restore to expand PII on the request
+			// forwarding path (pseudonym→real PII substitution in arguments).
+			name:    "tool_call function name matching canonical PII pseudonym shape is rejected",
+			input:   `{"model":"gemini-1.5-pro","messages":[{"role":"user","content":"q"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_pii","type":"function","function":{"name":"PII_EM_abc123def456abc123def456","arguments":"{}"}}]}]}`,
+			wantErr: true,
+		},
+		{
+			name: "tool_call function name with at-sign returns error",
+			input: `{"model":"gemini-1.5-pro","messages":[
+				{"role":"user","content":"q"},
+				{"role":"assistant","content":null,"tool_calls":[
+					{"id":"call_at","type":"function","function":{"name":"fn@bad","arguments":"{}"}}
+				]}
+			]}`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &GeminiAdapter{}
+			out, err := a.TransformRequest([]byte(tc.input), Model{})
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				// Error message must not echo back function name content.
+				errStr := err.Error()
+				if strings.Contains(errStr, "PII_EM_") {
+					t.Errorf("error message leaks PII pseudonym: %s", errStr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("TransformRequest() error = %v", err)
+			}
+
+			var req geminiRequest
+			if err := json.Unmarshal(out, &req); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+
+			// Find the model content.
+			var modelContent *geminiContent
+			for i := range req.Contents {
+				if req.Contents[i].Role == "model" {
+					modelContent = &req.Contents[i]
+					break
+				}
+			}
+			if modelContent == nil {
+				t.Fatal("no model-role content in output")
+			}
+
+			if len(modelContent.Parts) != tc.wantParts {
+				t.Fatalf("len(parts) = %d, want %d", len(modelContent.Parts), tc.wantParts)
+			}
+
+			fcIdx := 0
+			if tc.wantTextFirst {
+				if modelContent.Parts[0].Text == "" {
+					t.Error("first part should be text, got empty text")
+				}
+				if modelContent.Parts[0].FunctionCall != nil {
+					t.Error("first part should be text, not functionCall")
+				}
+				fcIdx = 1
+			}
+
+			fc := modelContent.Parts[fcIdx].FunctionCall
+			if fc == nil {
+				t.Fatalf("parts[%d].functionCall is nil", fcIdx)
+			}
+			if tc.wantFirstFC != "" && fc.Name != tc.wantFirstFC {
+				t.Errorf("functionCall.name = %q, want %q", fc.Name, tc.wantFirstFC)
+			}
+
+			// Verify args are a JSON object, not the raw string.
+			if len(fc.Args) == 0 || fc.Args[0] != '{' {
+				t.Errorf("functionCall.args = %s, want JSON object", fc.Args)
+			}
+			if tc.wantArgs != "" {
+				// Normalise by re-parsing to avoid whitespace differences.
+				var gotArgs, wantArgs map[string]json.RawMessage
+				_ = json.Unmarshal(fc.Args, &gotArgs)
+				_ = json.Unmarshal([]byte(tc.wantArgs), &wantArgs)
+				if len(gotArgs) != len(wantArgs) {
+					t.Errorf("functionCall.args = %s, want %s", fc.Args, tc.wantArgs)
+				}
+			}
+
+			// The OpenAI id must NOT appear in any functionCall part (Gemini has no id).
+			// This is a structural guarantee: geminiFunctionCall has no id field,
+			// so the OpenAI id cannot appear inside a functionCall part regardless
+			// of what the OpenAI message carried.
+			_ = tc.wantIDAbsent // documented for clarity; enforced by struct design.
+		})
+	}
+}
+
+// ── REQUEST: role:tool messages → functionResponse ────────────────────────────
+
+// TestGeminiTransformRequest_ToolResultMessages covers the translation of
+// OpenAI role:"tool" messages to Gemini functionResponse parts, including:
+//   - String content wrapped as {"content":"..."}
+//   - Array content preserved as separate strings (never concatenated)
+//   - Consecutive tool messages merged into one user content
+//   - Name correlation from tool_call_id via the toolCallIDToName map
+func TestGeminiTransformRequest_ToolResultMessages(t *testing.T) {
+	t.Parallel()
+
+	t.Run("string content wrapped as object", func(t *testing.T) {
+		t.Parallel()
+
+		input := `{"model":"gemini-1.5-pro","messages":[
+			{"role":"user","content":"q"},
+			{"role":"assistant","content":null,"tool_calls":[
+				{"id":"call_str","type":"function","function":{"name":"get_data","arguments":"{}"}}
+			]},
+			{"role":"tool","tool_call_id":"call_str","content":"result string here"}
+		]}`
+
+		a := &GeminiAdapter{}
+		out, err := a.TransformRequest([]byte(input), Model{})
+		if err != nil {
+			t.Fatalf("TransformRequest() error = %v", err)
+		}
+
+		var req geminiRequest
+		if err := json.Unmarshal(out, &req); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		// Expect 3 contents: user, model, user(functionResponse)
+		if len(req.Contents) != 3 {
+			t.Fatalf("len(contents) = %d, want 3", len(req.Contents))
+		}
+		frContent := req.Contents[2]
+		if frContent.Role != "user" {
+			t.Errorf("role = %q, want user", frContent.Role)
+		}
+		if len(frContent.Parts) != 1 {
+			t.Fatalf("len(parts) = %d, want 1", len(frContent.Parts))
+		}
+		fr := frContent.Parts[0].FunctionResponse
+		if fr == nil {
+			t.Fatal("functionResponse is nil")
+		}
+		if fr.Name != "get_data" {
+			t.Errorf("name = %q, want get_data (must be correlated from tool_call_id)", fr.Name)
+		}
+		// Response must be a JSON object wrapping the string.
+		var wrapper struct {
+			Content string `json:"content"`
+		}
+		if err := json.Unmarshal(fr.Response, &wrapper); err != nil {
+			t.Fatalf("unmarshal response wrapper: %v (raw: %s)", err, fr.Response)
+		}
+		if wrapper.Content != "result string here" {
+			t.Errorf("response.content = %q, want %q", wrapper.Content, "result string here")
+		}
+	})
+
+	t.Run("array content preserved as list — no concatenation zero-knowledge", func(t *testing.T) {
+		t.Parallel()
+
+		// The two text parts "alice@" and "example.com" must remain separate —
+		// joining them into "alice@example.com" would reconstruct a PII email.
+		input := `{"model":"gemini-1.5-pro","messages":[
+			{"role":"user","content":"q"},
+			{"role":"assistant","content":null,"tool_calls":[
+				{"id":"call_arr","type":"function","function":{"name":"lookup_user","arguments":"{}"}}
+			]},
+			{"role":"tool","tool_call_id":"call_arr","content":[
+				{"type":"text","text":"alice@"},
+				{"type":"text","text":"example.com"}
+			]}
+		]}`
+
+		a := &GeminiAdapter{}
+		out, err := a.TransformRequest([]byte(input), Model{})
+		if err != nil {
+			t.Fatalf("TransformRequest() error = %v", err)
+		}
+
+		var req geminiRequest
+		if err := json.Unmarshal(out, &req); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		frContent := req.Contents[len(req.Contents)-1]
+		if frContent.Role != "user" {
+			t.Fatalf("last content role = %q, want user", frContent.Role)
+		}
+		fr := frContent.Parts[0].FunctionResponse
+		if fr == nil {
+			t.Fatal("functionResponse is nil")
+		}
+
+		// Response must be a JSON object with a list of strings.
+		var wrapper struct {
+			Content []string `json:"content"`
+		}
+		if err := json.Unmarshal(fr.Response, &wrapper); err != nil {
+			t.Fatalf("unmarshal response wrapper as list: %v (raw: %s)", err, fr.Response)
+		}
+		if len(wrapper.Content) != 2 {
+			t.Fatalf("content list len = %d, want 2 (parts must be separate)", len(wrapper.Content))
+		}
+		if wrapper.Content[0] != "alice@" {
+			t.Errorf("content[0] = %q, want %q", wrapper.Content[0], "alice@")
+		}
+		if wrapper.Content[1] != "example.com" {
+			t.Errorf("content[1] = %q, want %q", wrapper.Content[1], "example.com")
+		}
+		// Zero-knowledge boundary: joined PII string must never appear as a single value.
+		rawResponse := string(fr.Response)
+		if strings.Contains(rawResponse, "alice@example.com") {
+			t.Errorf("SECURITY: joined PII email %q appears in response; parts must stay separate; raw: %s",
+				"alice@example.com", rawResponse)
+		}
+	})
+
+	t.Run("consecutive tool messages merged into one user content with multiple functionResponse parts", func(t *testing.T) {
+		t.Parallel()
+
+		input := `{"model":"gemini-1.5-pro","messages":[
+			{"role":"user","content":"q"},
+			{"role":"assistant","content":null,"tool_calls":[
+				{"id":"c1","type":"function","function":{"name":"fn1","arguments":"{}"}},
+				{"id":"c2","type":"function","function":{"name":"fn2","arguments":"{}"}}
+			]},
+			{"role":"tool","tool_call_id":"c1","content":"result one"},
+			{"role":"tool","tool_call_id":"c2","content":"result two"}
+		]}`
+
+		a := &GeminiAdapter{}
+		out, err := a.TransformRequest([]byte(input), Model{})
+		if err != nil {
+			t.Fatalf("TransformRequest() error = %v", err)
+		}
+
+		var req geminiRequest
+		if err := json.Unmarshal(out, &req); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		// Expected: user, model, user (merged functionResponses)
+		if len(req.Contents) != 3 {
+			t.Fatalf("len(contents) = %d, want 3 (consecutive tools merged)", len(req.Contents))
+		}
+		merged := req.Contents[2]
+		if merged.Role != "user" {
+			t.Errorf("merged content role = %q, want user", merged.Role)
+		}
+		if len(merged.Parts) != 2 {
+			t.Fatalf("len(parts) = %d, want 2 merged functionResponse parts", len(merged.Parts))
+		}
+		fr0 := merged.Parts[0].FunctionResponse
+		fr1 := merged.Parts[1].FunctionResponse
+		if fr0 == nil || fr1 == nil {
+			t.Fatal("both parts must be functionResponse")
+		}
+		if fr0.Name != "fn1" {
+			t.Errorf("parts[0].functionResponse.name = %q, want fn1", fr0.Name)
+		}
+		if fr1.Name != "fn2" {
+			t.Errorf("parts[1].functionResponse.name = %q, want fn2", fr1.Name)
+		}
+	})
+}
+
+// ── REQUEST: full round-trip conversation ────────────────────────────────────
+
+// TestGeminiTransformRequest_FullRound verifies a complete multi-turn conversation:
+// system + user + assistant(tool_calls) + tool(result) + user
+// The system is extracted into systemInstruction, the function response name is
+// correlated from tool_call_id, and the contents sequence is well-formed.
+func TestGeminiTransformRequest_FullRound(t *testing.T) {
+	t.Parallel()
+
+	input := `{"model":"gemini-1.5-pro","messages":[
+		{"role":"system","content":"You are a helpful assistant."},
+		{"role":"user","content":"What is the weather in Paris?"},
+		{"role":"assistant","content":null,"tool_calls":[
+			{"id":"call_paris","type":"function","function":{"name":"get_weather","arguments":"{\"city\":\"Paris\"}"}}
+		]},
+		{"role":"tool","tool_call_id":"call_paris","content":"It is 18C and sunny."},
+		{"role":"user","content":"Thanks!"}
+	]}`
+
+	a := &GeminiAdapter{}
+	out, err := a.TransformRequest([]byte(input), Model{})
+	if err != nil {
+		t.Fatalf("TransformRequest() error = %v", err)
+	}
+
+	var req geminiRequest
+	if err := json.Unmarshal(out, &req); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// System extracted to systemInstruction.
+	if req.SystemInstruction == nil {
+		t.Fatal("systemInstruction is nil, want non-nil")
+	}
+	if len(req.SystemInstruction.Parts) != 1 {
+		t.Fatalf("systemInstruction.parts len = %d, want 1", len(req.SystemInstruction.Parts))
+	}
+	if req.SystemInstruction.Parts[0].Text != "You are a helpful assistant." {
+		t.Errorf("systemInstruction.parts[0].text = %q, want 'You are a helpful assistant.'",
+			req.SystemInstruction.Parts[0].Text)
+	}
+
+	// Contents: user, model(functionCall), user(functionResponse), user
+	if len(req.Contents) != 4 {
+		t.Fatalf("len(contents) = %d, want 4; contents: %+v", len(req.Contents), req.Contents)
+	}
+
+	// [0] user
+	if req.Contents[0].Role != "user" {
+		t.Errorf("contents[0].role = %q, want user", req.Contents[0].Role)
+	}
+	if req.Contents[0].Parts[0].Text != "What is the weather in Paris?" {
+		t.Errorf("contents[0].parts[0].text = %q, want weather question", req.Contents[0].Parts[0].Text)
+	}
+
+	// [1] model with functionCall
+	if req.Contents[1].Role != "model" {
+		t.Errorf("contents[1].role = %q, want model", req.Contents[1].Role)
+	}
+	if len(req.Contents[1].Parts) != 1 {
+		t.Fatalf("contents[1] parts = %d, want 1", len(req.Contents[1].Parts))
+	}
+	fc := req.Contents[1].Parts[0].FunctionCall
+	if fc == nil {
+		t.Fatal("contents[1].parts[0].functionCall is nil")
+	}
+	if fc.Name != "get_weather" {
+		t.Errorf("functionCall.name = %q, want get_weather", fc.Name)
+	}
+	var fcArgs map[string]json.RawMessage
+	if err := json.Unmarshal(fc.Args, &fcArgs); err != nil {
+		t.Fatalf("unmarshal functionCall.args: %v", err)
+	}
+	var city string
+	if err := json.Unmarshal(fcArgs["city"], &city); err != nil {
+		t.Fatalf("unmarshal city: %v", err)
+	}
+	if city != "Paris" {
+		t.Errorf("functionCall.args.city = %q, want Paris", city)
+	}
+
+	// [2] user with functionResponse — name correlated from tool_call_id
+	if req.Contents[2].Role != "user" {
+		t.Errorf("contents[2].role = %q, want user", req.Contents[2].Role)
+	}
+	if len(req.Contents[2].Parts) != 1 {
+		t.Fatalf("contents[2] parts = %d, want 1", len(req.Contents[2].Parts))
+	}
+	fr := req.Contents[2].Parts[0].FunctionResponse
+	if fr == nil {
+		t.Fatal("contents[2].parts[0].functionResponse is nil")
+	}
+	if fr.Name != "get_weather" {
+		t.Errorf("functionResponse.name = %q, want get_weather (correlated from call_paris→get_weather)",
+			fr.Name)
+	}
+	var respWrapper struct {
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(fr.Response, &respWrapper); err != nil {
+		t.Fatalf("unmarshal functionResponse.response: %v", err)
+	}
+	if respWrapper.Content != "It is 18C and sunny." {
+		t.Errorf("functionResponse.response.content = %q, want 'It is 18C and sunny.'",
+			respWrapper.Content)
+	}
+
+	// [3] final user
+	if req.Contents[3].Role != "user" {
+		t.Errorf("contents[3].role = %q, want user", req.Contents[3].Role)
+	}
+	if req.Contents[3].Parts[0].Text != "Thanks!" {
+		t.Errorf("contents[3].parts[0].text = %q, want Thanks!", req.Contents[3].Parts[0].Text)
+	}
+}
+
+// ── REQUEST: fail-closed validation ──────────────────────────────────────────
+
+// TestGeminiTransformRequest_FailClosed verifies that the adapter returns an
+// error for all invalid inputs without leaking caller values in error strings.
+func TestGeminiTransformRequest_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		input        string
+		leakPatterns []string // substrings that must NOT appear in the error string
+	}{
+		{
+			name: "tool type not function",
+			input: `{"model":"gemini-1.5-pro","messages":[{"role":"user","content":"q"}],
+				"tools":[{"type":"code_interpreter","function":{"name":"fn","parameters":{}}}]}`,
+		},
+		{
+			name: "empty tool function name",
+			input: `{"model":"gemini-1.5-pro","messages":[{"role":"user","content":"q"}],
+				"tools":[{"type":"function","function":{"name":"","parameters":{}}}]}`,
+		},
+		{
+			name: "parameters is a JSON number",
+			input: `{"model":"gemini-1.5-pro","messages":[{"role":"user","content":"q"}],
+				"tools":[{"type":"function","function":{"name":"fn","parameters":42}}]}`,
+		},
+		{
+			name: "function name with at-sign",
+			input: `{"model":"gemini-1.5-pro","messages":[{"role":"user","content":"q"}],
+				"tools":[{"type":"function","function":{"name":"fn@domain","parameters":{}}}]}`,
+			leakPatterns: []string{"fn@domain"},
+		},
+		{
+			name: "function name with space",
+			input: `{"model":"gemini-1.5-pro","messages":[{"role":"user","content":"q"}],
+				"tools":[{"type":"function","function":{"name":"has space","parameters":{}}}]}`,
+			leakPatterns: []string{"has space"},
+		},
+		// Note: PII pseudonyms (PII_EM_...) use charset [A-Za-z0-9_] — a valid
+		// subset of anthropicToolIDRe — so the adapter's charset check does NOT
+		// reject them. Zero-knowledge enforcement is the PII pipeline's job.
+		// This case is omitted from the fail-closed table.
+
+		{
+			name: "unknown tool_choice string",
+			input: `{"model":"gemini-1.5-pro","messages":[{"role":"user","content":"q"}],
+				"tools":[{"type":"function","function":{"name":"fn","parameters":{}}}],
+				"tool_choice":"forbidden_value"}`,
+			leakPatterns: []string{"forbidden_value"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &GeminiAdapter{}
+			_, err := a.TransformRequest([]byte(tc.input), Model{})
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			errStr := err.Error()
+			for _, pattern := range tc.leakPatterns {
+				if strings.Contains(errStr, pattern) {
+					t.Errorf("error leaks caller value %q: %s", pattern, errStr)
+				}
+			}
+		})
+	}
+}
+
+// ── RESPONSE (non-streaming): function call translation ───────────────────────
+
+// TestGeminiTransformResponse_ToolCalls_Detailed covers detailed assertions on
+// functionCall → tool_calls translation: synthesised id format, content null,
+// arguments as JSON string, multiple calls, mixed text+tool, FUNCTION_CALL
+// finishReason, and text-only no-regression.
+func TestGeminiTransformResponse_ToolCalls_Detailed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		inputJSON       string
+		wantNullContent bool
+		wantContent     string // non-empty: assert content equals this
+		wantToolCount   int
+		wantToolNames   []string
+		wantFinish      string
+		wantIDPattern   string // if non-empty, each tool_call.id must match this prefix
+		wantErr         bool
+	}{
+		{
+			name: "single functionCall: content null finish_reason tool_calls synthesised id",
+			inputJSON: `{"candidates":[{"content":{"role":"model","parts":[
+				{"functionCall":{"name":"get_weather","args":{"location":"NYC","unit":"celsius"}}}
+			]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{"promptTokenCount":10,"candidatesTokenCount":5,"totalTokenCount":15}}`,
+			wantNullContent: true,
+			wantToolCount:   1,
+			wantToolNames:   []string{"get_weather"},
+			wantFinish:      "tool_calls",
+			wantIDPattern:   "call_g",
+		},
+		{
+			name: "FUNCTION_CALL finishReason maps to tool_calls not stop",
+			inputJSON: `{"candidates":[{"content":{"role":"model","parts":[
+				{"functionCall":{"name":"fn","args":{}}}
+			]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`,
+			wantToolCount: 1,
+			wantFinish:    "tool_calls",
+		},
+		{
+			name: "multiple functionCall parts get sequential synthesised ids",
+			inputJSON: `{"candidates":[{"content":{"role":"model","parts":[
+				{"functionCall":{"name":"fn_a","args":{"x":1}}},
+				{"functionCall":{"name":"fn_b","args":{"y":2}}},
+				{"functionCall":{"name":"fn_c","args":{"z":3}}}
+			]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`,
+			wantNullContent: true,
+			wantToolCount:   3,
+			wantToolNames:   []string{"fn_a", "fn_b", "fn_c"},
+			wantFinish:      "tool_calls",
+			wantIDPattern:   "call_g",
+		},
+		{
+			name: "mixed text and functionCall: content non-null and tool_calls present",
+			inputJSON: `{"candidates":[{"content":{"role":"model","parts":[
+				{"text":"Let me look that up."},
+				{"functionCall":{"name":"search","args":{"query":"golang"}}}
+			]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`,
+			wantContent:   "Let me look that up.",
+			wantToolCount: 1,
+			wantToolNames: []string{"search"},
+			wantFinish:    "tool_calls",
+		},
+		{
+			name: "text-only response: content string no tool_calls finish_reason stop",
+			inputJSON: `{"candidates":[{"content":{"role":"model","parts":[
+				{"text":"Just a plain answer."}
+			]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":3,"candidatesTokenCount":5,"totalTokenCount":8}}`,
+			wantContent:   "Just a plain answer.",
+			wantToolCount: 0,
+			wantFinish:    "stop",
+		},
+		{
+			name: "functionCall args serialised to JSON string for function.arguments",
+			inputJSON: `{"candidates":[{"content":{"role":"model","parts":[
+				{"functionCall":{"name":"fn","args":{"a":"hello","b":42,"c":true}}}
+			]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`,
+			wantToolCount: 1,
+		},
+		{
+			name: "empty args object serialises to empty JSON object string",
+			inputJSON: `{"candidates":[{"content":{"role":"model","parts":[
+				{"functionCall":{"name":"noop","args":{}}}
+			]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`,
+			wantToolCount: 1,
+		},
+		{
+			name:      "invalid JSON returns error",
+			inputJSON: "not-json",
+			wantErr:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &GeminiAdapter{}
+			out, err := a.TransformResponse([]byte(tc.inputJSON))
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("TransformResponse() error = %v", err)
+			}
+
+			var resp openAIResponse
+			if err := json.Unmarshal(out, &resp); err != nil {
+				t.Fatalf("unmarshal response: %v", err)
+			}
+
+			if len(resp.Choices) != 1 {
+				t.Fatalf("len(choices) = %d, want 1", len(resp.Choices))
+			}
+			ch := resp.Choices[0]
+			msg := ch.Message
+
+			// Finish reason.
+			if tc.wantFinish != "" && ch.FinishReason != tc.wantFinish {
+				t.Errorf("finish_reason = %q, want %q", ch.FinishReason, tc.wantFinish)
+			}
+
+			// Content assertions.
+			if tc.wantNullContent {
+				if msg.Content != nil {
+					t.Errorf("content = %q, want nil (null) when only tool calls present", *msg.Content)
+				}
+			} else if tc.wantContent != "" {
+				if msg.Content == nil {
+					t.Fatalf("content is nil, want %q", tc.wantContent)
+				}
+				if *msg.Content != tc.wantContent {
+					t.Errorf("content = %q, want %q", *msg.Content, tc.wantContent)
+				}
+			}
+
+			// Tool calls assertions.
+			if tc.wantToolCount == 0 {
+				if len(msg.ToolCalls) != 0 {
+					t.Errorf("tool_calls = %v, want absent", msg.ToolCalls)
+				}
+				return
+			}
+			if len(msg.ToolCalls) != tc.wantToolCount {
+				t.Fatalf("len(tool_calls) = %d, want %d", len(msg.ToolCalls), tc.wantToolCount)
+			}
+
+			seenIDs := make(map[string]bool)
+			for i, tc2 := range msg.ToolCalls {
+				if tc2.Type != "function" {
+					t.Errorf("tool_calls[%d].type = %q, want function", i, tc2.Type)
+				}
+				if tc2.ID == "" {
+					t.Errorf("tool_calls[%d].id is empty (must be synthesised)", i)
+				}
+				if tc.wantIDPattern != "" && !strings.HasPrefix(tc2.ID, tc.wantIDPattern) {
+					t.Errorf("tool_calls[%d].id = %q, want prefix %q", i, tc2.ID, tc.wantIDPattern)
+				}
+				if seenIDs[tc2.ID] {
+					t.Errorf("tool_calls[%d].id = %q is a duplicate", i, tc2.ID)
+				}
+				seenIDs[tc2.ID] = true
+
+				if i < len(tc.wantToolNames) && tc2.Function.Name != tc.wantToolNames[i] {
+					t.Errorf("tool_calls[%d].function.name = %q, want %q", i, tc2.Function.Name, tc.wantToolNames[i])
+				}
+				// Arguments must be valid JSON.
+				if !json.Valid([]byte(tc2.Function.Arguments)) {
+					t.Errorf("tool_calls[%d].function.arguments is not valid JSON: %q", i, tc2.Function.Arguments)
+				}
+				// Arguments must be a JSON object (Gemini args are always objects).
+				if len(tc2.Function.Arguments) == 0 || tc2.Function.Arguments[0] != '{' {
+					t.Errorf("tool_calls[%d].function.arguments = %q, want JSON object string", i, tc2.Function.Arguments)
+				}
+			}
+		})
+	}
+}
+
+// TestGeminiTransformResponse_ToolCallID_Charset verifies that the synthesised
+// tool-call id satisfies the charset constraint expected by the PII pipeline
+// ([A-Za-z0-9_.+\-]+), matching geminiSynthesiseToolCallID's documented format.
+func TestGeminiTransformResponse_ToolCallID_Charset(t *testing.T) {
+	t.Parallel()
+
+	inputJSON := `{"candidates":[{"content":{"role":"model","parts":[
+		{"functionCall":{"name":"fn","args":{}}}
+	]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`
+
+	a := &GeminiAdapter{}
+	out, err := a.TransformResponse([]byte(inputJSON))
+	if err != nil {
+		t.Fatalf("TransformResponse() error = %v", err)
+	}
+	var resp openAIResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	id := resp.Choices[0].Message.ToolCalls[0].ID
+	if !anthropicToolIDRe.MatchString(id) {
+		t.Errorf("synthesised id %q does not satisfy charset [A-Za-z0-9_.+-]: violates anthropicToolIDRe", id)
+	}
+}
+
+// TestGeminiTransformResponse_InvalidFunctionName verifies that a functionCall
+// from upstream whose name contains invalid characters causes TransformResponse
+// to return an error (defence-in-depth, not drop-and-continue).
+func TestGeminiTransformResponse_InvalidFunctionName(t *testing.T) {
+	t.Parallel()
+
+	inputJSON := `{"candidates":[{"content":{"role":"model","parts":[
+		{"functionCall":{"name":"fn with spaces","args":{}}}
+	]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`
+
+	a := &GeminiAdapter{}
+	_, err := a.TransformResponse([]byte(inputJSON))
+	if err == nil {
+		t.Fatal("expected error for invalid function name in response, got nil")
+	}
+}
+
+// ── STREAMING: tool call deltas ───────────────────────────────────────────────
+
+// TestGeminiTransformStreamLine_ToolCalls_Detailed covers streaming tool-call
+// delta emission with Stage-0c conformance, finish chunk routing, index ordering,
+// and the maxGeminiToolBlocks cap.
+func TestGeminiTransformStreamLine_ToolCalls_Detailed(t *testing.T) {
+	t.Parallel()
+
+	t.Run("functionCall-only chunk is NOT dropped — content-free-drop fix", func(t *testing.T) {
+		t.Parallel()
+		// A chunk with only a functionCall part (no text, no finishReason):
+		// must NOT be dropped. This was the original bug: deltaText=="" &&
+		// finishReason==nil dropped the line without checking toolCallParts.
+		line := `data: {"candidates":[{"content":{"role":"model","parts":[
+			{"functionCall":{"name":"fn","args":{"k":"v"}}}
+		]},"finishReason":""}],"usageMetadata":{}}`
+		a := &GeminiAdapter{}
+		out := a.TransformStreamLine([]byte(line))
+		if out == nil {
+			t.Fatal("functionCall-only chunk returned nil (content-free-drop bug)")
+		}
+		chunk := parseChunk(t, out)
+		if len(chunk.Choices) != 1 {
+			t.Fatalf("len(choices) = %d, want 1", len(chunk.Choices))
+		}
+		if len(chunk.Choices[0].Delta.ToolCalls) != 1 {
+			t.Fatalf("len(delta.tool_calls) = %d, want 1", len(chunk.Choices[0].Delta.ToolCalls))
+		}
+	})
+
+	t.Run("Stage-0c shape: index id type function.name function.arguments all present", func(t *testing.T) {
+		t.Parallel()
+		line := `data: {"candidates":[{"content":{"role":"model","parts":[
+			{"functionCall":{"name":"get_weather","args":{"location":"NYC","unit":"celsius"}}}
+		]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`
+		a := &GeminiAdapter{}
+		out := a.TransformStreamLine([]byte(line))
+		if out == nil {
+			t.Fatal("functionCall chunk returned nil")
+		}
+		chunk := parseChunk(t, out)
+		if len(chunk.Choices[0].Delta.ToolCalls) != 1 {
+			t.Fatalf("len(tool_calls) = %d, want 1", len(chunk.Choices[0].Delta.ToolCalls))
+		}
+		tc := chunk.Choices[0].Delta.ToolCalls[0]
+		// Stage-0c: all four fields present on the first (and only) delta.
+		if tc.Index == nil {
+			t.Fatal("index is nil (must be present for Stage-0c)")
+		}
+		if *tc.Index != 0 {
+			t.Errorf("index = %d, want 0", *tc.Index)
+		}
+		if tc.ID == "" {
+			t.Error("id is empty (must be synthesised for Stage-0c)")
+		}
+		if !strings.HasPrefix(tc.ID, "call_g") {
+			t.Errorf("id = %q, want prefix 'call_g'", tc.ID)
+		}
+		if tc.Type != "function" {
+			t.Errorf("type = %q, want function", tc.Type)
+		}
+		if tc.Function.Name != "get_weather" {
+			t.Errorf("function.name = %q, want get_weather", tc.Function.Name)
+		}
+		if tc.Function.Arguments == "" {
+			t.Error("function.arguments is empty (must be non-empty JSON string for Stage-0c)")
+		}
+		if !json.Valid([]byte(tc.Function.Arguments)) {
+			t.Errorf("function.arguments is not valid JSON: %q", tc.Function.Arguments)
+		}
+		// finish_reason tool_calls on same chunk as functionCall.
+		if chunk.Choices[0].FinishReason == nil {
+			t.Fatal("finish_reason is nil, want tool_calls")
+		}
+		if *chunk.Choices[0].FinishReason != "tool_calls" {
+			t.Errorf("finish_reason = %q, want tool_calls", *chunk.Choices[0].FinishReason)
+		}
+	})
+
+	t.Run("two functionCall parts across chunks get sequential indices 0 and 1 with distinct ids", func(t *testing.T) {
+		t.Parallel()
+		a := &GeminiAdapter{}
+
+		line1 := `data: {"candidates":[{"content":{"role":"model","parts":[
+			{"functionCall":{"name":"fn_a","args":{}}}
+		]},"finishReason":""}],"usageMetadata":{}}`
+		out1 := a.TransformStreamLine([]byte(line1))
+		if out1 == nil {
+			t.Fatal("first functionCall chunk returned nil")
+		}
+
+		line2 := `data: {"candidates":[{"content":{"role":"model","parts":[
+			{"functionCall":{"name":"fn_b","args":{"x":2}}}
+		]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`
+		out2 := a.TransformStreamLine([]byte(line2))
+		if out2 == nil {
+			t.Fatal("second functionCall chunk returned nil")
+		}
+
+		chunk1 := parseChunk(t, out1)
+		chunk2 := parseChunk(t, out2)
+
+		tc1 := chunk1.Choices[0].Delta.ToolCalls[0]
+		tc2 := chunk2.Choices[0].Delta.ToolCalls[0]
+
+		if tc1.Index == nil || *tc1.Index != 0 {
+			t.Errorf("first chunk index = %v, want 0", tc1.Index)
+		}
+		if tc2.Index == nil || *tc2.Index != 1 {
+			t.Errorf("second chunk index = %v, want 1", tc2.Index)
+		}
+		if tc1.ID == tc2.ID {
+			t.Errorf("both chunks share the same id %q (must be distinct)", tc1.ID)
+		}
+		if tc1.Function.Name != "fn_a" {
+			t.Errorf("chunk1.function.name = %q, want fn_a", tc1.Function.Name)
+		}
+		if tc2.Function.Name != "fn_b" {
+			t.Errorf("chunk2.function.name = %q, want fn_b", tc2.Function.Name)
+		}
+	})
+
+	t.Run("FUNCTION_CALL finish chunk sets finish_reason tool_calls and doneSent", func(t *testing.T) {
+		t.Parallel()
+		line := `data: {"candidates":[{"content":{"role":"model","parts":[
+			{"functionCall":{"name":"fn","args":{}}}
+		]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":4,"totalTokenCount":12}}`
+		a := &GeminiAdapter{}
+		out := a.TransformStreamLine([]byte(line))
+		if out == nil {
+			t.Fatal("terminal functionCall chunk returned nil")
+		}
+		chunk := parseChunk(t, out)
+		if chunk.Choices[0].FinishReason == nil {
+			t.Fatal("finish_reason is nil, want tool_calls")
+		}
+		if *chunk.Choices[0].FinishReason != "tool_calls" {
+			t.Errorf("finish_reason = %q, want tool_calls", *chunk.Choices[0].FinishReason)
+		}
+		if !a.doneSent {
+			t.Error("doneSent must be true after terminal functionCall chunk")
+		}
+		// Blank line after terminal chunk must become data: [DONE].
+		done := a.TransformStreamLine([]byte(""))
+		if string(done) != "data: [DONE]" {
+			t.Errorf("blank-after-terminal = %q, want data: [DONE]", done)
+		}
+	})
+
+	t.Run("usage accumulated from terminal functionCall chunk", func(t *testing.T) {
+		t.Parallel()
+		line := `data: {"candidates":[{"content":{"role":"model","parts":[
+			{"functionCall":{"name":"fn","args":{}}}
+		]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{"promptTokenCount":20,"candidatesTokenCount":10,"totalTokenCount":30}}`
+		a := &GeminiAdapter{}
+		_ = a.TransformStreamLine([]byte(line))
+		usage := a.StreamUsage()
+		if usage.PromptTokens != 20 {
+			t.Errorf("PromptTokens = %d, want 20", usage.PromptTokens)
+		}
+		if usage.CompletionTokens != 10 {
+			t.Errorf("CompletionTokens = %d, want 10", usage.CompletionTokens)
+		}
+		if usage.TotalTokens != 30 {
+			t.Errorf("TotalTokens = %d, want 30", usage.TotalTokens)
+		}
+	})
+
+	t.Run("tool-call counter cap: excess blocks beyond maxGeminiToolBlocks are dropped", func(t *testing.T) {
+		t.Parallel()
+		a := &GeminiAdapter{}
+		// Prime the counter to one below the cap.
+		a.streamToolCallCounter = maxGeminiToolBlocks - 1
+
+		// This chunk should emit the last allowed tool call.
+		lineAtCap := `data: {"candidates":[{"content":{"role":"model","parts":[
+			{"functionCall":{"name":"fn_last","args":{}}}
+		]},"finishReason":""}],"usageMetadata":{}}`
+		outAtCap := a.TransformStreamLine([]byte(lineAtCap))
+		if outAtCap == nil {
+			t.Fatal("chunk at cap-1 returned nil, expected to be allowed")
+		}
+		chunkAtCap := parseChunk(t, outAtCap)
+		if len(chunkAtCap.Choices[0].Delta.ToolCalls) != 1 {
+			t.Error("chunk at cap-1 should emit one tool call")
+		}
+
+		// Counter is now at maxGeminiToolBlocks. Next chunk must be dropped.
+		lineOverCap := `data: {"candidates":[{"content":{"role":"model","parts":[
+			{"functionCall":{"name":"fn_over","args":{}}}
+		]},"finishReason":""}],"usageMetadata":{}}`
+		outOverCap := a.TransformStreamLine([]byte(lineOverCap))
+		// When all tool call parts are dropped and there is no finishReason, result is nil.
+		if outOverCap != nil {
+			// The cap was not enforced — this is a failure.
+			// (If the chunk has no finishReason and all parts dropped, should be nil.)
+			t.Logf("note: over-cap chunk produced %q (may be empty finish chunk if finishReason present)", outOverCap)
+		}
+	})
+
+	t.Run("invalid function name from upstream in stream is dropped, not panic", func(t *testing.T) {
+		t.Parallel()
+		// The model hallucinated a function name with spaces (invalid charset).
+		// The adapter should drop this block silently.
+		line := `data: {"candidates":[{"content":{"role":"model","parts":[
+			{"functionCall":{"name":"bad name with spaces","args":{}}}
+		]},"finishReason":""}],"usageMetadata":{}}`
+		a := &GeminiAdapter{}
+		// Must not panic.
+		out := a.TransformStreamLine([]byte(line))
+		// When the only part has an invalid name and no finishReason, result is nil.
+		if out != nil {
+			t.Logf("note: invalid-name chunk produced %q (may be finish chunk if finishReason)", out)
+		}
+		// Counter still incremented past the invalid block.
+	})
+}
+
+// TestGeminiTransformStreamLine_FinishReason_ToolCalls verifies that the
+// FUNCTION_CALL finish reason produces "tool_calls" in the streaming path
+// (regression guard: previously it may have been mis-mapped to "stop").
+func TestGeminiTransformStreamLine_FinishReason_ToolCalls(t *testing.T) {
+	t.Parallel()
+
+	// The existing TestGeminiFinishReason table test covers FUNCTION_CALL→"tool_calls"
+	// at the unit level. This test verifies it propagates correctly through the
+	// streaming path end-to-end.
+	line := `data: {"candidates":[{"content":{"role":"model","parts":[
+		{"functionCall":{"name":"fn","args":{}}}
+	]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`
+
+	a := &GeminiAdapter{}
+	out := a.TransformStreamLine([]byte(line))
+	if out == nil {
+		t.Fatal("FUNCTION_CALL terminal chunk returned nil")
+	}
+	chunk := parseChunk(t, out)
+	if len(chunk.Choices) != 1 {
+		t.Fatalf("len(choices) = %d, want 1", len(chunk.Choices))
+	}
+	if chunk.Choices[0].FinishReason == nil {
+		t.Fatal("finish_reason is nil, want tool_calls")
+	}
+	// Regression: must NOT be "stop".
+	if *chunk.Choices[0].FinishReason == "stop" {
+		t.Errorf("finish_reason = %q (REGRESSION: FUNCTION_CALL was mis-mapped to stop)", *chunk.Choices[0].FinishReason)
+	}
+	if *chunk.Choices[0].FinishReason != "tool_calls" {
+		t.Errorf("finish_reason = %q, want tool_calls", *chunk.Choices[0].FinishReason)
+	}
+}
+
+// TestGeminiTransformStreamLine_MixedTextAndFunctionCall documents the current
+// behaviour when a single Gemini chunk contains both text and functionCall parts:
+// the implementation emits only the tool-calls chunk, dropping the text.
+// This is noted as a known limitation (Stage-0c cannot handle mixed
+// content+tool_calls in one chunk, and Gemini should not produce this in practice).
+func TestGeminiTransformStreamLine_MixedTextAndFunctionCall(t *testing.T) {
+	t.Parallel()
+
+	// A chunk with both text and functionCall — Gemini rarely produces this.
+	line := `data: {"candidates":[{"content":{"role":"model","parts":[
+		{"text":"Thinking..."},
+		{"functionCall":{"name":"fn","args":{}}}
+	]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`
+
+	a := &GeminiAdapter{}
+	out := a.TransformStreamLine([]byte(line))
+	if out == nil {
+		t.Fatal("mixed text+functionCall chunk returned nil, expected non-nil")
+	}
+
+	chunk := parseChunk(t, out)
+	// The implementation emits only the tool-calls chunk in the mixed case.
+	// Text is dropped. This is documented behaviour (see comment in TransformStreamLine).
+	if len(chunk.Choices[0].Delta.ToolCalls) == 0 {
+		// If text was emitted instead, also acceptable — just verify non-nil output.
+		t.Logf("mixed chunk produced text delta (not tool_calls); behaviour: %+v", chunk.Choices[0].Delta)
+	}
+	// Either way, the output is valid and non-nil.
+	// NOTE: This test explicitly documents that text IS dropped when a mixed
+	// chunk arrives. If the implementation is fixed to emit both, this test
+	// should be updated. Current behaviour: text chunk is built but discarded
+	// (the `_ = out` line in TransformStreamLine), and the tool-calls chunk
+	// is returned instead.
+}
+
+// ── geminiSynthesiseToolCallID unit test ─────────────────────────────────────
+
+// TestGeminiSynthesiseToolCallID verifies the id format and charset conformance.
+func TestGeminiSynthesiseToolCallID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		idx    int
+		wantID string
+	}{
+		{0, "call_g0"},
+		{1, "call_g1"},
+		{99, "call_g99"},
+		{1023, "call_g1023"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.wantID, func(t *testing.T) {
+			t.Parallel()
+			got := geminiSynthesiseToolCallID(tc.idx)
+			if got != tc.wantID {
+				t.Errorf("geminiSynthesiseToolCallID(%d) = %q, want %q", tc.idx, got, tc.wantID)
+			}
+			if !anthropicToolIDRe.MatchString(got) {
+				t.Errorf("id %q does not satisfy anthropicToolIDRe ([A-Za-z0-9_.+-]+)", got)
+			}
+		})
+	}
+}
+
+// ── geminiWrapToolResult unit tests ──────────────────────────────────────────
+
+// TestGeminiWrapToolResult verifies the wrapping function for tool result content.
+func TestGeminiWrapToolResult(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		content     string // raw JSON to pass as content (empty string = nil)
+		wantWrapper string // expected raw JSON wrapper (prefix check)
+		wantIsArray bool   // wrapper.content is a JSON array
+		wantErr     bool
+	}{
+		{
+			name:    "nil content produces empty string wrapper",
+			content: "",
+		},
+		{
+			name:        "plain string content produces string wrapper",
+			content:     `"hello world"`,
+			wantWrapper: `{"content":"hello world"}`,
+		},
+		{
+			name:        "array content produces list wrapper",
+			content:     `[{"type":"text","text":"part1"},{"type":"text","text":"part2"}]`,
+			wantIsArray: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var rawContent jsonxRawMessage
+			if tc.content != "" {
+				rawContent = jsonxRawMessage(tc.content)
+			}
+
+			result, err := geminiWrapToolResult(rawContent)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("geminiWrapToolResult() error = %v", err)
+			}
+
+			if tc.content == "" {
+				// nil content → empty wrapper.
+				if len(result) == 0 {
+					t.Fatal("result is empty")
+				}
+				return
+			}
+
+			if tc.wantWrapper != "" {
+				// Normalise by parsing both.
+				var got, want map[string]json.RawMessage
+				if err := json.Unmarshal(result, &got); err != nil {
+					t.Fatalf("unmarshal result: %v", err)
+				}
+				if err := json.Unmarshal([]byte(tc.wantWrapper), &want); err != nil {
+					t.Fatalf("unmarshal wantWrapper: %v", err)
+				}
+				if len(got) != len(want) {
+					t.Errorf("result = %s, want %s", result, tc.wantWrapper)
+				}
+			}
+
+			if tc.wantIsArray {
+				var wrapper struct {
+					Content []string `json:"content"`
+				}
+				if err := json.Unmarshal(result, &wrapper); err != nil {
+					t.Fatalf("unmarshal array wrapper: %v (raw: %s)", err, result)
+				}
+				if len(wrapper.Content) != 2 {
+					t.Errorf("content list len = %d, want 2", len(wrapper.Content))
+				}
+				if wrapper.Content[0] != "part1" {
+					t.Errorf("content[0] = %q, want part1", wrapper.Content[0])
+				}
+				if wrapper.Content[1] != "part2" {
+					t.Errorf("content[1] = %q, want part2", wrapper.Content[1])
+				}
+			}
+		})
+	}
+}
+
+// ── END-TO-END Stage-0c conformance for Gemini tool-calls ────────────────────
+
+// TestGeminiStream_Stage0c_ToolCallArgs_EndToEnd verifies the full proxy pipeline
+// for a Gemini streaming response that contains a functionCall with a PII
+// pseudonym in the arguments. Since Gemini delivers arguments complete (not
+// fragmented), the pseudonym is contained in a single chunk. The StreamRestorer
+// must recognise and restore it.
+//
+// Pattern: mirrors TestAnthropicStream_Stage0c_EndToEnd_ViaProxy (anthropic_test.go)
+// but uses GeminiAdapter and Gemini SSE format (full generateContent objects per
+// chunk). The "sawToolCall" path in the StreamRestorer is exercised here.
+func TestGeminiStream_Stage0c_ToolCallArgs_EndToEnd(t *testing.T) {
+	t.Parallel()
+
+	// Build PII engine and compute the pseudonym that will be generated for piiTestEmail.
+	engine := newTestPIIEngine(t)
+	sampleFilter := engine.NewFilter("")
+	sampleBody := []byte(chatBody("gemini-test", "lookup "+piiTestEmail))
+	anonBody, err := sampleFilter.AnonymizeJSON(sampleBody)
+	if err != nil {
+		t.Fatalf("pre-compute AnonymizeJSON: %v", err)
+	}
+	pseudo := piiPseudonymPattern.FindString(string(anonBody))
+	if pseudo == "" {
+		t.Fatal("could not derive pseudonym for piiTestEmail")
+	}
+
+	// Gemini delivers args complete per chunk — no fragmentation needed.
+	// The full pseudonym appears in one functionCall.args block.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			return
+		}
+
+		// Emit a Gemini-format stream with the pseudonym in functionCall.args.
+		// The adapter translates this to an OpenAI tool_calls delta.
+		// The StreamRestorer restores pseudonym → original email.
+		argsJSON := `{"email":"` + pseudo + `"}`
+		geminiChunk := `data: {"candidates":[{"content":{"role":"model","parts":[` +
+			`{"functionCall":{"name":"lookup_user","args":` + argsJSON + `}}` +
+			`]},"finishReason":"FUNCTION_CALL","index":0}],"usageMetadata":{"promptTokenCount":12,"candidatesTokenCount":8,"totalTokenCount":20}}`
+
+		fmt.Fprintln(w, geminiChunk)
+		fmt.Fprintln(w) // blank separator → adapter converts to data: [DONE]
+		flusher.Flush()
+	}))
+	t.Cleanup(upstream.Close)
+
+	reg := piiRegistryGemini(t, upstream.URL)
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.PIIEngine = engine
+
+	baseURL := startTestServer(t, h)
+
+	streamBody := `{"model":"gemini-test","messages":[{"role":"user","content":"lookup ` + piiTestEmail + `"}],"stream":true}`
+	httpReq, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions",
+		strings.NewReader(streamBody))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: testTimeout.Timeout}
+	streamResp, err := client.Do(httpReq)
+	if err != nil {
+		t.Fatalf("streaming request: %v", err)
+	}
+	defer streamResp.Body.Close()
+
+	if streamResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(streamResp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", streamResp.StatusCode, body)
+	}
+
+	fullBody, _ := io.ReadAll(streamResp.Body)
+	fullStr := string(fullBody)
+
+	// 1. Stream must complete with [DONE].
+	if !strings.Contains(fullStr, "[DONE]") {
+		t.Errorf("Stage-0c Gemini: [DONE] absent — stream did not complete cleanly\noutput: %s", fullStr)
+	}
+
+	// 2. Restored email must appear in the arguments.
+	if !strings.Contains(fullStr, piiTestEmail) {
+		t.Errorf("Stage-0c Gemini: restored email %q absent from tool_calls arguments\noutput: %s",
+			piiTestEmail, fullStr)
+	}
+
+	// 3. No raw pseudonym must be visible.
+	if strings.Contains(fullStr, pseudo) {
+		t.Errorf("SECURITY: raw pseudonym %q visible in Stage-0c Gemini output\noutput: %s", pseudo, fullStr)
+	}
+
+	// 4. tool_calls and function name must be present.
+	if !strings.Contains(fullStr, `"tool_calls"`) {
+		t.Errorf("Stage-0c Gemini: tool_calls key absent from output\noutput: %s", fullStr)
+	}
+	if !strings.Contains(fullStr, `"lookup_user"`) {
+		t.Errorf("Stage-0c Gemini: function name lookup_user absent from output\noutput: %s", fullStr)
+	}
+}
+
+// jsonxRawMessage is a local alias so test helpers for geminiWrapToolResult can
+// pass a json.RawMessage without importing the internal jsonx package directly.
+// geminiWrapToolResult accepts jsonx.RawMessage which is defined as json.RawMessage.
+type jsonxRawMessage = json.RawMessage
+
+// ── FIX 1: pseudonym-shaped function name in TransformResponse rejected ───────
+
+// TestGeminiTransformResponse_PseudonymFunctionName verifies that FIX 1 closes
+// the non-streaming PII leak: if a (malicious or compromised) upstream returns
+// a functionCall.name that contains or matches the canonical PII pseudonym
+// shape, TransformResponse must return a content-free error rather than
+// forwarding the name (where filter.Restore would expand it to real PII).
+func TestGeminiTransformResponse_PseudonymFunctionName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		inputJSON string
+	}{
+		{
+			name: "canonical pseudonym shape in function name is rejected",
+			// PII_EM_<24hex> is the exact shape of an email pseudonym.
+			inputJSON: `{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"PII_EM_aabbccddeeff00112233445566","args":{}}}]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`,
+		},
+		{
+			name:      "PII_ prefix substring in function name is rejected",
+			inputJSON: `{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"call_PII_something","args":{}}}]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`,
+		},
+		{
+			name:      "function name that IS the pseudonym marker prefix is rejected",
+			inputJSON: `{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"PII_XX_000000000000000000000000","args":{}}}]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &GeminiAdapter{}
+			out, err := a.TransformResponse([]byte(tc.inputJSON))
+			if err == nil {
+				t.Fatalf("TransformResponse() = %s, want error for pseudonym-shaped function name", out)
+			}
+			// Error must be content-free: must not echo back the function name.
+			errStr := err.Error()
+			if strings.Contains(errStr, "PII_EM_") || strings.Contains(errStr, "aabbcc") {
+				t.Errorf("error message leaks pseudonym content: %s", errStr)
+			}
+		})
+	}
+}
+
+// TestGeminiTransformResponse_LegitFunctionName confirms that a legitimate
+// function name (no PII_ prefix) is not rejected by the pseudonym check.
+func TestGeminiTransformResponse_LegitFunctionName(t *testing.T) {
+	t.Parallel()
+
+	input := `{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"get_weather","args":{"location":"NYC"}}}]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8}}`
+	a := &GeminiAdapter{}
+	out, err := a.TransformResponse([]byte(input))
+	if err != nil {
+		t.Fatalf("TransformResponse() error = %v for legitimate function name", err)
+	}
+	if out == nil {
+		t.Fatal("TransformResponse() = nil, want non-nil for legitimate function name")
+	}
+}
+
+// ── FIX 2: charset-validate tool_call_id and tc.ID on request path ───────────
+
+// TestGeminiTransformRequest_ToolCallIDCharset verifies that FIX 2 rejects
+// tool_call_id values with invalid characters on the role:"tool" message path
+// and tc.ID values with invalid characters on the assistant tool_calls path.
+func TestGeminiTransformRequest_ToolCallIDCharset(t *testing.T) {
+	t.Parallel()
+
+	t.Run("role:tool with at-sign in tool_call_id is rejected", func(t *testing.T) {
+		t.Parallel()
+		input := `{"model":"gemini-1.5-pro","messages":[
+			{"role":"user","content":"q"},
+			{"role":"assistant","content":null,"tool_calls":[{"id":"call_1","type":"function","function":{"name":"fn","arguments":"{}"}}]},
+			{"role":"tool","tool_call_id":"a@b","content":"result"}
+		]}`
+		a := &GeminiAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err == nil {
+			t.Fatal("expected error for invalid tool_call_id charset, got nil")
+		}
+		if strings.Contains(err.Error(), "a@b") {
+			t.Errorf("error message leaks invalid tool_call_id value: %s", err.Error())
+		}
+	})
+
+	t.Run("assistant tool_call with space in id is rejected", func(t *testing.T) {
+		t.Parallel()
+		input := `{"model":"gemini-1.5-pro","messages":[
+			{"role":"user","content":"q"},
+			{"role":"assistant","content":null,"tool_calls":[{"id":"call id bad","type":"function","function":{"name":"fn","arguments":"{}"}}]}
+		]}`
+		a := &GeminiAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err == nil {
+			t.Fatal("expected error for invalid tool_call id with space, got nil")
+		}
+	})
+
+	t.Run("role:tool with valid tool_call_id is accepted", func(t *testing.T) {
+		t.Parallel()
+		input := `{"model":"gemini-1.5-pro","messages":[
+			{"role":"user","content":"q"},
+			{"role":"assistant","content":null,"tool_calls":[{"id":"call_ok","type":"function","function":{"name":"fn","arguments":"{}"}}]},
+			{"role":"tool","tool_call_id":"call_ok","content":"result"}
+		]}`
+		a := &GeminiAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err != nil {
+			t.Fatalf("TransformRequest() error = %v for valid tool_call_id", err)
+		}
+	})
+}
+
+// ── FIX 3: tool-result array with only non-text parts → {"content":[]} ───────
+
+// TestGeminiWrapToolResult_NonTextOnly verifies that FIX 3 ensures a tool-result
+// array containing no text parts serialises as {"content":[]} (empty JSON array)
+// rather than {"content":null}. null is structurally incorrect for a list field.
+func TestGeminiWrapToolResult_NonTextOnly(t *testing.T) {
+	t.Parallel()
+
+	t.Run("array with only non-text parts produces empty content array not null", func(t *testing.T) {
+		t.Parallel()
+		// An array of image_url parts — no text parts at all.
+		content := json.RawMessage(`[{"type":"image_url","url":"http://example.com/img.png"}]`)
+		result, err := geminiWrapToolResult(content)
+		if err != nil {
+			t.Fatalf("geminiWrapToolResult() error = %v", err)
+		}
+		// The result must contain "content":[] not "content":null.
+		var wrapper struct {
+			Content json.RawMessage `json:"content"`
+		}
+		if err := json.Unmarshal(result, &wrapper); err != nil {
+			t.Fatalf("unmarshal result: %v (raw: %s)", err, result)
+		}
+		// Must be a JSON array (starts with '['), not null.
+		trimmed := strings.TrimSpace(string(wrapper.Content))
+		if trimmed == "null" {
+			t.Errorf("content = null, want [] for all-non-text parts array (FIX 3)")
+		}
+		if len(trimmed) == 0 || trimmed[0] != '[' {
+			t.Errorf("content = %q, want JSON array []", trimmed)
+		}
+	})
+
+	t.Run("empty parts array produces empty content array not null", func(t *testing.T) {
+		t.Parallel()
+		content := json.RawMessage(`[]`)
+		result, err := geminiWrapToolResult(content)
+		if err != nil {
+			t.Fatalf("geminiWrapToolResult() error = %v", err)
+		}
+		var wrapper struct {
+			Content json.RawMessage `json:"content"`
+		}
+		if err := json.Unmarshal(result, &wrapper); err != nil {
+			t.Fatalf("unmarshal result: %v (raw: %s)", err, result)
+		}
+		trimmed := strings.TrimSpace(string(wrapper.Content))
+		if trimmed == "null" {
+			t.Errorf("content = null, want [] for empty parts array (FIX 3)")
+		}
+		if len(trimmed) == 0 || trimmed[0] != '[' {
+			t.Errorf("content = %q, want JSON array []", trimmed)
+		}
+	})
+}
+
+// ── FIX 4: unknown tool_call_id → error ──────────────────────────────────────
+
+// TestGeminiTransformRequest_UnknownToolCallID verifies that FIX 4 makes the
+// adapter fail-closed when a role:"tool" message references a tool_call_id that
+// was not seen in any prior assistant tool_calls message.
+func TestGeminiTransformRequest_UnknownToolCallID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-empty tool_call_id not in map returns error", func(t *testing.T) {
+		t.Parallel()
+		// role:tool referencing "call_unknown" which was never in an assistant
+		// tool_calls message. Previously this silently set funcName=""; now it
+		// must return a content-free error.
+		input := `{"model":"gemini-1.5-pro","messages":[
+			{"role":"user","content":"q"},
+			{"role":"tool","tool_call_id":"call_unknown","content":"some result"}
+		]}`
+		a := &GeminiAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err == nil {
+			t.Fatal("expected error for unknown tool_call_id, got nil")
+		}
+		// Error must be content-free: no caller data echoed.
+		errStr := err.Error()
+		if strings.Contains(errStr, "call_unknown") {
+			t.Errorf("error message leaks tool_call_id value: %s", errStr)
+		}
+	})
+
+	t.Run("empty tool_call_id returns error fail-closed", func(t *testing.T) {
+		t.Parallel()
+		// FIX 3: an empty tool_call_id must fail-closed. A tool message without a
+		// tool_call_id cannot be correlated to a function name, which would produce
+		// a malformed functionResponse. The adapter must reject this case.
+		input := `{"model":"gemini-1.5-pro","messages":[
+			{"role":"user","content":"q"},
+			{"role":"tool","tool_call_id":"","content":"some result"}
+		]}`
+		a := &GeminiAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err == nil {
+			t.Fatal("expected error for empty tool_call_id, got nil")
+		}
+	})
+}
+
+// ── FIX 5: no double marshal/unmarshal of tools/toolConfig ───────────────────
+
+// TestGeminiTransformRequest_ToolsDirectAssignment verifies that FIX 5 did not
+// change observable behaviour: tools and tool_choice are still correctly
+// translated when assigned directly to the geminiRequest rather than going
+// through the marshal-into-doc → re-unmarshal round-trip.
+func TestGeminiTransformRequest_ToolsDirectAssignment(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tools and named tool_choice both present and correct after FIX 5", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"model":"gemini-1.5-pro",
+			"messages":[{"role":"user","content":"q"}],
+			"tools":[
+				{"type":"function","function":{"name":"fn_a","description":"A","parameters":{"type":"object","properties":{}}}},
+				{"type":"function","function":{"name":"fn_b","description":"B","parameters":{"type":"object","properties":{}}}}
+			],
+			"tool_choice":{"type":"function","function":{"name":"fn_a"}}
+		}`
+		a := &GeminiAdapter{}
+		out, err := a.TransformRequest([]byte(input), Model{})
+		if err != nil {
+			t.Fatalf("TransformRequest() error = %v", err)
+		}
+		var req geminiRequest
+		if err := json.Unmarshal(out, &req); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		// Tools must be present with both declarations.
+		if len(req.Tools) != 1 {
+			t.Fatalf("len(tools) = %d, want 1", len(req.Tools))
+		}
+		if len(req.Tools[0].FunctionDeclarations) != 2 {
+			t.Fatalf("len(functionDeclarations) = %d, want 2", len(req.Tools[0].FunctionDeclarations))
+		}
+		if req.Tools[0].FunctionDeclarations[0].Name != "fn_a" {
+			t.Errorf("decls[0].name = %q, want fn_a", req.Tools[0].FunctionDeclarations[0].Name)
+		}
+		// ToolConfig must be set with ANY mode and fn_a allowed.
+		if req.ToolConfig == nil {
+			t.Fatal("toolConfig is nil, want non-nil")
+		}
+		cfg := req.ToolConfig.FunctionCallingConfig
+		if cfg.Mode != "ANY" {
+			t.Errorf("mode = %q, want ANY", cfg.Mode)
+		}
+		if len(cfg.AllowedFunctionNames) != 1 || cfg.AllowedFunctionNames[0] != "fn_a" {
+			t.Errorf("allowedFunctionNames = %v, want [fn_a]", cfg.AllowedFunctionNames)
+		}
+	})
+
+	t.Run("tool_choice none removes both tools and toolConfig", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"model":"gemini-1.5-pro",
+			"messages":[{"role":"user","content":"q"}],
+			"tools":[{"type":"function","function":{"name":"fn","parameters":{}}}],
+			"tool_choice":"none"
+		}`
+		a := &GeminiAdapter{}
+		out, err := a.TransformRequest([]byte(input), Model{})
+		if err != nil {
+			t.Fatalf("TransformRequest() error = %v", err)
+		}
+		var req geminiRequest
+		if err := json.Unmarshal(out, &req); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(req.Tools) != 0 {
+			t.Errorf("tools = %v, want absent after tool_choice=none", req.Tools)
+		}
+		if req.ToolConfig != nil {
+			t.Error("toolConfig should be nil after tool_choice=none")
+		}
+	})
+}
+
+// ── FIX 1: presence-based finish_reason for tool calls ───────────────────────
+
+// TestGeminiTransformResponse_FinishReasonPresenceBased verifies that the
+// non-streaming adapter derives finish_reason "tool_calls" from functionCall
+// presence, not from the Gemini finishReason string.
+func TestGeminiTransformResponse_FinishReasonPresenceBased(t *testing.T) {
+	t.Parallel()
+
+	t.Run("STOP with functionCall parts produces tool_calls finish_reason", func(t *testing.T) {
+		t.Parallel()
+		// Real Gemini behaviour: tool calls end with finishReason "STOP".
+		input := `{
+			"candidates": [{
+				"content": {
+					"role": "model",
+					"parts": [{"functionCall": {"name": "get_weather", "args": {"city": "Paris"}}}]
+				},
+				"finishReason": "STOP"
+			}],
+			"usageMetadata": {"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8}
+		}`
+		a := &GeminiAdapter{}
+		out, err := a.TransformResponse([]byte(input))
+		if err != nil {
+			t.Fatalf("TransformResponse() error = %v", err)
+		}
+		var resp openAIResponse
+		if err := json.Unmarshal(out, &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if len(resp.Choices) != 1 {
+			t.Fatalf("len(choices) = %d, want 1", len(resp.Choices))
+		}
+		if resp.Choices[0].FinishReason != "tool_calls" {
+			t.Errorf("finish_reason = %q, want tool_calls (functionCall presence must override STOP)", resp.Choices[0].FinishReason)
+		}
+		if len(resp.Choices[0].Message.ToolCalls) != 1 {
+			t.Fatalf("len(tool_calls) = %d, want 1", len(resp.Choices[0].Message.ToolCalls))
+		}
+	})
+
+	t.Run("STOP without functionCall parts produces stop finish_reason", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"candidates": [{
+				"content": {"role": "model", "parts": [{"text": "hello"}]},
+				"finishReason": "STOP"
+			}],
+			"usageMetadata": {}
+		}`
+		a := &GeminiAdapter{}
+		out, err := a.TransformResponse([]byte(input))
+		if err != nil {
+			t.Fatalf("TransformResponse() error = %v", err)
+		}
+		var resp openAIResponse
+		if err := json.Unmarshal(out, &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if resp.Choices[0].FinishReason != "stop" {
+			t.Errorf("finish_reason = %q, want stop for text-only STOP response", resp.Choices[0].FinishReason)
+		}
+	})
+
+	t.Run("mixed text and functionCall with STOP produces tool_calls", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"candidates": [{
+				"content": {
+					"role": "model",
+					"parts": [
+						{"text": "Let me check."},
+						{"functionCall": {"name": "search", "args": {"q": "weather"}}}
+					]
+				},
+				"finishReason": "STOP"
+			}],
+			"usageMetadata": {}
+		}`
+		a := &GeminiAdapter{}
+		out, err := a.TransformResponse([]byte(input))
+		if err != nil {
+			t.Fatalf("TransformResponse() error = %v", err)
+		}
+		var resp openAIResponse
+		if err := json.Unmarshal(out, &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if resp.Choices[0].FinishReason != "tool_calls" {
+			t.Errorf("finish_reason = %q, want tool_calls when functionCall parts present", resp.Choices[0].FinishReason)
+		}
+	})
+}
+
+// TestGeminiTransformStreamLine_FinishReasonPresenceBased verifies that the
+// streaming adapter derives finish_reason "tool_calls" from functionCall
+// presence and the sawFunctionCall flag, not from Gemini's finishReason string.
+func TestGeminiTransformStreamLine_FinishReasonPresenceBased(t *testing.T) {
+	t.Parallel()
+
+	t.Run("functionCall parts with STOP in same chunk produces tool_calls finish_reason", func(t *testing.T) {
+		t.Parallel()
+		// Real Gemini stream: functionCall and finishReason STOP arrive together.
+		line := `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"get_weather","args":{"city":"NYC"}}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8}}`
+		a := &GeminiAdapter{}
+		out := a.TransformStreamLine([]byte(line))
+		if out == nil {
+			t.Fatal("TransformStreamLine() = nil, want non-nil chunk")
+		}
+		chunk := parseChunk(t, out)
+		if len(chunk.Choices) != 1 {
+			t.Fatalf("len(choices) = %d, want 1", len(chunk.Choices))
+		}
+		ch := chunk.Choices[0]
+		if len(ch.Delta.ToolCalls) != 1 {
+			t.Fatalf("len(delta.tool_calls) = %d, want 1", len(ch.Delta.ToolCalls))
+		}
+		if ch.FinishReason == nil {
+			t.Fatal("finish_reason is nil, want tool_calls")
+		}
+		if *ch.FinishReason != "tool_calls" {
+			t.Errorf("finish_reason = %q, want tool_calls (functionCall presence with STOP must override)", *ch.FinishReason)
+		}
+		if !a.doneSent {
+			t.Error("doneSent should be true after terminal functionCall chunk")
+		}
+		if !a.sawFunctionCall {
+			t.Error("sawFunctionCall should be true after emitting tool call")
+		}
+	})
+
+	t.Run("sawFunctionCall flag set by earlier chunk overrides STOP on finish chunk", func(t *testing.T) {
+		t.Parallel()
+		a := &GeminiAdapter{}
+
+		// Chunk 1: functionCall part without finishReason (sets sawFunctionCall).
+		chunk1 := `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"fn","args":{}}}]},"finishReason":""}],"usageMetadata":{}}`
+		out1 := a.TransformStreamLine([]byte(chunk1))
+		if out1 == nil {
+			t.Fatal("chunk 1 returned nil")
+		}
+		if !a.sawFunctionCall {
+			t.Error("sawFunctionCall not set after first functionCall chunk")
+		}
+
+		// Chunk 2: empty parts with finishReason STOP (finish chunk).
+		chunk2 := `data: {"candidates":[{"content":{"role":"model","parts":[]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8}}`
+		out2 := a.TransformStreamLine([]byte(chunk2))
+		if out2 == nil {
+			t.Fatal("finish chunk returned nil")
+		}
+		finishChunk := parseChunk(t, out2)
+		if finishChunk.Choices[0].FinishReason == nil {
+			t.Fatal("finish_reason is nil on finish chunk")
+		}
+		if *finishChunk.Choices[0].FinishReason != "tool_calls" {
+			t.Errorf("finish_reason = %q, want tool_calls (sawFunctionCall override)", *finishChunk.Choices[0].FinishReason)
+		}
+	})
+
+	t.Run("STOP without any functionCall produces stop finish_reason", func(t *testing.T) {
+		t.Parallel()
+		a := &GeminiAdapter{}
+		line := `data: {"candidates":[{"content":{"role":"model","parts":[{"text":"bye"}]},"finishReason":"STOP"}],"usageMetadata":{}}`
+		out := a.TransformStreamLine([]byte(line))
+		if out == nil {
+			t.Fatal("TransformStreamLine() = nil")
+		}
+		chunk := parseChunk(t, out)
+		if chunk.Choices[0].FinishReason == nil {
+			t.Fatal("finish_reason is nil")
+		}
+		if *chunk.Choices[0].FinishReason != "stop" {
+			t.Errorf("finish_reason = %q, want stop for text-only stream", *chunk.Choices[0].FinishReason)
+		}
+	})
+
+	t.Run("full stream functionCall+STOP followed by blank becomes DONE sequence", func(t *testing.T) {
+		t.Parallel()
+		a := &GeminiAdapter{}
+
+		// Single chunk: functionCall parts + finishReason STOP (real Gemini shape).
+		line := `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"get_data","args":{"id":1}}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":4,"totalTokenCount":12}}`
+		out := a.TransformStreamLine([]byte(line))
+		if out == nil {
+			t.Fatal("terminal functionCall chunk returned nil")
+		}
+		chunk := parseChunk(t, out)
+		ch := chunk.Choices[0]
+		// Must have tool_calls delta AND finish_reason "tool_calls".
+		if len(ch.Delta.ToolCalls) != 1 {
+			t.Errorf("len(delta.tool_calls) = %d, want 1", len(ch.Delta.ToolCalls))
+		}
+		if ch.FinishReason == nil || *ch.FinishReason != "tool_calls" {
+			var got string
+			if ch.FinishReason != nil {
+				got = *ch.FinishReason
+			}
+			t.Errorf("finish_reason = %q, want tool_calls", got)
+		}
+		// doneSent must be true.
+		if !a.doneSent {
+			t.Error("doneSent should be true")
+		}
+		// Blank line converts to [DONE].
+		done := a.TransformStreamLine([]byte(""))
+		if string(done) != "data: [DONE]" {
+			t.Errorf("blank-after-terminal = %q, want data: [DONE]", done)
+		}
+	})
+}
+
+// ── FIX 3: empty/duplicate id and name validation ────────────────────────────
+
+// TestGeminiTransformRequest_Fix3_EmptyIDs verifies FIX 3 fail-closed
+// validation for empty tool_call IDs, empty function names, and duplicate
+// IDs with conflicting names.
+func TestGeminiTransformRequest_Fix3_EmptyIDs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty tool_call id in assistant tool_calls returns error", func(t *testing.T) {
+		t.Parallel()
+		input := `{"model":"gemini-1.5-pro","messages":[
+			{"role":"user","content":"q"},
+			{"role":"assistant","content":null,"tool_calls":[
+				{"id":"","type":"function","function":{"name":"get_data","arguments":"{}"}}
+			]}
+		]}`
+		a := &GeminiAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err == nil {
+			t.Fatal("expected error for empty tool_call id, got nil")
+		}
+	})
+
+	t.Run("empty function name in assistant tool_calls returns error", func(t *testing.T) {
+		t.Parallel()
+		input := `{"model":"gemini-1.5-pro","messages":[
+			{"role":"user","content":"q"},
+			{"role":"assistant","content":null,"tool_calls":[
+				{"id":"call_1","type":"function","function":{"name":"","arguments":"{}"}}
+			]}
+		]}`
+		a := &GeminiAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err == nil {
+			t.Fatal("expected error for empty function name, got nil")
+		}
+	})
+
+	t.Run("duplicate tool_call_id with different function name returns error", func(t *testing.T) {
+		t.Parallel()
+		// Same id "call_1" used for two different function names — conflict.
+		input := `{"model":"gemini-1.5-pro","messages":[
+			{"role":"user","content":"q"},
+			{"role":"assistant","content":null,"tool_calls":[
+				{"id":"call_1","type":"function","function":{"name":"fn_a","arguments":"{}"}},
+				{"id":"call_1","type":"function","function":{"name":"fn_b","arguments":"{}"}}
+			]}
+		]}`
+		a := &GeminiAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err == nil {
+			t.Fatal("expected error for duplicate id with conflicting name, got nil")
+		}
+	})
+
+	t.Run("duplicate tool_call_id with SAME function name is fine", func(t *testing.T) {
+		t.Parallel()
+		// Same id used for same function name — technically odd but not conflicting.
+		input := `{"model":"gemini-1.5-pro","messages":[
+			{"role":"user","content":"q"},
+			{"role":"assistant","content":null,"tool_calls":[
+				{"id":"call_1","type":"function","function":{"name":"fn_a","arguments":"{}"}},
+				{"id":"call_1","type":"function","function":{"name":"fn_a","arguments":"{\"x\":1}"}}
+			]}
+		]}`
+		a := &GeminiAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err != nil {
+			t.Fatalf("unexpected error for duplicate id with same name: %v", err)
+		}
+	})
+
+	t.Run("empty tool_call_id in role:tool message returns error", func(t *testing.T) {
+		t.Parallel()
+		input := `{"model":"gemini-1.5-pro","messages":[
+			{"role":"user","content":"q"},
+			{"role":"tool","tool_call_id":"","content":"result"}
+		]}`
+		a := &GeminiAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err == nil {
+			t.Fatal("expected error for empty tool_call_id in tool message, got nil")
+		}
+	})
+
+	t.Run("empty function name in TransformResponse functionCall returns error", func(t *testing.T) {
+		t.Parallel()
+		// Upstream returns a functionCall part with an empty name.
+		input := `{
+			"candidates": [{
+				"content": {"role": "model", "parts": [{"functionCall": {"name": "", "args": {}}}]},
+				"finishReason": "STOP"
+			}],
+			"usageMetadata": {}
+		}`
+		a := &GeminiAdapter{}
+		_, err := a.TransformResponse([]byte(input))
+		if err == nil {
+			t.Fatal("expected error for empty function name in response, got nil")
+		}
+	})
+}
+
+// ── FIX 4: named tool_choice with no declared tools ───────────────────────────
+
+// TestGeminiTransformRequest_Fix4_NamedToolChoiceNoTools verifies that a
+// named tool_choice without any declared tools (or with a name not in the
+// declared list) fails closed unconditionally.
+func TestGeminiTransformRequest_Fix4_NamedToolChoiceNoTools(t *testing.T) {
+	t.Parallel()
+
+	t.Run("named tool_choice with no tools array returns error", func(t *testing.T) {
+		t.Parallel()
+		// tool_choice names a function but no tools are declared — must fail.
+		input := `{"model":"gemini-1.5-pro","messages":[{"role":"user","content":"q"}],"tool_choice":{"type":"function","function":{"name":"get_data"}}}`
+		a := &GeminiAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err == nil {
+			t.Fatal("expected error for named tool_choice with no tools declared, got nil")
+		}
+	})
+
+	t.Run("named tool_choice with tools but name not in list returns error", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"model":"gemini-1.5-pro",
+			"messages":[{"role":"user","content":"q"}],
+			"tools":[{"type":"function","function":{"name":"existing_fn","parameters":{}}}],
+			"tool_choice":{"type":"function","function":{"name":"nonexistent_fn"}}
+		}`
+		a := &GeminiAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err == nil {
+			t.Fatal("expected error for named tool_choice referencing undeclared function, got nil")
+		}
+	})
+
+	t.Run("named tool_choice with matching declared tool succeeds", func(t *testing.T) {
+		t.Parallel()
+		input := `{
+			"model":"gemini-1.5-pro",
+			"messages":[{"role":"user","content":"q"}],
+			"tools":[{"type":"function","function":{"name":"get_data","parameters":{}}}],
+			"tool_choice":{"type":"function","function":{"name":"get_data"}}
+		}`
+		a := &GeminiAdapter{}
+		_, err := a.TransformRequest([]byte(input), Model{})
+		if err != nil {
+			t.Fatalf("unexpected error for valid named tool_choice: %v", err)
+		}
+	})
+}
+
+// ── FIX 5: tool block cap at 64 ───────────────────────────────────────────────
+
+// TestGeminiToolBlockCap verifies that maxGeminiToolBlocks is 64, aligned with
+// the PII Stage 0c StreamRestorer's maxToolCallsPerChoice=64.
+func TestGeminiToolBlockCap(t *testing.T) {
+	t.Parallel()
+
+	if maxGeminiToolBlocks != 64 {
+		t.Errorf("maxGeminiToolBlocks = %d, want 64 (must match Stage 0c maxToolCallsPerChoice)", maxGeminiToolBlocks)
 	}
 }
 


### PR DESCRIPTION
## L-017 (part 2/2) - Gemini tool-call support

Completes L-017: tool calling now works end-to-end on the Gemini provider, mirroring the Anthropic adapter (PR #138). Full bidirectional OpenAI <-> Gemini generateContent translation across request, non-streaming response, and streaming.

### Request
- OpenAI `tools` -> `functionDeclarations`; `tool_choice` -> `functionCallingConfig` (auto/any/none/named). Validated **fail-closed** (type, non-empty name, object parameters, declared-tool reference even when no tools array, charset, pseudonym-shape).
- Assistant `tool_calls` -> `functionCall` parts (role `model`). `role:"tool"` -> `functionResponse` (role `user`). Gemini `functionCall` carries **no id**, so the request transform correlates by **name** via a `tool_call_id -> name` map built from the assistant tool_calls in the same request; unknown/duplicate/empty ids fail closed.
- Tool-result **array content parts preserved as a list** (`{"content":["a","b"]}`), never concatenated - so PII split across parts is never reconstructed.

### Response
- `functionCall` parts -> OpenAI `tool_calls` with **synthesised ids** (Gemini has none). `finish_reason` is derived from **functionCall presence**, not a finish-reason string: real Gemini tool calls end with `STOP` (there is **no** `FUNCTION_CALL` enum value), so the presence-based derivation is what lets Stage 0c accept the stream.

### Streaming
- A `functionCall` chunk now emits a 0c-conformant `tool_calls` delta (the content-free-drop guard no longer discards functionCall-only chunks). A per-stream `sawFunctionCall` flag drives the `tool_calls` finish across both the same-chunk and split-chunk orderings. PII + tools + streaming works on Gemini (end-to-end proxy test).

### Shared / cross-adapter
- A single `isForwardedPseudonym` helper (adapter.go) rejects pseudonym-shaped tool id/name in **both** adapters' non-streaming responses - the global `filter.Restore` would otherwise turn an echoed pseudonym in a structural field into real PII. **Security parity fix to the merged Anthropic adapter:** it now synthesizes the response id/model instead of forwarding the upstream strings.
- Adapter tool-call cap aligned to **64** (= Stage 0c index range) in both adapters.

### Decisions / scope (documented)
- **Function names are out of scope** for the content firewall: they are app configuration (like `tool_call_id`, model name, endpoint URL), not user content, and cannot be pseudonymized without breaking tool calling. Defense = charset + pseudonym-shape reject. Applies to all providers; pre-existing.
- **Streaming abort signal:** `TransformStreamLine` returns `[]byte` only and cannot fail-closed, so a malformed/invalid/excess streaming tool call may be silently dropped (correctness, **never** a PII leak; the data is pseudonymized and discarded in memory). Tracked as a follow-up (interface change across all adapters + handler).

### Reviews
Internal code-review + security-audit, then an external round (Codex + Antigravity). Codex caught the `FUNCTION_CALL`-finish-reason bug (would have broken Gemini tool calls in production), unscanned function-name forwarding, silent stream drops, a pseudonym-in-id/model leak (also fixed in the merged Anthropic adapter), and empty/duplicate-id gaps - all fixed or decided + documented; a re-review confirmed the finish-reason logic is 0c-safe in all orderings. `go build ./...`, `go vet ./...`, full `go test ./...` and `go test -race ./internal/proxy/ ./internal/pii/` green.