### PR TITLE
chore: release 0.0.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to VoidLLM are documented in this file.
 
+## [0.0.22] - 2026-06-21
+
+### Features
+- PII anonymization (opt-in "de-tokenizer firewall"): when `settings.pii.enabled` is on, PII detected in outbound prompts is replaced with deterministic, per-organization pseudonyms before the request leaves to an external provider, and the original values are restored in the response. No prompt or response content, PII, or pseudonyms are ever persisted or logged. Public destinations are anonymized; private/loopback upstreams pass through, and the behavior is configurable per model/deployment via `pii_filter` (#134)
+- Token-by-token streaming for the PII firewall: pseudonyms are restored incrementally across SSE chunks — both message content and streamed tool-call arguments — instead of buffering the whole response (#135, #137)
+- Native tool-call support for the Anthropic and Gemini providers: OpenAI-style tool calls are translated to and from the Anthropic Messages and Gemini generateContent APIs across requests, non-streaming responses, and streaming, including alongside the PII firewall (#138, #139)
+
+### Fixes
+- The PII firewall no longer rejects messages with `null` content (such as assistant messages that carry only `tool_calls`), so multi-turn tool conversations work with anonymization enabled (#136)
+
+---
+
 ## [0.0.21] - 2026-06-19
 
 ### Features

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 COPY --from=ui-builder /app/ui/dist ./ui/dist
-ARG VERSION=0.0.21
+ARG VERSION=0.0.22
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -ldflags="-s -w -X 'github.com/voidmind-io/voidllm/internal/api/health.Version=${VERSION}'" \
     -o /voidllm ./cmd/voidllm

--- a/chart/voidllm/Chart.yaml
+++ b/chart/voidllm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: voidllm
 description: Privacy-first LLM proxy and AI gateway with load balancing, RBAC, MCP gateway, and built-in admin UI. Self-hosted, single binary, sub-500us overhead.
 type: application
-version: 0.0.21
-appVersion: "0.0.21"
+version: 0.0.22
+appVersion: "0.0.22"
 home: https://voidllm.ai
 icon: https://voidllm.ai/logo.svg
 sources:

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -89,5 +89,5 @@ The Docker image sets `VOIDLLM_DATABASE_DSN=/data/voidllm.db` by default. Overri
 
 ```bash
 curl http://localhost:8080/healthz
-# {"status":"ok","uptime_seconds":42,"version":"0.0.21"}
+# {"status":"ok","uptime_seconds":42,"version":"0.0.22"}
 ```


### PR DESCRIPTION
Release 0.0.22. Bundles the PII anonymization firewall (Stage 0a/0b/0c) and native tool-call support for the Anthropic and Gemini providers.

Edits exactly four files per the release process:
- `CHANGELOG.md` — new `## [0.0.22]` block
- `Dockerfile` — `ARG VERSION=0.0.22`
- `chart/voidllm/Chart.yaml` — `version` + `appVersion` 0.0.22
- `docs/deployment/docker.md` — `/healthz` version string

Bundled PRs: #134 #135 #136 #137 #138 #139.

After merge: tag `v0.0.22` on the merge commit (triggers the release workflow), and mark the `voidllm-0.0.22` Helm release as a pre-release. GitHub release notes written by hand.