### PR TITLE
feat(pii): Stage 1 gazetteer detector (locale-neutral, Aho-Corasick)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1511,10 +1511,29 @@ func buildPIIEngine(encKey []byte, cfg config.PIIConfig, log *slog.Logger) (*pii
 		return nil, fmt.Errorf("compile detector patterns: %w", err)
 	}
 
+	detectors := []pii.Detector{detector}
+
+	// When the gazetteer sub-system is also enabled, build and append it.
+	// The gazetteer detector is built at startup and adds zero overhead when
+	// disabled (it is simply not constructed and not appended to the slice).
+	if cfg.Gazetteer.IsEnabled() {
+		gazDetector, gazErr := pii.LoadGazetteerDetector(cfg.Gazetteer)
+		if gazErr != nil {
+			return nil, fmt.Errorf("build gazetteer detector: %w", gazErr)
+		}
+		detectors = append(detectors, gazDetector)
+		log.LogAttrs(context.Background(), slog.LevelInfo,
+			"pii gazetteer detector enabled",
+			slog.Int("packs", len(cfg.Gazetteer.Packs)),
+			slog.Int("dirs", len(cfg.Gazetteer.Dirs)),
+			slog.Int("inline_term_groups", len(cfg.Gazetteer.Terms)),
+		)
+	}
+
 	log.LogAttrs(context.Background(), slog.LevelInfo,
 		"pii anonymization enabled",
 		slog.Int("builtin_patterns", len(pii.DefaultPatterns())),
 		slog.Int("custom_patterns", len(cfg.Patterns)),
 	)
-	return pii.NewEngine(piiSecret, []pii.Detector{detector}), nil
+	return pii.NewEngine(piiSecret, detectors), nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -468,6 +468,65 @@ type PIIPatternConfig struct {
 	Regexp string `yaml:"regexp"`
 }
 
+// PIIGazetteerTermConfig defines a set of inline operator-supplied terms for a
+// single PII type to detect via the gazetteer detector.
+type PIIGazetteerTermConfig struct {
+	// Type is the PII category label to assign to matched terms (e.g. "ORG").
+	// Must not be empty.
+	Type string `yaml:"type"`
+	// Values is the list of exact terms to match.
+	Values []string `yaml:"values"`
+}
+
+// PIIGazetteerOptionsConfig controls matching behaviour of the gazetteer detector.
+type PIIGazetteerOptionsConfig struct {
+	// CaseInsensitive folds case before matching. Defaults to true.
+	// A pointer is used so that an explicit "false" in YAML can be
+	// distinguished from the zero value (allowing the default of true to
+	// be applied by setDefaults).
+	CaseInsensitive *bool `yaml:"case_insensitive"`
+}
+
+// PIIGazetteerConfig controls the gazetteer-based PII detector. It is an
+// opt-in subsystem within pii: the outer pii.enabled flag must also be true
+// for any detection to occur.
+type PIIGazetteerConfig struct {
+	// Enabled activates the gazetteer detector. Defaults to false (opt-in).
+	// A pointer is used so that an explicit "enabled: false" can be
+	// distinguished from the zero value after unmarshalling.
+	Enabled *bool `yaml:"enabled"`
+	// Packs is the list of embedded pack names to load (e.g. "company-forms",
+	// "de-cities"). Unknown names cause a startup error.
+	Packs []string `yaml:"packs"`
+	// Dirs is a list of directory paths. Every *.txt file in each directory
+	// is loaded as a gazetteer file (same format as embedded packs). A
+	// nonexistent directory causes a startup error.
+	Dirs []string `yaml:"dirs"`
+	// Terms is a list of inline operator-supplied term sets. Empty type causes
+	// a startup error.
+	Terms []PIIGazetteerTermConfig `yaml:"terms"`
+	// Options controls matching behaviour.
+	Options PIIGazetteerOptionsConfig `yaml:"options"`
+}
+
+// IsEnabled returns true only when the gazetteer detector has been explicitly
+// enabled. A nil pointer (field absent from YAML) returns false.
+func (g PIIGazetteerConfig) IsEnabled() bool {
+	if g.Enabled == nil {
+		return false
+	}
+	return *g.Enabled
+}
+
+// IsCaseInsensitive returns whether case-insensitive matching is active.
+// A nil pointer (field absent from YAML) returns true (the default).
+func (o PIIGazetteerOptionsConfig) IsCaseInsensitive() bool {
+	if o.CaseInsensitive == nil {
+		return true
+	}
+	return *o.CaseInsensitive
+}
+
 // PIIConfig controls in-memory PII anonymization of outbound LLM requests.
 // When enabled, PII detected in message content is replaced with
 // deterministic pseudonyms before the request leaves the proxy. The
@@ -485,6 +544,9 @@ type PIIConfig struct {
 	// applied in addition to the built-in defaults. An empty list means
 	// only the built-in patterns are used.
 	Patterns []PIIPatternConfig `yaml:"patterns"`
+	// Gazetteer controls the optional gazetteer-based PII detector. Disabled
+	// by default; set gazetteer.enabled: true to activate.
+	Gazetteer PIIGazetteerConfig `yaml:"gazetteer"`
 }
 
 // IsEnabled returns true only when PII anonymization has been explicitly
@@ -866,6 +928,17 @@ func (c *Config) setDefaults() {
 	}
 	if c.Settings.PII.Action == "" {
 		c.Settings.PII.Action = "pseudonymize"
+	}
+
+	// PII gazetteer — disabled by default (opt-in).
+	if c.Settings.PII.Gazetteer.Enabled == nil {
+		disabled := false
+		c.Settings.PII.Gazetteer.Enabled = &disabled
+	}
+	// options.case_insensitive defaults to true (opt-out).
+	if c.Settings.PII.Gazetteer.Options.CaseInsensitive == nil {
+		v := true
+		c.Settings.PII.Gazetteer.Options.CaseInsensitive = &v
 	}
 
 	// Logging

--- a/internal/config/gazetteer_test.go
+++ b/internal/config/gazetteer_test.go
@@ -1,0 +1,421 @@
+package config_test
+
+// gazetteer_test.go covers settings.pii.gazetteer configuration: YAML parsing,
+// default values, and validation rules (pack names, dirs, inline terms).
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/voidmind-io/voidllm/internal/config"
+)
+
+// minimalValidYAMLWithGazetteer inlines the provided gazetteer YAML block
+// inside a minimal valid config that already has pii.enabled: true so that the
+// gazetteer block itself is validated.
+func minimalValidYAMLWithGazetteer(gazBlock string) string {
+	return `
+server:
+  proxy:
+    port: 8080
+database:
+  driver: sqlite
+  dsn: voidllm.db
+settings:
+  encryption_key: aaaaaaaaaaaaaaaa
+  usage:
+    buffer_size: 100
+  pii:
+    enabled: true
+    action: pseudonymize
+    gazetteer:
+` + gazBlock
+}
+
+// TestGazetteerConfig_Parse verifies that a full gazetteer block is parsed
+// and stored correctly in the loaded Config struct.
+func TestGazetteerConfig_Parse(t *testing.T) {
+	t.Parallel()
+
+	// Create a real temp dir so dir validation passes.
+	dir := t.TempDir()
+
+	yaml := minimalValidYAMLWithGazetteer(`
+      enabled: true
+      packs:
+        - company-forms
+        - de-cities
+      dirs:
+        - ` + dir + `
+      terms:
+        - type: ORG
+          values:
+            - Project Titan
+            - Operation Moonshot
+      options:
+        case_insensitive: true
+`)
+
+	path := writeTemp(t, "voidllm.yaml", yaml)
+	cfg, _, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	gaz := cfg.Settings.PII.Gazetteer
+
+	if !gaz.IsEnabled() {
+		t.Error("Gazetteer.IsEnabled() = false, want true")
+	}
+
+	if len(gaz.Packs) != 2 {
+		t.Fatalf("Packs = %v, want [company-forms, de-cities]", gaz.Packs)
+	}
+	if gaz.Packs[0] != "company-forms" {
+		t.Errorf("Packs[0] = %q, want company-forms", gaz.Packs[0])
+	}
+	if gaz.Packs[1] != "de-cities" {
+		t.Errorf("Packs[1] = %q, want de-cities", gaz.Packs[1])
+	}
+
+	if len(gaz.Dirs) != 1 || gaz.Dirs[0] != dir {
+		t.Errorf("Dirs = %v, want [%q]", gaz.Dirs, dir)
+	}
+
+	if len(gaz.Terms) != 1 {
+		t.Fatalf("Terms = %v, want 1 entry", gaz.Terms)
+	}
+	if gaz.Terms[0].Type != "ORG" {
+		t.Errorf("Terms[0].Type = %q, want ORG", gaz.Terms[0].Type)
+	}
+	if len(gaz.Terms[0].Values) != 2 {
+		t.Errorf("Terms[0].Values = %v, want 2 values", gaz.Terms[0].Values)
+	}
+
+	if !gaz.Options.IsCaseInsensitive() {
+		t.Error("Options.IsCaseInsensitive() = false, want true")
+	}
+}
+
+// TestGazetteerConfig_Defaults verifies the default values applied by
+// setDefaults when no gazetteer block is present in the YAML.
+func TestGazetteerConfig_Defaults(t *testing.T) {
+	t.Parallel()
+
+	path := writeTemp(t, "voidllm.yaml", minimalValidYAML())
+	cfg, _, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	gaz := cfg.Settings.PII.Gazetteer
+
+	t.Run("enabled defaults to false", func(t *testing.T) {
+		t.Parallel()
+		if gaz.IsEnabled() {
+			t.Error("Gazetteer.IsEnabled() = true, want false (disabled by default)")
+		}
+		if gaz.Enabled == nil {
+			t.Error("Gazetteer.Enabled is nil after setDefaults, want &false")
+		}
+	})
+
+	t.Run("case_insensitive defaults to true", func(t *testing.T) {
+		t.Parallel()
+		if !gaz.Options.IsCaseInsensitive() {
+			t.Error("Options.IsCaseInsensitive() = false, want true (default)")
+		}
+		if gaz.Options.CaseInsensitive == nil {
+			t.Error("Options.CaseInsensitive is nil after setDefaults, want &true")
+		}
+	})
+}
+
+// TestGazetteerConfig_CaseInsensitiveFalse verifies that explicitly setting
+// case_insensitive: false is preserved and not overwritten to the default.
+func TestGazetteerConfig_CaseInsensitiveFalse(t *testing.T) {
+	t.Parallel()
+
+	yaml := minimalValidYAMLWithGazetteer(`
+      enabled: true
+      packs:
+        - company-forms
+      options:
+        case_insensitive: false
+`)
+
+	path := writeTemp(t, "voidllm.yaml", yaml)
+	cfg, _, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	if cfg.Settings.PII.Gazetteer.Options.IsCaseInsensitive() {
+		t.Error("IsCaseInsensitive() = true, want false when explicitly set to false")
+	}
+}
+
+// TestGazetteerConfig_EnabledNilMeansDisabled verifies that a nil Enabled
+// pointer (field absent from YAML) means the detector is disabled.
+func TestGazetteerConfig_EnabledNilMeansDisabled(t *testing.T) {
+	t.Parallel()
+
+	// Build a PIIGazetteerConfig directly without going through YAML/Load
+	// to test the IsEnabled() method with a nil pointer.
+	var gaz config.PIIGazetteerConfig
+	if gaz.IsEnabled() {
+		t.Error("IsEnabled() on zero-value config = true, want false")
+	}
+}
+
+// TestGazetteerConfig_CaseInsensitiveNilMeansTrue verifies that a nil
+// CaseInsensitive pointer means case-insensitive is on.
+func TestGazetteerConfig_CaseInsensitiveNilMeansTrue(t *testing.T) {
+	t.Parallel()
+
+	var opts config.PIIGazetteerOptionsConfig
+	if !opts.IsCaseInsensitive() {
+		t.Error("IsCaseInsensitive() on nil pointer = false, want true (default on)")
+	}
+}
+
+// TestGazetteerValidation covers all validation error paths for the
+// settings.pii.gazetteer block.
+func TestGazetteerValidation(t *testing.T) {
+	t.Parallel()
+
+	// We need a real temp dir for the "valid dir" cases.
+	existingDir := t.TempDir()
+
+	tests := []struct {
+		name        string
+		yaml        string
+		wantErr     bool
+		errContains string
+	}{
+		// ── valid ────────────────────────────────────────────────────────────
+		{
+			name: "gazetteer disabled, pack list not validated",
+			yaml: minimalValidYAMLWithGazetteer(`
+      enabled: false
+      packs:
+        - nonexistent-pack
+`),
+			// Pack name is invalid but gazetteer is disabled, so no error.
+		},
+		{
+			name: "gazetteer enabled with known packs",
+			yaml: minimalValidYAMLWithGazetteer(`
+      enabled: true
+      packs:
+        - company-forms
+        - de-cities
+`),
+		},
+		{
+			name: "gazetteer enabled with valid existing dir",
+			yaml: minimalValidYAMLWithGazetteer(`
+      enabled: true
+      dirs:
+        - ` + existingDir + `
+`),
+		},
+		{
+			name: "gazetteer enabled with inline terms with type",
+			yaml: minimalValidYAMLWithGazetteer(`
+      enabled: true
+      terms:
+        - type: ORG
+          values:
+            - Acme Corp
+`),
+		},
+		{
+			name: "gazetteer enabled with no packs or terms (empty detector)",
+			yaml: minimalValidYAMLWithGazetteer(`
+      enabled: true
+`),
+		},
+		// ── invalid ──────────────────────────────────────────────────────────
+		{
+			name: "unknown pack name returns error",
+			yaml: minimalValidYAMLWithGazetteer(`
+      enabled: true
+      packs:
+        - company-forms
+        - unknown-pack-xyz
+`),
+			wantErr:     true,
+			errContains: "settings.pii.gazetteer.packs",
+		},
+		{
+			name: "only unknown pack returns error",
+			yaml: minimalValidYAMLWithGazetteer(`
+      enabled: true
+      packs:
+        - totally-unknown
+`),
+			wantErr:     true,
+			errContains: "settings.pii.gazetteer.packs",
+		},
+		{
+			name: "nonexistent dir returns error",
+			yaml: minimalValidYAMLWithGazetteer(`
+      enabled: true
+      dirs:
+        - /no/such/dir/xyz123
+`),
+			wantErr:     true,
+			errContains: "settings.pii.gazetteer.dirs",
+		},
+		{
+			name: "inline term with empty type returns error",
+			yaml: minimalValidYAMLWithGazetteer(`
+      enabled: true
+      terms:
+        - type: ""
+          values:
+            - foo
+`),
+			wantErr:     true,
+			errContains: "settings.pii.gazetteer.terms[0].type",
+		},
+		{
+			name: "second inline term with empty type uses correct index",
+			yaml: minimalValidYAMLWithGazetteer(`
+      enabled: true
+      terms:
+        - type: ORG
+          values:
+            - GmbH
+        - type: ""
+          values:
+            - bar
+`),
+			wantErr:     true,
+			errContains: "settings.pii.gazetteer.terms[1].type",
+		},
+		{
+			name: "dir that is a file not a directory returns error",
+			// Write a temp file then use its path as a dir.
+			// We build this inline using a file path approach in the subtest below.
+		},
+	}
+
+	for _, tc := range tests {
+		if tc.yaml == "" {
+			continue // skip the "dir is a file" case handled below
+		}
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			path := writeTemp(t, "voidllm.yaml", tc.yaml)
+			_, _, err := config.Load(path)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("Load() expected error, got nil")
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Load() unexpected error: %v", err)
+				}
+			}
+		})
+	}
+
+	// Special case: path that points to a file (not a directory).
+	t.Run("dir path pointing to a file returns error", func(t *testing.T) {
+		t.Parallel()
+
+		// Write a plain file, then use its path as a "dir".
+		fileAsDir := filepath.Join(t.TempDir(), "not-a-dir.txt")
+		if err := os.WriteFile(fileAsDir, []byte("content"), 0o600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		yaml := minimalValidYAMLWithGazetteer(`
+      enabled: true
+      dirs:
+        - ` + fileAsDir + `
+`)
+		path := writeTemp(t, "voidllm.yaml", yaml)
+		_, _, err := config.Load(path)
+		if err == nil {
+			t.Error("expected error when dir path is a file, got nil")
+		}
+		if err != nil && !strings.Contains(err.Error(), "settings.pii.gazetteer.dirs") {
+			t.Errorf("error %q should mention settings.pii.gazetteer.dirs", err.Error())
+		}
+	})
+}
+
+// TestGazetteerConfig_MultipleInlineTermGroups verifies that multiple inline
+// term entries with different types are all stored correctly.
+func TestGazetteerConfig_MultipleInlineTermGroups(t *testing.T) {
+	t.Parallel()
+
+	yaml := minimalValidYAMLWithGazetteer(`
+      enabled: true
+      terms:
+        - type: ORG
+          values:
+            - Acme Corp
+            - Foo Inc
+        - type: PERSON
+          values:
+            - Alice Smith
+`)
+
+	path := writeTemp(t, "voidllm.yaml", yaml)
+	cfg, _, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("Load() unexpected error: %v", err)
+	}
+
+	terms := cfg.Settings.PII.Gazetteer.Terms
+	if len(terms) != 2 {
+		t.Fatalf("Terms length = %d, want 2", len(terms))
+	}
+	if terms[0].Type != "ORG" {
+		t.Errorf("Terms[0].Type = %q, want ORG", terms[0].Type)
+	}
+	if len(terms[0].Values) != 2 {
+		t.Errorf("Terms[0].Values = %v, want 2 entries", terms[0].Values)
+	}
+	if terms[1].Type != "PERSON" {
+		t.Errorf("Terms[1].Type = %q, want PERSON", terms[1].Type)
+	}
+	if len(terms[1].Values) != 1 || terms[1].Values[0] != "Alice Smith" {
+		t.Errorf("Terms[1].Values = %v, want [Alice Smith]", terms[1].Values)
+	}
+}
+
+// TestGazetteerConfig_DisabledPackValidationSkipped verifies that when
+// gazetteer.enabled is false the pack-name validation is not applied, allowing
+// the config to load even with a fake pack name.  This lets operators disable
+// the feature temporarily without removing their config entries.
+func TestGazetteerConfig_DisabledPackValidationSkipped(t *testing.T) {
+	t.Parallel()
+
+	yaml := minimalValidYAMLWithGazetteer(`
+      enabled: false
+      packs:
+        - not-a-real-pack
+      terms:
+        - type: ""
+          values:
+            - ignored
+`)
+	// Even though type is empty and pack name is invalid, no error because disabled.
+	path := writeTemp(t, "voidllm.yaml", yaml)
+	_, _, err := config.Load(path)
+	if err != nil {
+		t.Errorf("Load() unexpected error when gazetteer disabled: %v", err)
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"time"
@@ -371,6 +372,41 @@ func (c *Config) validate() error {
 				errs = append(errs, fmt.Errorf("settings.pii.patterns[%d].regexp: must not be empty", i))
 			} else if _, reErr := regexp.Compile(p.Regexp); reErr != nil {
 				errs = append(errs, fmt.Errorf("settings.pii.patterns[%d].regexp: invalid regexp: %w", i, reErr))
+			}
+		}
+	}
+
+	// --- settings.pii.gazetteer ---
+	// Validate gazetteer config when it is enabled, regardless of whether the
+	// outer pii.enabled is set — this catches configuration mistakes early and
+	// lets operators verify pack names without enabling PII globally.
+	if c.Settings.PII.Gazetteer.IsEnabled() {
+		gaz := c.Settings.PII.Gazetteer
+
+		// Validate pack names against the known embedded registry.
+		knownPacks := map[string]bool{
+			"company-forms": true,
+			"de-cities":     true,
+		}
+		for _, packName := range gaz.Packs {
+			if !knownPacks[packName] {
+				errs = append(errs, fmt.Errorf("settings.pii.gazetteer.packs: unknown embedded pack %q", packName))
+			}
+		}
+
+		// Validate operator directories: must exist.
+		for _, dir := range gaz.Dirs {
+			if info, statErr := os.Stat(dir); statErr != nil {
+				errs = append(errs, fmt.Errorf("settings.pii.gazetteer.dirs: %q: %w", dir, statErr))
+			} else if !info.IsDir() {
+				errs = append(errs, fmt.Errorf("settings.pii.gazetteer.dirs: %q is not a directory", dir))
+			}
+		}
+
+		// Validate inline terms.
+		for i, entry := range gaz.Terms {
+			if entry.Type == "" {
+				errs = append(errs, fmt.Errorf("settings.pii.gazetteer.terms[%d].type: must not be empty", i))
 			}
 		}
 	}

--- a/internal/pii/ahocorasick.go
+++ b/internal/pii/ahocorasick.go
@@ -1,0 +1,188 @@
+package pii
+
+import (
+	"fmt"
+)
+
+// maxGazetteerStates is the maximum number of trie states the Aho-Corasick
+// automaton may allocate. Each state corresponds to one rune in the trie.
+// At ~40 bytes per state (IDs + map overhead) this caps memory at roughly
+// 20 MB before terms are even matched. Exceeding the cap causes the
+// constructor to return an error rather than silently exhausting heap.
+const maxGazetteerStates = 500_000
+
+// maxGazetteerOutputs is the maximum total number of output-link entries
+// summed across all trie states. Without this bound, BFS output-link
+// flattening for prefix-heavy dictionaries (e.g. "a", "aa", "aaa", …)
+// copies failure outputs into every descendant, growing quadratically in
+// the number of states. Exceeding this cap causes the constructor to return
+// an error (fail-closed at startup) rather than exhausting heap.
+const maxGazetteerOutputs = 1_000_000
+
+// acState is a single node in the Aho-Corasick trie.
+type acState struct {
+	// children maps a rune to the next state ID on that edge.
+	children map[rune]int32
+	// fail is the failure-link state ID (BFS-computed).
+	fail int32
+	// output holds the term payloads that match at this state (via goto or
+	// output links). Each element is an index into acMatcher.terms.
+	output []int32
+}
+
+// acTerm pairs a normalized term with the PII type it represents.
+type acTerm struct {
+	norm    string // case-folded (or original if case-sensitive)
+	typ     string
+	runeLen int // precomputed len([]rune(norm)); set once in newACMatcher
+}
+
+// acMatcher is a compiled, immutable Aho-Corasick automaton over runes.
+// It is built once in newACMatcher and reused concurrently across Find calls.
+type acMatcher struct {
+	states []acState
+	terms  []acTerm
+}
+
+// newACMatcher builds an Aho-Corasick automaton from the given (normalized
+// term, type) pairs. It returns an error if the number of trie states would
+// exceed maxGazetteerStates, or if the total number of output-link entries
+// across all states would exceed maxGazetteerOutputs.
+//
+// The output-link bound prevents quadratic memory growth for prefix-heavy
+// dictionaries (e.g. "a", "aa", "aaa", …) where BFS output-link flattening
+// copies failure outputs into every descendant, potentially producing
+// O(states^2) total entries.
+//
+// The caller is responsible for deduplication; duplicate terms produce
+// redundant but harmless output entries.
+func newACMatcher(terms []acTerm) (*acMatcher, error) {
+	if len(terms) == 0 {
+		return &acMatcher{states: []acState{{}}}, nil
+	}
+
+	m := &acMatcher{
+		states: make([]acState, 1, min(len(terms)*4, maxGazetteerStates)),
+		terms:  terms,
+	}
+	// State 0 is the root.
+	m.states[0] = acState{children: make(map[rune]int32)}
+
+	// Phase 1: insert all terms into the trie.
+	totalOutputs := 0
+	for termIdx, t := range terms {
+		// Precompute rune length once; avoids repeated allocation in match().
+		m.terms[termIdx].runeLen = len([]rune(t.norm))
+		cur := int32(0)
+		for _, r := range t.norm {
+			if _, ok := m.states[cur].children[r]; !ok {
+				if len(m.states) >= maxGazetteerStates {
+					return nil, fmt.Errorf("pii: gazetteer: trie exceeds %d states (reduce term count)", maxGazetteerStates)
+				}
+				newID := int32(len(m.states))
+				m.states = append(m.states, acState{children: make(map[rune]int32)})
+				m.states[cur].children[r] = newID
+			}
+			cur = m.states[cur].children[r]
+		}
+		// Mark this state as an output for termIdx.
+		m.states[cur].output = append(m.states[cur].output, int32(termIdx))
+		totalOutputs++
+	}
+
+	// Phase 2: compute failure links and output links via BFS.
+	// Failure links use a FIFO queue of state IDs.
+	queue := make([]int32, 0, len(m.states))
+
+	// Seed: depth-1 nodes fail to root.
+	for _, childID := range m.states[0].children {
+		m.states[childID].fail = 0
+		queue = append(queue, childID)
+	}
+
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+
+		for r, childID := range m.states[cur].children {
+			// Compute failure link for childID.
+			f := m.states[cur].fail
+			for f != 0 {
+				if _, ok := m.states[f].children[r]; ok {
+					break
+				}
+				f = m.states[f].fail
+			}
+			if next, ok := m.states[f].children[r]; ok && next != childID {
+				m.states[childID].fail = next
+			} else {
+				m.states[childID].fail = 0
+			}
+
+			// Merge output links: childID inherits the outputs of its fail state.
+			// Count the new entries before merging to enforce the output cap.
+			failOutputs := m.states[m.states[childID].fail].output
+			if len(failOutputs) > 0 {
+				added := len(failOutputs)
+				totalOutputs += added
+				if totalOutputs > maxGazetteerOutputs {
+					return nil, fmt.Errorf("pii: gazetteer: output links exceed %d entries (reduce term count or remove prefix dictionaries)", maxGazetteerOutputs)
+				}
+				merged := make([]int32, len(m.states[childID].output)+len(failOutputs))
+				copy(merged, m.states[childID].output)
+				copy(merged[len(m.states[childID].output):], failOutputs)
+				m.states[childID].output = merged
+			}
+
+			queue = append(queue, childID)
+		}
+	}
+
+	return m, nil
+}
+
+// acMatch is a single occurrence found by the automaton scan.
+type acMatch struct {
+	startRune int // inclusive start rune index in the scanned text
+	endRune   int // exclusive end rune index
+	termIdx   int // index into acMatcher.terms
+}
+
+// match scans text (as a rune slice) using the automaton and returns every
+// occurrence of every dictionary term. Overlapping occurrences are all
+// reported; the caller resolves overlaps.
+func (m *acMatcher) match(runes []rune) []acMatch {
+	if len(m.states) == 0 || len(runes) == 0 {
+		return nil
+	}
+
+	var results []acMatch
+	cur := int32(0)
+
+	for pos, r := range runes {
+		// Follow failure links until we find a valid goto or reach root.
+		for cur != 0 {
+			if _, ok := m.states[cur].children[r]; ok {
+				break
+			}
+			cur = m.states[cur].fail
+		}
+		if next, ok := m.states[cur].children[r]; ok {
+			cur = next
+		}
+		// cur now holds the state after consuming runes[pos].
+
+		// Collect all outputs at this state (term matches ending at pos+1).
+		for _, tIdx := range m.states[cur].output {
+			term := m.terms[tIdx]
+			startRune := pos + 1 - term.runeLen
+			results = append(results, acMatch{
+				startRune: startRune,
+				endRune:   pos + 1,
+				termIdx:   int(tIdx),
+			})
+		}
+	}
+
+	return results
+}

--- a/internal/pii/gazetteer.go
+++ b/internal/pii/gazetteer.go
@@ -1,0 +1,453 @@
+package pii
+
+import (
+	"bufio"
+	"embed"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+//go:embed gazetteer_packs/*.txt
+var embeddedPacks embed.FS
+
+// maxGazetteerMatches is the maximum number of raw automaton hits (before
+// word-boundary filtering) allowed for a single Find call. Exceeding this
+// cap causes Find to return an error so the request is rejected fail-closed
+// rather than silently truncated. Truncation would leave PII unmasked;
+// rejection is always safer. 200 000 is well above any realistic match
+// density for legitimate input and low enough to bound per-request work.
+const maxGazetteerMatches = 200_000
+
+// Gazetteer describes a named collection of terms that identify a single PII
+// type (e.g. city names, company suffixes). The Locale field is selection
+// metadata only; matching itself is language-blind.
+type Gazetteer struct {
+	// Name is the unique identifier used to select this pack in config
+	// (e.g. "company-forms", "de-cities").
+	Name string
+	// Locale is an informational BCP-47 locale tag (e.g. "de", "universal").
+	// It has no effect on matching behaviour.
+	Locale string
+	// Type is the PII type label assigned to spans matched by this gazetteer
+	// (e.g. "ORG", "CITY").
+	Type string
+	// Terms is the list of terms to match. Empty terms are ignored.
+	Terms []string
+}
+
+// GazetteerOptions controls matching behaviour of a GazetteerDetector.
+type GazetteerOptions struct {
+	// CaseInsensitive folds the case of both dictionary terms and the scanned
+	// text before matching. Original byte offsets are always preserved in the
+	// returned Spans. Default: true.
+	CaseInsensitive bool
+}
+
+// GazetteerDetector finds PII spans using a set of gazetteer term lists.
+// It is built once and safe for concurrent Find calls; all state is
+// read-only after construction.
+//
+// Case folding: when GazetteerOptions.CaseInsensitive is true, matching
+// uses simple per-rune unicode.ToLower folding (see foldRunes). This does
+// not perform Unicode full case folding, so variants such as "ß" vs "ss",
+// Greek final sigma, and NFC/NFD-different accented forms are not matched.
+// Operators should add spelling and case variants to their gazetteer lists
+// for full coverage.
+type GazetteerDetector struct {
+	matcher *acMatcher
+	opts    GazetteerOptions
+}
+
+// foldRunes lowercases s one rune at a time using unicode.ToLower, guaranteeing
+// a strict 1:1 rune correspondence between the input and output strings.
+// Both the dictionary term normalization and the scan-text folding in Find use
+// this function so the two sides are always folded identically — a requirement
+// for correct byte-offset alignment in the returned Spans.
+//
+// Documented limitation (FIX 6): foldRunes uses simple per-rune unicode.ToLower,
+// not Unicode full case folding (golang.org/x/text/unicode/norm or cases.Fold).
+// As a result, the following variants are NOT matched by CaseInsensitive mode:
+//
+//   - "ß" (U+00DF) vs "ss": unicode.ToLower('ß') == 'ß'; it does NOT expand to
+//     "ss", so Straße and STRASSE are treated as distinct strings. Operators
+//     must add both spelling variants to their gazetteer lists.
+//   - Greek final sigma (ς / σ): treated as distinct runes by unicode.ToLower.
+//   - NFC/NFD-different forms of accented characters (e.g. "é" as U+00E9 vs
+//     "e" + U+0301): not normalized; operators should use a single canonical form.
+//
+// Full Unicode case folding or NFC normalization would require changing rune
+// count or byte length, which would break the security-critical 1:1
+// rune-index-to-byte-offset mapping. Accepting a slightly weaker matching model
+// is the correct tradeoff for a privacy-critical anonymizer where incorrect
+// byte offsets could silently mis-mask a different text region.
+func foldRunes(s string) string {
+	runes := []rune(s)
+	for i, r := range runes {
+		runes[i] = unicode.ToLower(r)
+	}
+	return string(runes)
+}
+
+// NewGazetteerDetector builds a GazetteerDetector from the given gazetteers.
+// One Aho-Corasick automaton is compiled from all terms across all gazetteers;
+// each term carries its gazetteer's Type.
+//
+// When opts.CaseInsensitive is true (the default), terms are folded to
+// lowercase for the automaton dictionary, and the input text is also folded
+// before scanning. Matches are then mapped back to original byte offsets in the
+// returned Spans.
+//
+// Returns an error if the total number of automaton states would exceed
+// maxGazetteerStates (see ahocorasick.go).
+func NewGazetteerDetector(gazes []Gazetteer, opts GazetteerOptions) (*GazetteerDetector, error) {
+	// Collect all (term, type) pairs, deduplicating identical (norm, type) pairs.
+	type termKey struct {
+		norm string
+		typ  string
+	}
+	seen := make(map[termKey]struct{})
+	var terms []acTerm
+
+	for _, g := range gazes {
+		for _, raw := range g.Terms {
+			raw = strings.TrimSpace(raw)
+			if raw == "" {
+				continue
+			}
+			norm := raw
+			if opts.CaseInsensitive {
+				norm = foldRunes(raw)
+			}
+			k := termKey{norm: norm, typ: g.Type}
+			if _, dup := seen[k]; dup {
+				continue
+			}
+			seen[k] = struct{}{}
+			terms = append(terms, acTerm{norm: norm, typ: g.Type})
+		}
+	}
+
+	matcher, err := newACMatcher(terms)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GazetteerDetector{matcher: matcher, opts: opts}, nil
+}
+
+// Find returns all non-overlapping PII spans in text where a gazetteer term
+// matches at a whole-token boundary. Whole-token filtering: a match at
+// [start, end) is accepted only when the rune before start and the rune after
+// end are NOT Unicode letters or digits (or the match is at the start/end of
+// the string). This prevents partial-word matches such as "Berg" matching
+// inside "Bergmann".
+//
+// When multiple spans overlap, the leftmost match wins; ties are broken by
+// longest match (same policy as RegexDetector). The returned Spans use byte
+// offsets into the original text, regardless of whether case folding was used.
+//
+// Find returns an error when the number of raw automaton hits before boundary
+// filtering exceeds maxGazetteerMatches. The caller must treat this as a
+// hard failure (fail-closed): an over-cap condition means the input is
+// pathologically term-dense and cannot be safely processed — partial results
+// would risk leaving PII unmasked. The request must be rejected rather than
+// forwarded with incomplete anonymization.
+func (d *GazetteerDetector) Find(text string) ([]Span, error) {
+	if len(text) == 0 || len(d.matcher.states) == 0 {
+		return nil, nil
+	}
+
+	// Build rune slice of the original text and a parallel slice for scanning.
+	// When case-insensitive, the scan slice is lowercased via foldRunes — the
+	// same function used for dictionary normalization — guaranteeing a strict
+	// 1:1 rune correspondence between origRunes and scanRunes so that rune
+	// indices computed from automaton output map correctly back to origRunes.
+	//
+	// Note: Find assumes valid UTF-8 input. The proxy guarantees this via
+	// Sonic ConfigStd JSON parsing before detection. If the input contains
+	// invalid UTF-8, []rune yields U+FFFD replacement characters whose byte
+	// lengths differ from the original sequences, causing runeByteStart
+	// offsets to be incorrect for the affected positions.
+	origRunes := []rune(text)
+	scanRunes := origRunes
+	if d.opts.CaseInsensitive {
+		scanRunes = []rune(foldRunes(text))
+	}
+
+	// Build a rune-index → byte-offset mapping so matches can be converted
+	// back to original byte offsets. runeByteStart[i] is the byte offset of
+	// origRunes[i] in text.
+	runeByteStart := make([]int, len(origRunes)+1)
+	byteOff := 0
+	for i, r := range origRunes {
+		runeByteStart[i] = byteOff
+		n := utf8.RuneLen(r)
+		if n < 0 {
+			// origRunes comes from []rune(text) so all runes are valid;
+			// treat the impossible case as 1 to avoid corrupting byteOff.
+			n = 1
+		}
+		byteOff += n
+	}
+	runeByteStart[len(origRunes)] = len(text)
+
+	// Run the automaton over the (possibly folded) rune slice, applying the
+	// word-boundary filter inline to avoid materializing all raw hits before
+	// filtering. The cap is checked against the raw hit count (before
+	// boundary filtering) so that a dictionary attack via a term-dense input
+	// is detected even when most hits are rejected by the boundary filter.
+	var filtered []acMatch
+	cur := int32(0)
+	rawCount := 0
+	states := d.matcher.states
+	terms := d.matcher.terms
+
+	for pos, r := range scanRunes {
+		// Follow failure links until we find a valid goto or reach root.
+		for cur != 0 {
+			if _, ok := states[cur].children[r]; ok {
+				break
+			}
+			cur = states[cur].fail
+		}
+		if next, ok := states[cur].children[r]; ok {
+			cur = next
+		}
+
+		// Collect all outputs at this state (term matches ending at pos+1).
+		for _, tIdx := range states[cur].output {
+			rawCount++
+			if rawCount > maxGazetteerMatches {
+				return nil, fmt.Errorf("pii: gazetteer: match count exceeded %d for a single input (request rejected)", maxGazetteerMatches)
+			}
+			t := terms[tIdx]
+			startRune := pos + 1 - t.runeLen
+			// Apply word-boundary filter inline so only whole-token hits
+			// are kept; this avoids a separate allocation for all raw hits.
+			if isWordBoundary(origRunes, startRune, pos+1) {
+				filtered = append(filtered, acMatch{
+					startRune: startRune,
+					endRune:   pos + 1,
+					termIdx:   int(tIdx),
+				})
+			}
+		}
+	}
+
+	if len(filtered) == 0 {
+		return nil, nil
+	}
+
+	// Sort: leftmost first; on tie, longest first (largest endRune first).
+	sort.Slice(filtered, func(i, j int) bool {
+		a, b := filtered[i], filtered[j]
+		if a.startRune != b.startRune {
+			return a.startRune < b.startRune
+		}
+		return a.endRune > b.endRune
+	})
+
+	// Greedy non-overlapping selection, advancing cursor past each accepted match.
+	result := make([]Span, 0, len(filtered))
+	cursor := 0
+	for _, m := range filtered {
+		if m.startRune < cursor {
+			continue
+		}
+		result = append(result, Span{
+			Start: runeByteStart[m.startRune],
+			End:   runeByteStart[m.endRune],
+			Type:  d.matcher.terms[m.termIdx].typ,
+		})
+		cursor = m.endRune
+	}
+	return result, nil
+}
+
+// isWordBoundary reports whether a match at [startRune, endRune) in runes is
+// at a whole-token boundary. The rune before startRune and the rune after
+// endRune-1 must not be a Unicode letter or digit.
+func isWordBoundary(runes []rune, startRune, endRune int) bool {
+	if startRune > 0 {
+		prev := runes[startRune-1]
+		if unicode.IsLetter(prev) || unicode.IsDigit(prev) {
+			return false
+		}
+	}
+	if endRune < len(runes) {
+		next := runes[endRune]
+		if unicode.IsLetter(next) || unicode.IsDigit(next) {
+			return false
+		}
+	}
+	return true
+}
+
+// embeddedPackRegistry maps pack names to their embedded Gazetteer loaded from
+// the embedded file system. Packs are loaded lazily by loadEmbeddedPack and
+// cached here.
+var embeddedPackRegistry = map[string]string{
+	"company-forms": "gazetteer_packs/company-forms.txt",
+	"de-cities":     "gazetteer_packs/de-cities.txt",
+}
+
+// loadEmbeddedPack loads a Gazetteer from an embedded pack file by name.
+// Returns an error for unknown pack names.
+func loadEmbeddedPack(name string) (Gazetteer, error) {
+	path, ok := embeddedPackRegistry[name]
+	if !ok {
+		return Gazetteer{}, fmt.Errorf("pii: gazetteer: unknown embedded pack %q", name)
+	}
+	f, err := embeddedPacks.Open(path)
+	if err != nil {
+		return Gazetteer{}, fmt.Errorf("pii: gazetteer: open embedded pack %q: %w", name, err)
+	}
+	defer f.Close()
+	return parseGazetteerFile(f, name)
+}
+
+// maxGazetteerFiles is the maximum total number of *.txt files read across
+// all loadGazetteerDir calls in one LoadGazetteerDetector invocation.
+// Exceeding this limit causes an error at startup so that a misconfigured
+// set of directories (e.g. pointing at /usr/share) fails fast rather than
+// reading thousands of files before the trie cap fires.
+const maxGazetteerFiles = 256
+
+// maxGazetteerBytes is the maximum total byte volume read across all files
+// in all loadGazetteerDir calls in one LoadGazetteerDetector invocation
+// (64 MiB). Together with maxGazetteerFiles this bounds the startup I/O
+// surface for operator-supplied gazetteer directories.
+const maxGazetteerBytes = 64 << 20 // 64 MiB
+
+// loadGazetteerDir reads every *.txt regular file in dir and appends the
+// resulting Gazetteers to *out. The shared counters *fileCount and
+// *totalBytes are incremented as files are processed; both limits are
+// enforced globally across all directories in a single loader run.
+//
+// Returns an error if dir does not exist, cannot be read, the cumulative
+// number of *.txt files across all dirs exceeds maxGazetteerFiles, or the
+// cumulative byte volume exceeds maxGazetteerBytes.
+func loadGazetteerDir(dir string, out *[]Gazetteer, fileCount *int, totalBytes *int64) error {
+	info, err := os.Stat(dir)
+	if err != nil {
+		return fmt.Errorf("pii: gazetteer: dir %q: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("pii: gazetteer: %q is not a directory", dir)
+	}
+
+	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		// FIX 3: skip symlinks and any non-regular file (FIFOs, devices,
+		// sockets). Symlinks are excluded explicitly to prevent an operator
+		// from pointing a symlink into a sensitive path that bypasses the
+		// byte-volume cap. FIFOs and device files would stall os.Open
+		// indefinitely at startup.
+		//
+		// d.Type() returns the file-mode type bits. A regular file has no
+		// type bits set (Type() == 0); a symlink has ModeSymlink set;
+		// FIFOs, sockets, and devices have their own bits. We use
+		// d.Type().IsRegular() (i.e. Type() == 0) as the affirmative check
+		// so that any future special-file type is also skipped by default.
+		if !d.Type().IsRegular() {
+			return nil
+		}
+
+		if !strings.HasSuffix(d.Name(), ".txt") {
+			return nil
+		}
+
+		*fileCount++
+		if *fileCount > maxGazetteerFiles {
+			return fmt.Errorf("pii: gazetteer: directory exceeds %d file limit", maxGazetteerFiles)
+		}
+
+		// Use d.Info() for the file size. Since we confirmed the entry is a
+		// regular file above, Info() reflects the file itself, not a symlink
+		// target, and will not block on a FIFO.
+		fi, statErr := d.Info()
+		if statErr != nil {
+			return fmt.Errorf("pii: gazetteer: stat %q: %w", path, statErr)
+		}
+		*totalBytes += fi.Size()
+		if *totalBytes > maxGazetteerBytes {
+			return fmt.Errorf("pii: gazetteer: directory exceeds %d byte limit", maxGazetteerBytes)
+		}
+
+		f, openErr := os.Open(path)
+		if openErr != nil {
+			return fmt.Errorf("pii: gazetteer: open %q: %w", path, openErr)
+		}
+		defer f.Close()
+
+		name := strings.TrimSuffix(d.Name(), ".txt")
+		g, parseErr := parseGazetteerFile(f, name)
+		if parseErr != nil {
+			return fmt.Errorf("pii: gazetteer: parse %q: %w", path, parseErr)
+		}
+		*out = append(*out, g)
+		return nil
+	})
+}
+
+// parseGazetteerFile reads a gazetteer text file from r and returns a Gazetteer.
+// The file format is:
+//
+//	# locale: <locale>   (optional comment header)
+//	# type: <TYPE>       (required comment header; sets the PII type)
+//	<term>               (one term per line)
+//	# <comment>          (ignored)
+//	                     (blank lines ignored)
+//
+// The name parameter sets Gazetteer.Name. The type parsed from a "# type:"
+// header (uppercased) is required — a file with an empty or missing "# type:"
+// header is considered malformed and returns an error. This is consistent with
+// inline-term validation in LoadGazetteerDetector, which also rejects empty types.
+func parseGazetteerFile(r io.Reader, name string) (Gazetteer, error) {
+	g := Gazetteer{
+		Name: name,
+	}
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "#") {
+			// Parse metadata headers.
+			rest := strings.TrimSpace(line[1:])
+			if strings.HasPrefix(rest, "locale:") {
+				g.Locale = strings.TrimSpace(rest[len("locale:"):])
+			} else if strings.HasPrefix(rest, "type:") {
+				g.Type = strings.TrimSpace(strings.ToUpper(rest[len("type:"):]))
+			}
+			continue
+		}
+		g.Terms = append(g.Terms, line)
+	}
+	if err := scanner.Err(); err != nil {
+		return Gazetteer{}, fmt.Errorf("pii: gazetteer: scan: %w", err)
+	}
+	// FIX 5: reject files with an empty or missing # type: header. An empty
+	// type would create anonymous spans whose pseudonyms collide across types
+	// and whose meaning is undefined. Consistent with inline-term validation
+	// which also rejects empty types.
+	if g.Type == "" {
+		return Gazetteer{}, fmt.Errorf("pii: gazetteer: file %q: missing or empty '# type:' header", name)
+	}
+	return g, nil
+}

--- a/internal/pii/gazetteer_load.go
+++ b/internal/pii/gazetteer_load.go
@@ -1,0 +1,84 @@
+package pii
+
+import (
+	"fmt"
+
+	"github.com/voidmind-io/voidllm/internal/config"
+)
+
+// maxGazetteerInlineTerms is the maximum total number of term values that may
+// be provided across all inline config entries in a single LoadGazetteerDetector
+// call. Exceeding this cap causes a startup error (fail-closed) so that a
+// misconfigured inline section cannot exhaust memory before the trie state cap
+// fires.
+const maxGazetteerInlineTerms = 100_000
+
+// LoadGazetteerDetector constructs a GazetteerDetector from the three sources
+// described in the config: embedded packs, operator directories, and inline
+// terms. All sources are merged into a single Aho-Corasick automaton.
+//
+// Source priority: all sources contribute equally; deduplication is applied
+// across all of them by (normalized-term, type) pair inside
+// NewGazetteerDetector.
+//
+// Global load limits (FIX 4): the file count and byte volume caps are enforced
+// across ALL operator directories in a single call, not per-directory. The
+// inline term count is also bounded globally.
+//
+// Returns an error on any of:
+//   - unknown embedded pack name
+//   - nonexistent or unreadable directory
+//   - empty or missing type in pack files or inline terms
+//   - too many files or bytes across all operator directories
+//   - too many inline terms
+//   - too many trie states (exceeds maxGazetteerStates)
+//   - too many output-link entries (exceeds maxGazetteerOutputs)
+func LoadGazetteerDetector(cfg config.PIIGazetteerConfig) (*GazetteerDetector, error) {
+	var gazes []Gazetteer
+
+	// 1. Embedded packs selected by name.
+	for _, packName := range cfg.Packs {
+		g, err := loadEmbeddedPack(packName)
+		if err != nil {
+			return nil, fmt.Errorf("pii: gazetteer: load pack %q: %w", packName, err)
+		}
+		gazes = append(gazes, g)
+	}
+
+	// 2. Operator directories — global counters threaded across all dirs.
+	var (
+		globalFileCount  int
+		globalTotalBytes int64
+	)
+	for _, dir := range cfg.Dirs {
+		if err := loadGazetteerDir(dir, &gazes, &globalFileCount, &globalTotalBytes); err != nil {
+			return nil, fmt.Errorf("pii: gazetteer: load dir %q: %w", dir, err)
+		}
+	}
+
+	// 3. Inline config terms — count total values across all entries.
+	inlineTermCount := 0
+	for i, entry := range cfg.Terms {
+		if entry.Type == "" {
+			return nil, fmt.Errorf("pii: gazetteer: settings.pii.gazetteer.terms[%d].type: must not be empty", i)
+		}
+		if len(entry.Values) == 0 {
+			continue
+		}
+		inlineTermCount += len(entry.Values)
+		if inlineTermCount > maxGazetteerInlineTerms {
+			return nil, fmt.Errorf("pii: gazetteer: inline terms exceed %d entry limit (reduce settings.pii.gazetteer.terms)", maxGazetteerInlineTerms)
+		}
+		gazes = append(gazes, Gazetteer{
+			Name:  fmt.Sprintf("inline[%d]", i),
+			Type:  entry.Type,
+			Terms: entry.Values,
+		})
+	}
+
+	opts := GazetteerOptions{
+		CaseInsensitive: cfg.Options.IsCaseInsensitive(),
+	}
+
+	return NewGazetteerDetector(gazes, opts)
+}

--- a/internal/pii/gazetteer_packs/company-forms.txt
+++ b/internal/pii/gazetteer_packs/company-forms.txt
@@ -1,0 +1,89 @@
+# locale: universal
+# type: ORG
+#
+# Universal legal entity suffixes and company form abbreviations.
+# These are near-zero false-positive identifiers: they appear in natural text
+# only as part of a legal entity name and almost never as standalone words.
+# The list covers the major European and Anglo-Saxon jurisdictions.
+#
+# Germany / Austria / Switzerland
+GmbH
+mbH
+GmbH & Co. KG
+GmbH & Co KG
+AG
+UG
+gUG
+KG
+OHG
+e.V.
+e.K.
+PartG
+PartGmbB
+KGaA
+# European Union
+SE
+SCE
+EWIV
+# United Kingdom / Ireland / Commonwealth
+Ltd
+Ltd.
+Limited
+PLC
+Plc
+LLP
+CIC
+# United States / Canada
+Inc
+Inc.
+LLC
+L.L.C.
+Corp
+Corp.
+Corporation
+LP
+L.P.
+# France
+S.A.S.
+SAS
+SARL
+S.A.R.L.
+S.A.
+SA
+SNC
+# Italy
+S.r.l.
+SRL
+S.p.A.
+SPA
+# Netherlands / Belgium
+B.V.
+BV
+N.V.
+NV
+# Finland
+Oy
+Oyj
+# Sweden
+AB
+# Denmark / Norway
+A/S
+# Australia
+Pty Ltd
+Pty. Ltd.
+# Poland
+Sp. z o.o.
+S.A.
+SA
+# Spain / Portugal
+S.L.
+SL
+S.A.
+# Switzerland
+GmbH
+AG
+# Luxembourg
+S.à r.l.
+# Czech Republic / Slovakia
+s.r.o.
+a.s.

--- a/internal/pii/gazetteer_packs/de-cities.txt
+++ b/internal/pii/gazetteer_packs/de-cities.txt
@@ -1,0 +1,82 @@
+# locale: de
+# type: CITY
+#
+# Curated set of unambiguous German city names for use as a template pack.
+# Only cities whose names are not common German words are included here to
+# minimise false positives. Avoid common-word cities such as "Essen", "Hof",
+# "Landsberg", "Neustadt", "Bad" (prefix), or "Berg" (suffix component).
+#
+# This pack is intentionally small. Operators should supplement it with their
+# own domain-specific gazetteer files via pii.gazetteer.dirs.
+Düsseldorf
+Dortmund
+Stuttgart
+Hannover
+Nürnberg
+Duisburg
+Bochum
+Wuppertal
+Bielefeld
+Bonn
+Mannheim
+Karlsruhe
+Wiesbaden
+Münster
+Augsburg
+Gelsenkirchen
+Mönchengladbach
+Braunschweig
+Chemnitz
+Kiel
+Aachen
+Magdeburg
+Freiburg im Breisgau
+Krefeld
+Lübeck
+Oberhausen
+Erfurt
+Mainz
+Rostock
+Kassel
+Hagen
+Hamm
+Saarbrücken
+Mülheim an der Ruhr
+Potsdam
+Ludwigshafen am Rhein
+Oldenburg
+Leverkusen
+Osnabrück
+Solingen
+Heidelberg
+Darmstadt
+Regensburg
+Ingolstadt
+Würzburg
+Fürth
+Wolfsburg
+Ulm
+Heilbronn
+Pforzheim
+Göttingen
+Bottrop
+Trier
+Recklinghausen
+Bremerhaven
+Jena
+Remscheid
+Erlangen
+Moers
+Siegen
+Salzgitter
+Gütersloh
+Hildesheim
+Kaiserslautern
+Cottbus
+Gera
+Iserlohn
+Schwerin
+Witten
+Zwickau
+Dessau
+Wilhelmshaven

--- a/internal/pii/gazetteer_stage1a_test.go
+++ b/internal/pii/gazetteer_stage1a_test.go
@@ -1,0 +1,1492 @@
+package pii
+
+// gazetteer_stage1a_test.go covers the PII Stage 1a (gazetteer detector)
+// feature introduced on feat/pii-stage1-gazetteer.  Tests are grouped by
+// the component under test:
+//
+//   - Aho-Corasick automaton (ahocorasick.go)
+//   - GazetteerDetector.Find (gazetteer.go)
+//   - Loader + embedded packs (gazetteer_load.go, parseGazetteerFile)
+//   - Pseudonym helpers (pseudonym.go)
+//   - End-to-end pipeline (Engine + GazetteerDetector + RegexDetector)
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/voidmind-io/voidllm/internal/config"
+)
+
+// ── Aho-Corasick automaton ────────────────────────────────────────────────────
+
+// TestAC_SingleTerm verifies that a single-term dictionary finds one match.
+func TestAC_SingleTerm(t *testing.T) {
+	t.Parallel()
+
+	m, err := newACMatcher([]acTerm{{norm: "gmbh", typ: "ORG"}})
+	if err != nil {
+		t.Fatalf("newACMatcher: %v", err)
+	}
+	matches := m.match([]rune("acme gmbh corp"))
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d: %+v", len(matches), matches)
+	}
+	if m.terms[matches[0].termIdx].norm != "gmbh" {
+		t.Errorf("matched term = %q, want %q", m.terms[matches[0].termIdx].norm, "gmbh")
+	}
+}
+
+// TestAC_MultipleTerms verifies that all three dictionary terms are found in a
+// single pass over the input.
+func TestAC_MultipleTerms(t *testing.T) {
+	t.Parallel()
+
+	terms := []acTerm{
+		{norm: "gmbh", typ: "ORG"},
+		{norm: "ag", typ: "ORG"},
+		{norm: "berlin", typ: "CITY"},
+	}
+	m, err := newACMatcher(terms)
+	if err != nil {
+		t.Fatalf("newACMatcher: %v", err)
+	}
+
+	matches := m.match([]rune("acme gmbh und berlin ag"))
+	found := make(map[string]bool)
+	for _, match := range matches {
+		found[m.terms[match.termIdx].norm] = true
+	}
+
+	for _, want := range []string{"gmbh", "ag", "berlin"} {
+		if !found[want] {
+			t.Errorf("expected to find term %q, but did not; all found: %v", want, found)
+		}
+	}
+}
+
+// TestAC_OverlappingDictionaryTerms verifies that when dictionary terms overlap
+// (e.g. "ag" is a suffix of "gmbh & co. kg"), both are reported by the raw
+// automaton (it is the Find() caller's job to filter, not the automaton's).
+func TestAC_OverlappingDictionaryTerms(t *testing.T) {
+	t.Parallel()
+
+	// "kg" is a suffix of "gmbh & co. kg"; both should be raw-reported.
+	terms := []acTerm{
+		{norm: "gmbh & co. kg", typ: "ORG"},
+		{norm: "kg", typ: "ORG"},
+	}
+	m, err := newACMatcher(terms)
+	if err != nil {
+		t.Fatalf("newACMatcher: %v", err)
+	}
+
+	runes := []rune("foo gmbh & co. kg bar")
+	matches := m.match(runes)
+
+	found := make(map[string]bool)
+	for _, match := range matches {
+		found[m.terms[match.termIdx].norm] = true
+	}
+	// Both "gmbh & co. kg" and "kg" appear as raw automaton hits.
+	if !found["gmbh & co. kg"] {
+		t.Error("expected raw match for 'gmbh & co. kg', but did not find it")
+	}
+	if !found["kg"] {
+		t.Error("expected raw match for 'kg', but did not find it")
+	}
+}
+
+// TestAC_SuffixPrefixInDictionary verifies that "berg" is found when it appears
+// inside "bergmann", demonstrating that the raw automaton reports all hits
+// (word-boundary filtering is done by Find(), not by match()).
+func TestAC_SuffixPrefixInDictionary(t *testing.T) {
+	t.Parallel()
+
+	terms := []acTerm{
+		{norm: "berg", typ: "CITY"},
+		{norm: "bergmann", typ: "NAME"},
+	}
+	m, err := newACMatcher(terms)
+	if err != nil {
+		t.Fatalf("newACMatcher: %v", err)
+	}
+
+	runes := []rune("bergmann")
+	matches := m.match(runes)
+
+	found := make(map[string]bool)
+	for _, match := range matches {
+		found[m.terms[match.termIdx].norm] = true
+	}
+	// Raw automaton finds both "berg" (suffix of bergmann) and "bergmann".
+	if !found["berg"] {
+		t.Error("raw automaton: expected to find 'berg' inside 'bergmann'")
+	}
+	if !found["bergmann"] {
+		t.Error("raw automaton: expected to find 'bergmann' when the whole input is 'bergmann'")
+	}
+}
+
+// TestAC_NoMatch verifies that no matches are reported for an input that
+// contains none of the dictionary terms.
+func TestAC_NoMatch(t *testing.T) {
+	t.Parallel()
+
+	m, err := newACMatcher([]acTerm{{norm: "gmbh", typ: "ORG"}})
+	if err != nil {
+		t.Fatalf("newACMatcher: %v", err)
+	}
+	matches := m.match([]rune("nothing here"))
+	if len(matches) != 0 {
+		t.Errorf("expected 0 matches, got %d: %+v", len(matches), matches)
+	}
+}
+
+// TestAC_EmptyInput verifies that an empty rune slice produces no matches.
+func TestAC_EmptyInput(t *testing.T) {
+	t.Parallel()
+
+	m, err := newACMatcher([]acTerm{{norm: "gmbh", typ: "ORG"}})
+	if err != nil {
+		t.Fatalf("newACMatcher: %v", err)
+	}
+	if got := m.match([]rune{}); len(got) != 0 {
+		t.Errorf("empty input: expected 0 matches, got %d", len(got))
+	}
+	if got := m.match(nil); len(got) != 0 {
+		t.Errorf("nil input: expected 0 matches, got %d", len(got))
+	}
+}
+
+// TestAC_EmptyDictionary verifies that a zero-term automaton produces no
+// matches and does not panic.
+func TestAC_EmptyDictionary(t *testing.T) {
+	t.Parallel()
+
+	m, err := newACMatcher(nil)
+	if err != nil {
+		t.Fatalf("newACMatcher(nil): %v", err)
+	}
+	if got := m.match([]rune("anything")); len(got) != 0 {
+		t.Errorf("empty dictionary: expected 0 matches, got %d", len(got))
+	}
+}
+
+// TestAC_MemoryCap verifies that newACMatcher returns a non-nil error (and
+// never panics) when the dictionary would push the state count past
+// maxGazetteerStates.
+func TestAC_MemoryCap(t *testing.T) {
+	t.Parallel()
+
+	// Build terms whose combined unique rune paths are designed to fill the
+	// trie far faster than maxGazetteerStates terms would suggest.  Each
+	// term uses a unique 6-character prefix derived from its index so that
+	// the trie cannot share states between terms until the state limit fires.
+	// With base-26 encoding, 26^6 = 308 million possible terms, so we can
+	// safely pick a count that guarantees we hit the cap well before running
+	// out of unique prefixes.
+	//
+	// The cap is 500 000 states.  With 6-rune unique prefixes we need at
+	// most 500 000 / 6 ≈ 83 334 terms to guarantee a cap.  Use 100 000 to
+	// be certain.
+	const n = 100_000
+	const alpha = "abcdefghijklmnopqrstuvwxyz"
+
+	terms := make([]acTerm, n)
+	for i := 0; i < n; i++ {
+		b := make([]byte, 6)
+		idx := i
+		for j := 5; j >= 0; j-- {
+			b[j] = alpha[idx%len(alpha)]
+			idx /= len(alpha)
+		}
+		// Append a unique suffix so no two terms share a complete path.
+		terms[i] = acTerm{norm: string(b) + fmt.Sprintf("%d", i), typ: "TEST"}
+	}
+
+	_, err := newACMatcher(terms)
+	if err == nil {
+		// It is theoretically possible that path-sharing keeps us under the
+		// cap; treat this as a note rather than a hard failure so the test
+		// does not become flaky.  What matters is that there was NO PANIC.
+		t.Log("note: state cap not triggered; test confirms no panic but not the error path")
+	} else {
+		if !strings.Contains(err.Error(), "trie exceeds") {
+			t.Errorf("expected cap error, got: %v", err)
+		}
+	}
+}
+
+// TestAC_MemoryCap_Triggers ensures the cap error is returned for a dictionary
+// that definitely exceeds the limit.  We build all terms up front and call
+// newACMatcher exactly once so the test runs in O(n) time rather than O(n²).
+//
+// Strategy: each term is a two-character string "prefix + unique-letter" where
+// the prefix is a fixed non-ASCII rune.  Every term therefore has an entirely
+// unique second character, contributing exactly one new state per term (the
+// root-level node for the prefix rune is shared, but the second-level node is
+// new for each term).  We need maxGazetteerStates+1 terms.  We use lowercase
+// ASCII letters for the unique character to avoid the Unicode surrogate range.
+//
+// State budget: 1 (root) + 1 (shared prefix rune) + n (unique suffixes).
+// With n = maxGazetteerStates, total would be maxGazetteerStates + 2, and the
+// cap fires when len(states) reaches maxGazetteerStates.
+//
+// To stay clear of the surrogate range entirely we encode the index in
+// base-62 (a-z A-Z 0-9), packing up to 3 characters per term.  With
+// 3 characters we have 62^3 > 238 000 unique terms per prefix rune.
+// Using two distinct prefix runes gives 476 000+ unique 4-char paths,
+// comfortably exceeding the 500 000 cap.
+func TestAC_MemoryCap_Triggers(t *testing.T) {
+	t.Parallel()
+
+	// Encode i as a base-62 string using only plain ASCII printable chars,
+	// avoiding any Unicode surrogate-range values.
+	const alphabet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	encode := func(i int) string {
+		if i == 0 {
+			return "a"
+		}
+		b := make([]byte, 0, 4)
+		for i > 0 {
+			b = append(b, alphabet[i%len(alphabet)])
+			i /= len(alphabet)
+		}
+		// Reverse.
+		for l, r := 0, len(b)-1; l < r; l, r = l+1, r-1 {
+			b[l], b[r] = b[r], b[l]
+		}
+		return string(b)
+	}
+
+	// Build maxGazetteerStates + 1 terms.  Each term is a unique ASCII string,
+	// so every character along the path adds a new trie state.  We use
+	// short (1-4 char) strings derived from the counter, which guarantees
+	// no two terms share a complete trie path.
+	n := maxGazetteerStates + 1
+	terms := make([]acTerm, n)
+	for i := 0; i < n; i++ {
+		// Prefix with 'x' so 1-char codes don't collide with 2-char codes.
+		terms[i] = acTerm{norm: "x" + encode(i), typ: "TEST"}
+	}
+
+	_, err := newACMatcher(terms)
+	if err == nil {
+		t.Error("expected state-cap error for maxGazetteerStates+1 terms, got nil")
+		return
+	}
+	if !strings.Contains(err.Error(), "trie exceeds") {
+		t.Errorf("expected cap error containing 'trie exceeds', got: %v", err)
+	}
+}
+
+// ── GazetteerDetector.Find: whole-token boundary ──────────────────────────────
+
+// TestFind_WholeTokenBoundary is the authoritative test for the word-boundary
+// filter.  Dictionary has "Berg"; input contains "Bergmann" (no match) and
+// standalone "Berg" (match).  Exact byte Start/End are asserted.
+func TestFind_WholeTokenBoundary(t *testing.T) {
+	t.Parallel()
+
+	det, err := NewGazetteerDetector(
+		[]Gazetteer{{Name: "t", Type: "CITY", Terms: []string{"Berg"}}},
+		GazetteerOptions{CaseInsensitive: true},
+	)
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	// "Bergmann fuhr nach Berg."
+	//  0123456789...
+	//  B=0, e=1, r=2, g=3, m=4, a=5, n=6, n=7, ' '=8, ...
+	//  "Berg." at end: "Bergmann fuhr nach Berg."
+	text := "Bergmann fuhr nach Berg."
+
+	spans, err := det.Find(text)
+	if err != nil {
+		t.Fatalf("Find: unexpected error: %v", err)
+	}
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span (standalone Berg only), got %d: %+v", len(spans), spans)
+	}
+
+	wantStart := strings.Index(text, " Berg.") + 1 // skip the leading space
+	wantEnd := wantStart + len("Berg")
+
+	if spans[0].Start != wantStart {
+		t.Errorf("span.Start = %d, want %d", spans[0].Start, wantStart)
+	}
+	if spans[0].End != wantEnd {
+		t.Errorf("span.End = %d, want %d", spans[0].End, wantEnd)
+	}
+	if spans[0].Type != "CITY" {
+		t.Errorf("span.Type = %q, want %q", spans[0].Type, "CITY")
+	}
+	// Verify the slice is correct.
+	if got := text[spans[0].Start:spans[0].End]; got != "Berg" {
+		t.Errorf("text[span] = %q, want %q", got, "Berg")
+	}
+}
+
+// TestFind_ByteOffsetWithMultibytePrefix verifies that Span byte offsets are
+// correct even when multibyte UTF-8 characters appear before the matched term.
+func TestFind_ByteOffsetWithMultibytePrefix(t *testing.T) {
+	t.Parallel()
+
+	// "Grüße an München" — "ü" is 2 bytes, "ß" is 2 bytes, "ü" in München
+	// is 2 bytes.  The critical check: text[span.Start:span.End] == "München".
+	det, err := NewGazetteerDetector(
+		[]Gazetteer{{Name: "t", Type: "CITY", Terms: []string{"München"}}},
+		GazetteerOptions{CaseInsensitive: true},
+	)
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	text := "Grüße an München"
+	spans, err := det.Find(text)
+	if err != nil {
+		t.Fatalf("Find: unexpected error: %v", err)
+	}
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d: %+v", len(spans), spans)
+	}
+
+	got := text[spans[0].Start:spans[0].End]
+	if got != "München" {
+		t.Errorf("text[span.Start:span.End] = %q, want %q", got, "München")
+	}
+	if spans[0].Type != "CITY" {
+		t.Errorf("span.Type = %q, want CITY", spans[0].Type)
+	}
+}
+
+// TestFind_ByteOffsetWithEmoji verifies byte-offset correctness when a
+// multibyte emoji (4 bytes in UTF-8) precedes the matched term.
+func TestFind_ByteOffsetWithEmoji(t *testing.T) {
+	t.Parallel()
+
+	det, err := NewGazetteerDetector(
+		[]Gazetteer{{Name: "t", Type: "ORG", Terms: []string{"GmbH"}}},
+		GazetteerOptions{CaseInsensitive: true},
+	)
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	// U+1F600 GRINNING FACE is 4 bytes in UTF-8.
+	text := "\U0001F600 Acme GmbH"
+	spans, err := det.Find(text)
+	if err != nil {
+		t.Fatalf("Find: unexpected error: %v", err)
+	}
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d: %+v", len(spans), spans)
+	}
+
+	got := text[spans[0].Start:spans[0].End]
+	if got != "GmbH" {
+		t.Errorf("text[span.Start:span.End] = %q, want %q", got, "GmbH")
+	}
+}
+
+// TestFind_CaseInsensitiveUppercase verifies that upper-case input matches a
+// mixed-case dictionary term when CaseInsensitive is true.
+func TestFind_CaseInsensitiveUppercase(t *testing.T) {
+	t.Parallel()
+
+	det, err := NewGazetteerDetector(
+		[]Gazetteer{{Name: "t", Type: "CITY", Terms: []string{"München"}}},
+		GazetteerOptions{CaseInsensitive: true},
+	)
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	// All-caps form must be matched.
+	text := "Büro in MÜNCHEN"
+	spans, err := det.Find(text)
+	if err != nil {
+		t.Fatalf("Find: unexpected error: %v", err)
+	}
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span for MÜNCHEN, got %d: %+v", len(spans), spans)
+	}
+	// The returned Span must slice the ORIGINAL-case text.
+	got := text[spans[0].Start:spans[0].End]
+	if got != "MÜNCHEN" {
+		t.Errorf("span slices %q, want %q (original-case)", got, "MÜNCHEN")
+	}
+
+	// Lower-case form must also be matched.
+	text2 := "Büro in münchen"
+	spans2, err2 := det.Find(text2)
+	if err2 != nil {
+		t.Fatalf("Find (text2): unexpected error: %v", err2)
+	}
+	if len(spans2) != 1 {
+		t.Fatalf("expected 1 span for münchen, got %d: %+v", len(spans2), spans2)
+	}
+	if got2 := text2[spans2[0].Start:spans2[0].End]; got2 != "münchen" {
+		t.Errorf("span slices %q, want %q", got2, "münchen")
+	}
+}
+
+// TestFind_CaseSensitiveExactOnly verifies that CaseInsensitive:false only
+// matches exact-case terms.
+func TestFind_CaseSensitiveExactOnly(t *testing.T) {
+	t.Parallel()
+
+	det, err := NewGazetteerDetector(
+		[]Gazetteer{{Name: "t", Type: "CITY", Terms: []string{"München"}}},
+		GazetteerOptions{CaseInsensitive: false},
+	)
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	// "münchen" (all-lower) must NOT match when case-sensitive.
+	if spans, err := det.Find("Büro in münchen"); err != nil || len(spans) != 0 {
+		t.Errorf("case-sensitive: did not expect match for lowercase 'münchen', got %+v err=%v", spans, err)
+	}
+	// "MÜNCHEN" must NOT match.
+	if spans, err := det.Find("Büro in MÜNCHEN"); err != nil || len(spans) != 0 {
+		t.Errorf("case-sensitive: did not expect match for uppercase 'MÜNCHEN', got %+v err=%v", spans, err)
+	}
+	// Exact original form must match.
+	text := "Büro in München"
+	spans, err := det.Find(text)
+	if err != nil {
+		t.Fatalf("Find: unexpected error: %v", err)
+	}
+	if len(spans) != 1 {
+		t.Fatalf("case-sensitive: expected 1 span for exact 'München', got %d", len(spans))
+	}
+	if got := text[spans[0].Start:spans[0].End]; got != "München" {
+		t.Errorf("span slices %q, want %q", got, "München")
+	}
+}
+
+// TestFind_CaseFoldingOffsetAlignment is the critical edge-case test for offset
+// alignment when the input contains characters whose Unicode ToLower mapping
+// changes byte length or rune count.
+//
+// The Turkish dotted capital I (U+0130, "İ") lowercases to a 2-rune sequence
+// "i" + combining dot above (U+0069 + U+0307) in some locales, but
+// unicode.ToLower in Go maps it to the single rune U+0069 ("i"), preserving
+// a 1:1 rune correspondence.  This test verifies that a term AFTER "İ" in the
+// input still gets correct byte offsets regardless of how ToLower handles "İ".
+//
+// We also test "ß" (2 bytes in UTF-8), which lowercases to itself, so no
+// alignment issue is expected — but we assert it explicitly as a regression
+// anchor.
+func TestFind_CaseFoldingOffsetAlignment(t *testing.T) {
+	t.Parallel()
+
+	det, err := NewGazetteerDetector(
+		[]Gazetteer{{Name: "t", Type: "ORG", Terms: []string{"GmbH"}}},
+		GazetteerOptions{CaseInsensitive: true},
+	)
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		text      string
+		wantSlice string
+	}{
+		{
+			// U+0130 "İ" is 2 bytes (C4 B0) in UTF-8; followed by " GmbH".
+			name:      "turkish dotted I before GmbH",
+			text:      "İstanbul GmbH",
+			wantSlice: "GmbH",
+		},
+		{
+			// U+00DF "ß" is 2 bytes (C3 9F) in UTF-8.
+			name:      "german sharp s before GmbH",
+			text:      "Straße GmbH",
+			wantSlice: "GmbH",
+		},
+		{
+			// Combining character after "İ": ensure the byte/rune table is
+			// built from origRunes (not scanRunes), so the offset is stable.
+			name:      "multiple multibyte chars before GmbH",
+			text:      "Ö Ü Ä GmbH",
+			wantSlice: "GmbH",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			spans, err := det.Find(tc.text)
+			if err != nil {
+				t.Fatalf("Find: unexpected error: %v", err)
+			}
+			if len(spans) != 1 {
+				t.Fatalf("expected 1 span, got %d: %+v", len(spans), spans)
+			}
+			got := tc.text[spans[0].Start:spans[0].End]
+			if got != tc.wantSlice {
+				t.Errorf("text[span.Start:span.End] = %q, want %q (offset misalignment)", got, tc.wantSlice)
+			}
+		})
+	}
+}
+
+// TestFind_MultipleTypes verifies that a single detector built from multiple
+// gazetteers assigns the correct Type to each span.
+func TestFind_MultipleTypes(t *testing.T) {
+	t.Parallel()
+
+	det, err := NewGazetteerDetector(
+		[]Gazetteer{
+			{Name: "org", Type: "ORG", Terms: []string{"GmbH", "AG"}},
+			{Name: "city", Type: "CITY", Terms: []string{"Berlin", "Hamburg"}},
+		},
+		GazetteerOptions{CaseInsensitive: true},
+	)
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	text := "Acme GmbH sitzt in Berlin."
+	spans, err := det.Find(text)
+	if err != nil {
+		t.Fatalf("Find: unexpected error: %v", err)
+	}
+	if len(spans) != 2 {
+		t.Fatalf("expected 2 spans, got %d: %+v", len(spans), spans)
+	}
+
+	// Build a map of matched text → type for assertions.
+	got := make(map[string]string)
+	for _, sp := range spans {
+		got[text[sp.Start:sp.End]] = sp.Type
+	}
+	if got["GmbH"] != "ORG" {
+		t.Errorf("GmbH type = %q, want ORG", got["GmbH"])
+	}
+	if got["Berlin"] != "CITY" {
+		t.Errorf("Berlin type = %q, want CITY", got["Berlin"])
+	}
+}
+
+// TestFind_OverlapResolution_LeftmostLongest verifies that when two dictionary
+// terms overlap at the same start position, the longest one wins.
+func TestFind_OverlapResolution_LeftmostLongest(t *testing.T) {
+	t.Parallel()
+
+	// "gmbh & co. kg" and "gmbh" both start at the same position; the
+	// longer form must win.
+	det, err := NewGazetteerDetector(
+		[]Gazetteer{{Name: "t", Type: "ORG", Terms: []string{"GmbH & Co. KG", "GmbH"}}},
+		GazetteerOptions{CaseInsensitive: true},
+	)
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	text := "Foo GmbH & Co. KG ist eine Firma."
+	spans, err := det.Find(text)
+	if err != nil {
+		t.Fatalf("Find: unexpected error: %v", err)
+	}
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span (longest wins), got %d: %+v", len(spans), spans)
+	}
+	got := text[spans[0].Start:spans[0].End]
+	if got != "GmbH & Co. KG" {
+		t.Errorf("span = %q, want %q", got, "GmbH & Co. KG")
+	}
+}
+
+// TestFind_ConcurrentFindRace runs many goroutines calling Find on a shared
+// detector simultaneously.  Must be run with -race to catch data races.
+func TestFind_ConcurrentFindRace(t *testing.T) {
+	t.Parallel()
+
+	det, err := NewGazetteerDetector(
+		[]Gazetteer{
+			{Name: "org", Type: "ORG", Terms: []string{"GmbH", "AG", "Ltd"}},
+			{Name: "city", Type: "CITY", Terms: []string{"Berlin", "Hamburg", "München"}},
+		},
+		GazetteerOptions{CaseInsensitive: true},
+	)
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	const goroutines = 50
+	text := "Acme GmbH und Bar AG wohnen in Berlin und Hamburg."
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			spans, findErr := det.Find(text)
+			if findErr != nil {
+				t.Errorf("concurrent Find: unexpected error: %v", findErr)
+				return
+			}
+			// Expect GmbH, AG, Berlin, Hamburg — 4 spans.
+			if len(spans) != 4 {
+				// Use t.Errorf, not t.Fatalf; goroutines cannot call Fatal.
+				t.Errorf("concurrent Find: expected 4 spans, got %d: %+v", len(spans), spans)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestFind_MultiLocale verifies that terms from two different locale packs
+// (simulated as gazetteers with different names) are both found in one call.
+func TestFind_MultiLocale(t *testing.T) {
+	t.Parallel()
+
+	// Simulate a "de" pack and a custom "fr" operator pack.
+	det, err := NewGazetteerDetector(
+		[]Gazetteer{
+			{Name: "de-companies", Locale: "de", Type: "ORG", Terms: []string{"GmbH", "AG"}},
+			{Name: "fr-companies", Locale: "fr", Type: "ORG", Terms: []string{"SAS", "SARL"}},
+		},
+		GazetteerOptions{CaseInsensitive: true},
+	)
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	text := "Foo GmbH und Bar SAS sind Partner."
+	spans, err := det.Find(text)
+	if err != nil {
+		t.Fatalf("Find: unexpected error: %v", err)
+	}
+	if len(spans) != 2 {
+		t.Fatalf("expected 2 spans (de+fr), got %d: %+v", len(spans), spans)
+	}
+
+	matched := make(map[string]bool)
+	for _, sp := range spans {
+		matched[text[sp.Start:sp.End]] = true
+	}
+	if !matched["GmbH"] {
+		t.Error("expected GmbH (de pack) to match")
+	}
+	if !matched["SAS"] {
+		t.Error("expected SAS (fr pack) to match")
+	}
+}
+
+// TestFind_EmptyInputAndEmptyDict verifies edge cases do not panic.
+func TestFind_EmptyInputAndEmptyDict(t *testing.T) {
+	t.Parallel()
+
+	// Empty dictionary, non-empty input.
+	det, err := NewGazetteerDetector(nil, GazetteerOptions{CaseInsensitive: true})
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector(nil): %v", err)
+	}
+	if spans, findErr := det.Find("some text"); findErr != nil || len(spans) != 0 {
+		t.Errorf("empty dict: expected 0 spans, got %d err=%v", len(spans), findErr)
+	}
+
+	// Non-empty dictionary, empty input.
+	det2, err := NewGazetteerDetector(
+		[]Gazetteer{{Name: "t", Type: "ORG", Terms: []string{"GmbH"}}},
+		GazetteerOptions{CaseInsensitive: true},
+	)
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+	if spans, findErr := det2.Find(""); findErr != nil || len(spans) != 0 {
+		t.Errorf("empty input: expected 0 spans, got %d err=%v", len(spans), findErr)
+	}
+}
+
+// ── Loader + embedded packs ───────────────────────────────────────────────────
+
+// TestParseGazetteerFile_Full verifies all parsing features: locale header,
+// type header, blank lines, comments, and term extraction.
+func TestParseGazetteerFile_Full(t *testing.T) {
+	t.Parallel()
+
+	content := "# locale: de\n# type: CITY\n\n# A comment\nBerlin\nHamburg\n# another\nBremen\n"
+	g, err := parseGazetteerFile(strings.NewReader(content), "de-test")
+	if err != nil {
+		t.Fatalf("parseGazetteerFile: %v", err)
+	}
+	if g.Name != "de-test" {
+		t.Errorf("Name = %q, want %q", g.Name, "de-test")
+	}
+	if g.Locale != "de" {
+		t.Errorf("Locale = %q, want %q", g.Locale, "de")
+	}
+	if g.Type != "CITY" {
+		t.Errorf("Type = %q, want %q", g.Type, "CITY")
+	}
+	want := []string{"Berlin", "Hamburg", "Bremen"}
+	if len(g.Terms) != len(want) {
+		t.Fatalf("Terms = %v, want %v", g.Terms, want)
+	}
+	for i, w := range want {
+		if g.Terms[i] != w {
+			t.Errorf("Terms[%d] = %q, want %q", i, g.Terms[i], w)
+		}
+	}
+}
+
+// TestParseGazetteerFile_TypeUppercased verifies that the # type: header is
+// upper-cased before being stored.
+func TestParseGazetteerFile_TypeUppercased(t *testing.T) {
+	t.Parallel()
+
+	content := "# type: city\nBerlin\n"
+	g, err := parseGazetteerFile(strings.NewReader(content), "x")
+	if err != nil {
+		t.Fatalf("parseGazetteerFile: %v", err)
+	}
+	if g.Type != "CITY" {
+		t.Errorf("Type = %q, want CITY (type header should be uppercased)", g.Type)
+	}
+}
+
+// TestParseGazetteerFile_NoTypeHeader verifies that a missing # type: header
+// causes parseGazetteerFile to return an error (FIX 5). An empty or missing
+// type is malformed because it would produce PII spans with no type label,
+// breaking pseudonymization consistency.
+func TestParseGazetteerFile_NoTypeHeader(t *testing.T) {
+	t.Parallel()
+
+	content := "# locale: universal\nFoo\nBar\n"
+	_, err := parseGazetteerFile(strings.NewReader(content), "x")
+	if err == nil {
+		t.Fatal("expected error for missing # type: header, got nil")
+	}
+	if !strings.Contains(err.Error(), "type") {
+		t.Errorf("error should mention 'type', got: %v", err)
+	}
+}
+
+// TestParseGazetteerFile_BlankLinesAndComments verifies that blank lines and
+// comment-only lines are not included as terms.
+func TestParseGazetteerFile_BlankLinesAndComments(t *testing.T) {
+	t.Parallel()
+
+	// The file must include a # type: header (FIX 5: missing type is an error).
+	content := "# type: ENTITY\n\n# just comments\n\n# more comments\nActualTerm\n\n"
+	g, err := parseGazetteerFile(strings.NewReader(content), "x")
+	if err != nil {
+		t.Fatalf("parseGazetteerFile: %v", err)
+	}
+	if len(g.Terms) != 1 || g.Terms[0] != "ActualTerm" {
+		t.Errorf("Terms = %v, want [ActualTerm]", g.Terms)
+	}
+}
+
+// TestEmbeddedPack_CompanyForms verifies that the "company-forms" pack loads,
+// has Type ORG, and contains expected canonical terms.
+func TestEmbeddedPack_CompanyForms(t *testing.T) {
+	t.Parallel()
+
+	g, err := loadEmbeddedPack("company-forms")
+	if err != nil {
+		t.Fatalf("loadEmbeddedPack(company-forms): %v", err)
+	}
+	if g.Type != "ORG" {
+		t.Errorf("Type = %q, want ORG", g.Type)
+	}
+	if len(g.Terms) == 0 {
+		t.Fatal("company-forms pack has no terms")
+	}
+
+	// Check for a few expected entries.
+	want := map[string]bool{"GmbH": false, "AG": false, "Ltd": false, "Inc": false}
+	for _, term := range g.Terms {
+		if _, ok := want[term]; ok {
+			want[term] = true
+		}
+	}
+	for term, found := range want {
+		if !found {
+			t.Errorf("company-forms pack missing expected term %q", term)
+		}
+	}
+}
+
+// TestEmbeddedPack_DeCities verifies that the "de-cities" pack loads with
+// Type CITY and contains expected German city names.
+func TestEmbeddedPack_DeCities(t *testing.T) {
+	t.Parallel()
+
+	g, err := loadEmbeddedPack("de-cities")
+	if err != nil {
+		t.Fatalf("loadEmbeddedPack(de-cities): %v", err)
+	}
+	if g.Type != "CITY" {
+		t.Errorf("Type = %q, want CITY", g.Type)
+	}
+	if len(g.Terms) == 0 {
+		t.Fatal("de-cities pack has no terms")
+	}
+
+	want := map[string]bool{"Düsseldorf": false, "Dortmund": false, "Stuttgart": false}
+	for _, term := range g.Terms {
+		if _, ok := want[term]; ok {
+			want[term] = true
+		}
+	}
+	for term, found := range want {
+		if !found {
+			t.Errorf("de-cities pack missing expected term %q", term)
+		}
+	}
+}
+
+// TestEmbeddedPack_UnknownName verifies that an unknown pack name returns an error.
+func TestEmbeddedPack_UnknownName(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadEmbeddedPack("does-not-exist")
+	if err == nil {
+		t.Error("expected error for unknown pack name, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown embedded pack") {
+		t.Errorf("error should mention 'unknown embedded pack', got: %v", err)
+	}
+}
+
+// TestLoadGazetteerDir_TxtFiles verifies that a temp directory containing
+// *.txt gazetteer files is loaded correctly.
+func TestLoadGazetteerDir_TxtFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Write two gazetteer files.
+	file1 := "# locale: custom\n# type: ORG\nAcmeCorp\nFooBar Inc\n"
+	file2 := "# type: NAME\nAlice\nBob\n"
+	if err := os.WriteFile(filepath.Join(dir, "orgs.txt"), []byte(file1), 0o600); err != nil {
+		t.Fatalf("write orgs.txt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "names.txt"), []byte(file2), 0o600); err != nil {
+		t.Fatalf("write names.txt: %v", err)
+	}
+	// Non-.txt file must be ignored.
+	if err := os.WriteFile(filepath.Join(dir, "readme.md"), []byte("ignore me"), 0o600); err != nil {
+		t.Fatalf("write readme.md: %v", err)
+	}
+
+	var gazes []Gazetteer
+	var fc int
+	var tb int64
+	if err := loadGazetteerDir(dir, &gazes, &fc, &tb); err != nil {
+		t.Fatalf("loadGazetteerDir: %v", err)
+	}
+	if len(gazes) != 2 {
+		t.Fatalf("expected 2 gazetteers (one per .txt), got %d", len(gazes))
+	}
+
+	// Build a unified term set.
+	allTerms := make(map[string]bool)
+	for _, g := range gazes {
+		for _, term := range g.Terms {
+			allTerms[term] = true
+		}
+	}
+	for _, want := range []string{"AcmeCorp", "FooBar Inc", "Alice", "Bob"} {
+		if !allTerms[want] {
+			t.Errorf("expected term %q in loaded gazetteers, not found; all: %v", want, allTerms)
+		}
+	}
+}
+
+// TestLoadGazetteerDir_NonexistentDir verifies that a non-existent directory
+// returns an error.
+func TestLoadGazetteerDir_NonexistentDir(t *testing.T) {
+	t.Parallel()
+
+	var out []Gazetteer
+	var fc int
+	var tb int64
+	err := loadGazetteerDir("/absolutely/does/not/exist/12345", &out, &fc, &tb)
+	if err == nil {
+		t.Error("expected error for nonexistent dir, got nil")
+	}
+}
+
+// TestLoadGazetteerDetector_InlineTerms verifies that inline terms from
+// PIIGazetteerConfig are loaded and matched.
+func TestLoadGazetteerDetector_InlineTerms(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.PIIGazetteerConfig{
+		Terms: []config.PIIGazetteerTermConfig{
+			{Type: "ORG", Values: []string{"Project Titan", "Operation Moonshot"}},
+		},
+	}
+	// Set Options.CaseInsensitive to true via a pointer in the config.
+	trueVal := true
+	cfg.Options = config.PIIGazetteerOptionsConfig{CaseInsensitive: &trueVal}
+
+	det, err := LoadGazetteerDetector(cfg)
+	if err != nil {
+		t.Fatalf("LoadGazetteerDetector: %v", err)
+	}
+
+	text := "We launched Project Titan last week."
+	spans, findErr := det.Find(text)
+	if findErr != nil {
+		t.Fatalf("Find: unexpected error: %v", findErr)
+	}
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span for 'Project Titan', got %d: %+v", len(spans), spans)
+	}
+	if got := text[spans[0].Start:spans[0].End]; got != "Project Titan" {
+		t.Errorf("span = %q, want %q", got, "Project Titan")
+	}
+	if spans[0].Type != "ORG" {
+		t.Errorf("span.Type = %q, want ORG", spans[0].Type)
+	}
+}
+
+// TestLoadGazetteerDetector_EmptyTypeInlineTermError verifies that an inline
+// term entry with empty Type causes LoadGazetteerDetector to return an error.
+func TestLoadGazetteerDetector_EmptyTypeInlineTermError(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.PIIGazetteerConfig{
+		Terms: []config.PIIGazetteerTermConfig{
+			{Type: "", Values: []string{"foo"}},
+		},
+	}
+
+	_, err := LoadGazetteerDetector(cfg)
+	if err == nil {
+		t.Error("expected error for empty term type, got nil")
+	}
+	if !strings.Contains(err.Error(), "type") {
+		t.Errorf("error should mention 'type', got: %v", err)
+	}
+}
+
+// TestLoadGazetteerDetector_Dedup verifies that duplicate (term, type) pairs
+// across multiple sources do not produce duplicate spans.
+func TestLoadGazetteerDetector_Dedup(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.PIIGazetteerConfig{
+		Terms: []config.PIIGazetteerTermConfig{
+			{Type: "ORG", Values: []string{"GmbH", "GmbH"}}, // dup within same entry
+		},
+	}
+	trueVal := true
+	cfg.Options = config.PIIGazetteerOptionsConfig{CaseInsensitive: &trueVal}
+
+	det, err := LoadGazetteerDetector(cfg)
+	if err != nil {
+		t.Fatalf("LoadGazetteerDetector: %v", err)
+	}
+
+	spans, findErr := det.Find("Acme GmbH.")
+	if findErr != nil {
+		t.Fatalf("Find: unexpected error: %v", findErr)
+	}
+	if len(spans) != 1 {
+		t.Errorf("expected 1 span (dedup), got %d: %+v", len(spans), spans)
+	}
+}
+
+// ── Pseudonym helpers: typeAbbrev and stableAbbrev ───────────────────────────
+
+// TestLoadGazetteerDetector_WithPack exercises the embedded pack loading path
+// through LoadGazetteerDetector end-to-end.
+func TestLoadGazetteerDetector_WithPack(t *testing.T) {
+	t.Parallel()
+
+	trueVal := true
+	cfg := config.PIIGazetteerConfig{
+		Packs: []string{"company-forms"},
+	}
+	cfg.Options = config.PIIGazetteerOptionsConfig{CaseInsensitive: &trueVal}
+
+	det, err := LoadGazetteerDetector(cfg)
+	if err != nil {
+		t.Fatalf("LoadGazetteerDetector with pack: %v", err)
+	}
+
+	text := "Acme GmbH is a company."
+	spans, findErr := det.Find(text)
+	if findErr != nil {
+		t.Fatalf("Find: unexpected error: %v", findErr)
+	}
+	if len(spans) == 0 {
+		t.Fatal("expected at least one span from company-forms pack, got none")
+	}
+	// GmbH must be found and carry type ORG.
+	found := false
+	for _, sp := range spans {
+		if text[sp.Start:sp.End] == "GmbH" && sp.Type == "ORG" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected span for 'GmbH' with type ORG, spans: %+v", spans)
+	}
+}
+
+// TestLoadGazetteerDetector_WithDir exercises the operator directory loading
+// path through LoadGazetteerDetector end-to-end.
+func TestLoadGazetteerDetector_WithDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	content := "# type: ORG\nAcmeCorp\nFooBar Inc\n"
+	if err := os.WriteFile(filepath.Join(dir, "custom.txt"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write custom.txt: %v", err)
+	}
+
+	trueVal := true
+	cfg := config.PIIGazetteerConfig{
+		Dirs: []string{dir},
+	}
+	cfg.Options = config.PIIGazetteerOptionsConfig{CaseInsensitive: &trueVal}
+
+	det, err := LoadGazetteerDetector(cfg)
+	if err != nil {
+		t.Fatalf("LoadGazetteerDetector with dir: %v", err)
+	}
+
+	text := "We hired AcmeCorp."
+	spans, findErr := det.Find(text)
+	if findErr != nil {
+		t.Fatalf("Find: unexpected error: %v", findErr)
+	}
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d: %+v", len(spans), spans)
+	}
+	if got := text[spans[0].Start:spans[0].End]; got != "AcmeCorp" {
+		t.Errorf("span = %q, want AcmeCorp", got)
+	}
+	if spans[0].Type != "ORG" {
+		t.Errorf("span.Type = %q, want ORG", spans[0].Type)
+	}
+}
+
+// TestLoadGazetteerDetector_UnknownPackError verifies that LoadGazetteerDetector
+// returns an error for an unknown embedded pack name.
+func TestLoadGazetteerDetector_UnknownPackError(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.PIIGazetteerConfig{
+		Packs: []string{"does-not-exist"},
+	}
+
+	_, err := LoadGazetteerDetector(cfg)
+	if err == nil {
+		t.Error("expected error for unknown pack, got nil")
+	}
+}
+
+// TestLoadGazetteerDetector_NonexistentDirError verifies that LoadGazetteerDetector
+// returns an error when a configured directory does not exist.
+func TestLoadGazetteerDetector_NonexistentDirError(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.PIIGazetteerConfig{
+		Dirs: []string{"/no/such/dir/xyz99"},
+	}
+
+	_, err := LoadGazetteerDetector(cfg)
+	if err == nil {
+		t.Error("expected error for nonexistent dir, got nil")
+	}
+}
+
+// TestTypeAbbrev_GazetteerTypes verifies the fixed abbreviation codes for all
+// new gazetteer PII types added in Stage 1a.
+func TestTypeAbbrev_GazetteerTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		typ  string
+		want string
+	}{
+		// Stage 1a gazetteer types — fixed codes.
+		{"NAME", "NM"},
+		{"PERSON", "PN"},
+		{"CITY", "CT"},
+		{"LOCATION", "LO"},
+		{"ORG", "OR"},
+		{"COMPANY", "CO"},
+		// Stage 0 regex types — must remain unchanged.
+		{"EMAIL", "EM"},
+		{"IBAN", "IB"},
+		{"PHONE", "PH"},
+		{"CREDIT_CARD", "CC"},
+		{"TAX_ID", "TX"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.typ, func(t *testing.T) {
+			t.Parallel()
+
+			got := typeAbbrev(tc.typ)
+			if got != tc.want {
+				t.Errorf("typeAbbrev(%q) = %q, want %q", tc.typ, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStableAbbrev_Properties verifies the three required properties of
+// stableAbbrev for a broad set of custom types:
+//  1. Always exactly 2 characters.
+//  2. All characters in [A-Z0-9].
+//  3. Deterministic (same input → same output on repeated calls).
+func TestStableAbbrev_Properties(t *testing.T) {
+	t.Parallel()
+
+	// Broad set covering: long types, short types (1 char, empty), digit-only,
+	// lower-case, underscore-heavy (no leading alnum), and Unicode.
+	inputs := []string{
+		"UNKNOWN_TYPE",
+		"PASSPORT_NO",
+		"CUSTOM",
+		"X",
+		"",
+		"123",
+		"foo_bar",
+		"__UNDER__",
+		"ÄÖÜ", // no ASCII alnum → FNV pad path
+		"A",   // 1 alnum → needs 1 pad char
+		"AB",  // 2 alnum → no padding needed
+		"ABC", // 3 alnum → truncate to first 2
+	}
+
+	alphanumRe := regexp.MustCompile(`^[A-Z0-9]{2}$`)
+
+	for _, inp := range inputs {
+		t.Run(fmt.Sprintf("input=%q", inp), func(t *testing.T) {
+			t.Parallel()
+
+			got := stableAbbrev(inp)
+
+			if !alphanumRe.MatchString(got) {
+				t.Errorf("stableAbbrev(%q) = %q: not in [A-Z0-9]{2}", inp, got)
+			}
+			// Deterministic: calling again must return the same result.
+			got2 := stableAbbrev(inp)
+			if got != got2 {
+				t.Errorf("stableAbbrev(%q) not deterministic: %q then %q", inp, got, got2)
+			}
+		})
+	}
+}
+
+// TestStableAbbrev_PseudonymRegexValid verifies that every abbreviation
+// produced by stableAbbrev (for custom types) yields a valid pseudonym token
+// that matches the canonical regex PII_[A-Za-z0-9]{2}_[0-9a-f]{24}.
+func TestStableAbbrev_PseudonymRegexValid(t *testing.T) {
+	t.Parallel()
+
+	pseudonymRe := regexp.MustCompile(`^PII_[A-Za-z0-9]{2}_[0-9a-f]{24}$`)
+
+	customTypes := []string{"CUSTOM_TYPE", "X", "", "123", "foo_bar", "__X__"}
+	for _, typ := range customTypes {
+		p := pseudonym(testSecret, testOrgID, typ, "some-value")
+		if !pseudonymRe.MatchString(p) {
+			t.Errorf("pseudonym for type %q = %q: does not match canonical regex", typ, p)
+		}
+	}
+}
+
+// ── End-to-end: Engine + RegexDetector + GazetteerDetector ───────────────────
+
+// TestEndToEnd_GazetteerAndRegexBothAnonymized verifies that when an Engine is
+// built with both a RegexDetector and a GazetteerDetector, AnonymizeJSON
+// pseudonymizes spans from both detectors, Restore round-trips both back, and
+// the resulting tokens conform to the canonical pseudonym format.
+func TestEndToEnd_GazetteerAndRegexBothAnonymized(t *testing.T) {
+	t.Parallel()
+
+	regexDet, err := NewRegexDetector(DefaultPatterns())
+	if err != nil {
+		t.Fatalf("NewRegexDetector: %v", err)
+	}
+
+	gazDet, err := NewGazetteerDetector(
+		[]Gazetteer{
+			{Name: "code-names", Type: "ORG", Terms: []string{"Project Titan"}},
+			{Name: "forms", Type: "ORG", Terms: []string{"GmbH"}},
+		},
+		GazetteerOptions{CaseInsensitive: true},
+	)
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	engine := NewEngine(testSecret, []Detector{regexDet, gazDet})
+	f := engine.NewFilter(testOrgID)
+
+	// Body contains one email (regex) and one gazetteer term "Project Titan".
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"Email alice@example.com about Project Titan GmbH."}]}`)
+
+	anonBody, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+
+	// Neither the email nor the gazetteer terms should remain in plain text.
+	if strings.Contains(string(anonBody), "alice@example.com") {
+		t.Error("anonymized body still contains email")
+	}
+	if strings.Contains(string(anonBody), "Project Titan") {
+		t.Error("anonymized body still contains 'Project Titan'")
+	}
+	if strings.Contains(string(anonBody), "GmbH") {
+		t.Error("anonymized body still contains 'GmbH'")
+	}
+
+	if !f.Touched() {
+		t.Error("Touched() = false; expected PII to be detected")
+	}
+
+	// All tokens must match the canonical pseudonym regex.
+	pseudonymRe := regexp.MustCompile(`PII_[A-Za-z0-9]{2}_[0-9a-f]{24}`)
+	anonStr := string(anonBody)
+	tokens := pseudonymRe.FindAllString(anonStr, -1)
+	if len(tokens) < 2 {
+		t.Errorf("expected at least 2 pseudonym tokens, found %d in: %s", len(tokens), anonStr)
+	}
+	for _, tok := range tokens {
+		if len(tok) != pseudonymLen {
+			t.Errorf("token %q has length %d, want %d", tok, len(tok), pseudonymLen)
+		}
+	}
+
+	// Restore must recover all original values.
+	restored := f.Restore(anonBody)
+	if !strings.Contains(string(restored), "alice@example.com") {
+		t.Errorf("restore: email missing from restored body: %s", restored)
+	}
+	if !strings.Contains(string(restored), "Project Titan") {
+		t.Errorf("restore: 'Project Titan' missing from restored body: %s", restored)
+	}
+	if !strings.Contains(string(restored), "GmbH") {
+		t.Errorf("restore: 'GmbH' missing from restored body: %s", restored)
+	}
+}
+
+// TestEndToEnd_GazetteerTypeCodesInTokens verifies that the pseudonym token
+// for ORG spans uses the "OR" abbreviation and CITY uses "CT".
+func TestEndToEnd_GazetteerTypeCodesInTokens(t *testing.T) {
+	t.Parallel()
+
+	gazDet, err := NewGazetteerDetector(
+		[]Gazetteer{
+			{Name: "orgs", Type: "ORG", Terms: []string{"Acme Corp"}},
+			{Name: "cities", Type: "CITY", Terms: []string{"Berlin"}},
+		},
+		GazetteerOptions{CaseInsensitive: true},
+	)
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	engine := NewEngine(testSecret, []Detector{gazDet})
+	f := engine.NewFilter(testOrgID)
+
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"Acme Corp is based in Berlin."}]}`)
+	anonBody, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+
+	anonStr := string(anonBody)
+	if !strings.Contains(anonStr, "PII_OR_") {
+		t.Errorf("expected PII_OR_ token for ORG type, body: %s", anonStr)
+	}
+	if !strings.Contains(anonStr, "PII_CT_") {
+		t.Errorf("expected PII_CT_ token for CITY type, body: %s", anonStr)
+	}
+}
+
+// TestEndToEnd_RestoreRoundTrip_GazetteerSpans verifies full round-trip
+// fidelity for gazetteer-only spans: anonymize and then restore recovers the
+// exact original strings.
+func TestEndToEnd_RestoreRoundTrip_GazetteerSpans(t *testing.T) {
+	t.Parallel()
+
+	gazDet, err := NewGazetteerDetector(
+		[]Gazetteer{
+			{Name: "names", Type: "PERSON", Terms: []string{"Project Titan"}},
+		},
+		GazetteerOptions{CaseInsensitive: false},
+	)
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	engine := NewEngine(testSecret, []Detector{gazDet})
+	f := engine.NewFilter(testOrgID)
+
+	originalText := "We are discussing Project Titan today."
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"` + originalText + `"}]}`)
+
+	anonBody, err := f.AnonymizeJSON(body)
+	if err != nil {
+		t.Fatalf("AnonymizeJSON: %v", err)
+	}
+	if strings.Contains(string(anonBody), "Project Titan") {
+		t.Error("anonymized body still contains 'Project Titan'")
+	}
+
+	restored := f.Restore(anonBody)
+	if !strings.Contains(string(restored), "Project Titan") {
+		t.Errorf("restored body missing 'Project Titan': %s", restored)
+	}
+}
+
+// ── Review fixes ─────────────────────────────────────────────────────────────
+
+// TestFoldRunes_BothSides verifies that foldRunes is the single folding
+// function for both dictionary normalization (NewGazetteerDetector) and
+// scan-text folding (Find), and that span byte offsets are exact even when
+// the dictionary term and the input text have different cases.
+//
+// This is the regression anchor for FIX 1: if either side used a different
+// folding path the automaton would not match, or offsets would be wrong.
+func TestFoldRunes_BothSides(t *testing.T) {
+	t.Parallel()
+
+	// Dictionary term is mixed-case; input text will be supplied in three
+	// different case variants. All must produce a span whose byte slice
+	// reproduces the exact input substring.
+	det, err := NewGazetteerDetector(
+		[]Gazetteer{{Name: "t", Type: "ORG", Terms: []string{"GmbH & Co. KG"}}},
+		GazetteerOptions{CaseInsensitive: true},
+	)
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		text      string
+		wantSlice string
+	}{
+		{
+			name:      "exact case",
+			text:      "Foo GmbH & Co. KG bar",
+			wantSlice: "GmbH & Co. KG",
+		},
+		{
+			name:      "all upper",
+			text:      "Foo GMBH & CO. KG bar",
+			wantSlice: "GMBH & CO. KG",
+		},
+		{
+			name:      "all lower",
+			text:      "Foo gmbh & co. kg bar",
+			wantSlice: "gmbh & co. kg",
+		},
+		{
+			// Multibyte prefix tests offset alignment: "Grüße " is 9 bytes.
+			name:      "multibyte prefix exact case",
+			text:      "Grüße GmbH & Co. KG bar",
+			wantSlice: "GmbH & Co. KG",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			spans, findErr := det.Find(tc.text)
+			if findErr != nil {
+				t.Fatalf("Find: unexpected error: %v", findErr)
+			}
+			if len(spans) != 1 {
+				t.Fatalf("expected 1 span, got %d: %+v", len(spans), spans)
+			}
+			got := tc.text[spans[0].Start:spans[0].End]
+			if got != tc.wantSlice {
+				t.Errorf("text[span.Start:span.End] = %q, want %q (offset or folding mismatch)", got, tc.wantSlice)
+			}
+		})
+	}
+}
+
+// TestLoadGazetteerDir_FileCountLimit verifies that loadGazetteerDir returns
+// an error (not a panic) when the directory contains more than maxGazetteerFiles
+// *.txt files.
+func TestLoadGazetteerDir_FileCountLimit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Write maxGazetteerFiles+1 minimal *.txt files.
+	for i := 0; i <= maxGazetteerFiles; i++ {
+		name := filepath.Join(dir, fmt.Sprintf("pack%04d.txt", i))
+		if err := os.WriteFile(name, []byte("# type: ORG\nterm\n"), 0o600); err != nil {
+			t.Fatalf("write file %d: %v", i, err)
+		}
+	}
+
+	var out []Gazetteer
+	var fc int
+	var tb int64
+	err := loadGazetteerDir(dir, &out, &fc, &tb)
+	if err == nil {
+		t.Fatal("expected error when file count exceeds limit, got nil")
+	}
+	if !strings.Contains(err.Error(), "file limit") {
+		t.Errorf("error should mention 'file limit', got: %v", err)
+	}
+}
+
+// TestLoadGazetteerDir_ByteLimit verifies that loadGazetteerDir returns an
+// error when the total byte volume of *.txt files exceeds maxGazetteerBytes.
+//
+// Strategy: write two files each just over half the cap. The size guard checks
+// d.Info().Size() (the on-disk file size) before opening, so it fires before
+// the bufio.Scanner ever sees the content. Each file is filled with short
+// "term\n" lines so a scanner would not hit its own 64KB line limit; the
+// byte-total guard is what must fire here.
+func TestLoadGazetteerDir_ByteLimit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	// Each file is (maxGazetteerBytes/2 + 1) bytes of short lines.
+	// Include the required # type: header so parse does not fail before
+	// the byte-volume guard fires (the header itself is only a few bytes
+	// and does not move the size check to a later file).
+	const fileSize = maxGazetteerBytes/2 + 1
+	const line = "term\n"
+	reps := (fileSize / len(line)) + 1
+	content := "# type: ORG\n" + strings.Repeat(line, reps)
+
+	for _, name := range []string{"big1.txt", "big2.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	var out []Gazetteer
+	var fc int
+	var tb int64
+	err := loadGazetteerDir(dir, &out, &fc, &tb)
+	if err == nil {
+		t.Fatal("expected error when byte total exceeds limit, got nil")
+	}
+	if !strings.Contains(err.Error(), "byte limit") {
+		t.Errorf("error should mention 'byte limit', got: %v", err)
+	}
+}

--- a/internal/pii/gazetteer_test.go
+++ b/internal/pii/gazetteer_test.go
@@ -1,0 +1,339 @@
+package pii
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAhoCorasickBasic verifies that the automaton finds all dictionary terms
+// in a simple input string.
+func TestAhoCorasickBasic(t *testing.T) {
+	t.Parallel()
+
+	terms := []acTerm{
+		{norm: "gmbh", typ: "ORG"},
+		{norm: "ag", typ: "ORG"},
+		{norm: "berlin", typ: "CITY"},
+	}
+	m, err := newACMatcher(terms)
+	if err != nil {
+		t.Fatalf("newACMatcher: %v", err)
+	}
+
+	input := []rune("acme gmbh ag berlin")
+	matches := m.match(input)
+	if len(matches) == 0 {
+		t.Fatal("expected matches, got none")
+	}
+
+	// Verify "gmbh" is found.
+	found := make(map[string]bool)
+	for _, match := range matches {
+		found[terms[match.termIdx].norm] = true
+	}
+	for _, want := range []string{"gmbh", "ag", "berlin"} {
+		if !found[want] {
+			t.Errorf("expected to find term %q, but did not", want)
+		}
+	}
+}
+
+// TestAhoCorasickMaxStates ensures the constructor returns an error when the
+// state count would exceed maxGazetteerStates.
+func TestAhoCorasickMaxStates(t *testing.T) {
+	t.Parallel()
+
+	// Build a large number of long unique terms to saturate the state cap.
+	// Each unique rune path adds one state per rune; unique prefixes compound.
+	const alphabet = "abcdefghijklmnopqrstuvwxyz"
+	terms := make([]acTerm, 0, maxGazetteerStates/10)
+	for i := 0; i < maxGazetteerStates/10; i++ {
+		// Generate a unique 10-rune term from the index.
+		b := make([]byte, 10)
+		n := i
+		for j := 9; j >= 0; j-- {
+			b[j] = alphabet[n%len(alphabet)]
+			n /= len(alphabet)
+		}
+		terms = append(terms, acTerm{norm: string(b), typ: "TEST"})
+	}
+
+	// This may or may not exceed the cap depending on term overlap. We only
+	// care that the constructor never panics and returns either success or a
+	// meaningful error.
+	_, err := newACMatcher(terms)
+	// err may be nil (terms are short enough to stay under cap) or non-nil
+	// (exceeded cap); either outcome is acceptable. We just verify no panic.
+	_ = err
+}
+
+// TestGazetteerDetectorCaseInsensitive verifies that whole-token matching and
+// original byte-offset preservation work correctly with case folding.
+func TestGazetteerDetectorCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	gazes := []Gazetteer{
+		{Name: "test", Type: "ORG", Terms: []string{"GmbH", "AG"}},
+	}
+	det, err := NewGazetteerDetector(gazes, GazetteerOptions{CaseInsensitive: true})
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	text := "Acme GmbH und Foo AG sind Firmen."
+	spans, err := det.Find(text)
+	if err != nil {
+		t.Fatalf("Find: unexpected error: %v", err)
+	}
+	if len(spans) != 2 {
+		t.Fatalf("expected 2 spans, got %d: %+v", len(spans), spans)
+	}
+
+	// Verify start offsets correspond to original text bytes.
+	for _, sp := range spans {
+		got := text[sp.Start:sp.End]
+		if got != "GmbH" && got != "AG" {
+			t.Errorf("span [%d:%d] = %q, expected GmbH or AG", sp.Start, sp.End, got)
+		}
+		if sp.Type != "ORG" {
+			t.Errorf("span type = %q, expected ORG", sp.Type)
+		}
+	}
+}
+
+// TestGazetteerDetectorWholeToken verifies that partial-word matches are
+// rejected by the word-boundary filter.
+func TestGazetteerDetectorWholeToken(t *testing.T) {
+	t.Parallel()
+
+	gazes := []Gazetteer{
+		{Name: "test", Type: "CITY", Terms: []string{"Berg"}},
+	}
+	det, err := NewGazetteerDetector(gazes, GazetteerOptions{CaseInsensitive: true})
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	// "Bergmann" contains "Berg" but is not a whole token.
+	text := "Bergmann lebt in Berg."
+	spans, err := det.Find(text)
+	if err != nil {
+		t.Fatalf("Find: unexpected error: %v", err)
+	}
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span (standalone Berg), got %d: %+v", len(spans), spans)
+	}
+	got := text[spans[0].Start:spans[0].End]
+	if got != "Berg" {
+		t.Errorf("span = %q, want %q", got, "Berg")
+	}
+}
+
+// TestGazetteerDetectorConcurrent verifies that Find is safe to call
+// concurrently on the same detector.
+func TestGazetteerDetectorConcurrent(t *testing.T) {
+	t.Parallel()
+
+	gazes := []Gazetteer{
+		{Name: "test", Type: "ORG", Terms: []string{"GmbH", "AG", "Ltd"}},
+	}
+	det, err := NewGazetteerDetector(gazes, GazetteerOptions{CaseInsensitive: true})
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	const goroutines = 20
+	done := make(chan struct{}, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer func() { done <- struct{}{} }()
+			spans, findErr := det.Find("Foo GmbH and Bar AG and Baz Ltd.")
+			if findErr != nil {
+				t.Errorf("concurrent Find: unexpected error: %v", findErr)
+				return
+			}
+			if len(spans) != 3 {
+				t.Errorf("concurrent Find: expected 3 spans, got %d", len(spans))
+			}
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+}
+
+// TestGazetteerDetectorUnicode verifies correct handling of non-ASCII terms
+// (e.g. German city names with umlauts).
+func TestGazetteerDetectorUnicode(t *testing.T) {
+	t.Parallel()
+
+	gazes := []Gazetteer{
+		{Name: "de-cities", Type: "CITY", Terms: []string{"Düsseldorf", "München"}},
+	}
+	det, err := NewGazetteerDetector(gazes, GazetteerOptions{CaseInsensitive: true})
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	text := "Büro in Düsseldorf und München."
+	spans, err := det.Find(text)
+	if err != nil {
+		t.Fatalf("Find: unexpected error: %v", err)
+	}
+	if len(spans) != 2 {
+		t.Fatalf("expected 2 spans, got %d: %+v", len(spans), spans)
+	}
+	for _, sp := range spans {
+		got := text[sp.Start:sp.End]
+		if got != "Düsseldorf" && got != "München" {
+			t.Errorf("span = %q, expected Düsseldorf or München", got)
+		}
+	}
+}
+
+// TestGazetteerDetectorDedup verifies that duplicate (term, type) pairs across
+// gazetteers do not produce duplicate spans.
+func TestGazetteerDetectorDedup(t *testing.T) {
+	t.Parallel()
+
+	gazes := []Gazetteer{
+		{Name: "a", Type: "ORG", Terms: []string{"GmbH"}},
+		{Name: "b", Type: "ORG", Terms: []string{"GmbH"}}, // exact duplicate
+	}
+	det, err := NewGazetteerDetector(gazes, GazetteerOptions{CaseInsensitive: true})
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	spans, err := det.Find("Acme GmbH.")
+	if err != nil {
+		t.Fatalf("Find: unexpected error: %v", err)
+	}
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d: %+v", len(spans), spans)
+	}
+}
+
+// TestParseGazetteerFile verifies that the .txt format parser handles
+// comment headers and blank lines correctly.
+func TestParseGazetteerFile(t *testing.T) {
+	t.Parallel()
+
+	content := `# locale: de
+# type: CITY
+
+# A comment
+Berlin
+Hamburg
+# another comment
+Bremen
+`
+	g, err := parseGazetteerFile(strings.NewReader(content), "test-pack")
+	if err != nil {
+		t.Fatalf("parseGazetteerFile: %v", err)
+	}
+	if g.Locale != "de" {
+		t.Errorf("Locale = %q, want %q", g.Locale, "de")
+	}
+	if g.Type != "CITY" {
+		t.Errorf("Type = %q, want %q", g.Type, "CITY")
+	}
+	wantTerms := []string{"Berlin", "Hamburg", "Bremen"}
+	if len(g.Terms) != len(wantTerms) {
+		t.Fatalf("Terms count = %d, want %d: %v", len(g.Terms), len(wantTerms), g.Terms)
+	}
+	for i, want := range wantTerms {
+		if g.Terms[i] != want {
+			t.Errorf("Terms[%d] = %q, want %q", i, g.Terms[i], want)
+		}
+	}
+}
+
+// TestLoadEmbeddedPack verifies that the two bundled embedded packs load
+// without error and contain at least one term.
+func TestLoadEmbeddedPack(t *testing.T) {
+	t.Parallel()
+
+	for _, packName := range []string{"company-forms", "de-cities"} {
+		packName := packName
+		t.Run(packName, func(t *testing.T) {
+			t.Parallel()
+			g, err := loadEmbeddedPack(packName)
+			if err != nil {
+				t.Fatalf("loadEmbeddedPack(%q): %v", packName, err)
+			}
+			if len(g.Terms) == 0 {
+				t.Errorf("pack %q has no terms", packName)
+			}
+			if g.Name != packName {
+				t.Errorf("pack Name = %q, want %q", g.Name, packName)
+			}
+			if g.Type == "" {
+				t.Errorf("pack %q has empty Type", packName)
+			}
+		})
+	}
+}
+
+// TestLoadEmbeddedPackUnknown verifies that an unknown pack name returns an
+// error rather than silently succeeding.
+func TestLoadEmbeddedPackUnknown(t *testing.T) {
+	t.Parallel()
+
+	_, err := loadEmbeddedPack("does-not-exist")
+	if err == nil {
+		t.Error("expected error for unknown pack, got nil")
+	}
+}
+
+// TestStableAbbrev verifies the properties of the custom-type abbreviation:
+// always 2 chars in [A-Z0-9], stable across calls, distinct for distinct types.
+func TestStableAbbrev(t *testing.T) {
+	t.Parallel()
+
+	types := []string{"UNKNOWN_TYPE", "PASSPORT_NO", "CUSTOM", "X", "", "123", "foo_bar"}
+	seen := make(map[string]string)
+
+	for _, typ := range types {
+		abbr := stableAbbrev(typ)
+		if len(abbr) != 2 {
+			t.Errorf("stableAbbrev(%q) = %q: want len 2, got %d", typ, abbr, len(abbr))
+		}
+		for _, c := range abbr {
+			if !((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) {
+				t.Errorf("stableAbbrev(%q) = %q: char %q not in [A-Z0-9]", typ, abbr, c)
+			}
+		}
+		// Stability: calling again must return the same result.
+		if abbr2 := stableAbbrev(typ); abbr2 != abbr {
+			t.Errorf("stableAbbrev(%q) not stable: got %q then %q", typ, abbr, abbr2)
+		}
+		// Record for distinctness check.
+		if prev, conflict := seen[abbr]; conflict && prev != typ {
+			// Collision is allowed (pigeonhole) but log it so it's visible.
+			t.Logf("note: stableAbbrev collision: %q and %q both → %q", prev, typ, abbr)
+		}
+		seen[abbr] = typ
+	}
+}
+
+// TestGazetteerTypeAbbrev verifies that the new gazetteer PII types are
+// mapped to their fixed 2-char codes in typeAbbrev.
+func TestGazetteerTypeAbbrev(t *testing.T) {
+	t.Parallel()
+
+	cases := [][2]string{
+		{"NAME", "NM"},
+		{"PERSON", "PN"},
+		{"CITY", "CT"},
+		{"LOCATION", "LO"},
+		{"ORG", "OR"},
+		{"COMPANY", "CO"},
+	}
+	for _, tc := range cases {
+		got := typeAbbrev(tc[0])
+		if got != tc[1] {
+			t.Errorf("typeAbbrev(%q) = %q, want %q", tc[0], got, tc[1])
+		}
+	}
+}

--- a/internal/pii/json.go
+++ b/internal/pii/json.go
@@ -137,17 +137,29 @@ func anonymizeWithDetectors(body []byte, detectors []Detector, replace func(typ,
 	detect := func(text string) (string, bool, error) {
 		var spans []Span
 		for _, d := range detectors {
-			spans = append(spans, d.Find(text)...)
+			found, err := d.Find(text)
+			if err != nil {
+				return "", false, err
+			}
+			spans = append(spans, found...)
 		}
 		if len(spans) == 0 {
 			return text, false, nil
 		}
 		// Sort and de-overlap merged spans from all detectors.
+		// Primary: Start ascending. Secondary: End descending (longest first).
+		// Tertiary: Type ascending — ensures fully-identical intervals (same
+		// Start and End, different Type) always produce the same winner in
+		// deOverlap regardless of detector ordering or input order, making
+		// multi-turn pseudonym assignment fully deterministic.
 		sort.Slice(spans, func(i, j int) bool {
 			if spans[i].Start != spans[j].Start {
 				return spans[i].Start < spans[j].Start
 			}
-			return spans[i].End > spans[j].End // longest first on tie
+			if spans[i].End != spans[j].End {
+				return spans[i].End > spans[j].End // longest first on tie
+			}
+			return spans[i].Type < spans[j].Type // stable type tie-break
 		})
 		spans = deOverlap(spans)
 		out, touched, err := replaceSpansInText(text, spans, replace)
@@ -740,22 +752,60 @@ func replaceSpansInText(text string, spans []Span, replace func(typ, value strin
 	return b.String(), true, nil
 }
 
-// deOverlap removes overlapping spans from a Start-ascending sorted slice,
-// keeping the leftmost span and discarding any that starts before the
-// previous span ends.
+// deOverlap merges overlapping spans from a Start-ascending sorted slice
+// into their union intervals, guaranteeing that no byte flagged by any
+// detector is left unmasked.
+//
+// Algorithm: maintain an accumulated interval [curStart, curEnd) and the
+// "dominant" span for that interval (the one whose matched text covers the
+// most bytes; ties broken by the span seen first, i.e. leftmost). For each
+// subsequent span, if it overlaps or is adjacent to the accumulated interval,
+// extend the interval to max(curEnd, span.End) and update the dominant type
+// to the longest contributing span. When a span is strictly disjoint, flush
+// the accumulated interval as a single Span and start a new one.
+//
+// The Type of a merged span is taken from the longest contributing span
+// (largest End−Start); on a tie the first-seen (leftmost) span's type is
+// kept. The original text covered by the union is text[curStart:curEnd],
+// which is passed as a single value to replace() so that pseudonymization
+// treats the union as one PII entity and Restore always round-trips the
+// exact union substring.
+//
+// Privacy invariant: every byte in any input Span appears in exactly one
+// output Span — no byte is dropped. The merged output may over-mask the
+// gap bytes between two overlapping spans, which is acceptable: the
+// worst case is slight over-anonymization, never under-anonymization.
 func deOverlap(spans []Span) []Span {
 	if len(spans) == 0 {
 		return spans
 	}
-	result := spans[:1]
-	cursor := spans[0].End
+	result := make([]Span, 0, len(spans))
+
+	cur := spans[0]
+	curLen := cur.End - cur.Start
+
 	for _, s := range spans[1:] {
-		if s.Start < cursor {
+		if s.Start < cur.End {
+			// Overlapping or contained: merge into union.
+			// (s.Start == cur.End would be adjacent but is intentionally left
+			// disjoint; the condition is strictly less-than, not less-or-equal.)
+			if s.End > cur.End {
+				cur.End = s.End
+			}
+			// Prefer the type of the longest contributing span; ties keep cur.
+			sLen := s.End - s.Start
+			if sLen > curLen {
+				cur.Type = s.Type
+				curLen = sLen
+			}
 			continue
 		}
-		result = append(result, s)
-		cursor = s.End
+		// Disjoint: flush the accumulated span.
+		result = append(result, cur)
+		cur = s
+		curLen = cur.End - cur.Start
 	}
+	result = append(result, cur)
 	return result
 }
 

--- a/internal/pii/pii.go
+++ b/internal/pii/pii.go
@@ -40,11 +40,14 @@ type Span struct {
 // per-request state. All expensive initialisation (regexp compilation,
 // model loading) must happen in the constructor, not in Find.
 type Detector interface {
-	// Find returns all non-overlapping PII spans found in text.
-	// The returned slice may be nil or empty when no PII is detected.
+	// Find returns all non-overlapping PII spans found in text, or a
+	// non-nil error when a safety limit is exceeded. On error the caller
+	// must treat the input as unprocessable and fail closed — partial span
+	// results are never returned alongside an error. The returned slice
+	// may be nil or empty when no PII is detected.
 	// Overlapping matches are resolved according to each implementation's
 	// documented policy (typically: longest match or leftmost wins).
-	Find(text string) []Span
+	Find(text string) ([]Span, error)
 }
 
 // Engine is the shared, request-independent factory for PII filters. It

--- a/internal/pii/pii_codex_fixes_test.go
+++ b/internal/pii/pii_codex_fixes_test.go
@@ -1,0 +1,621 @@
+package pii
+
+// pii_codex_fixes_test.go covers the six external-review (Codex) fixes applied
+// to feat/pii-stage1-gazetteer:
+//
+//   FIX 1: union overlap-resolution prevents gazetteer span from suppressing
+//           a longer regex PII span (phone-number regression).
+//   FIX 2: maxGazetteerMatches cap causes Find to fail closed; build-time
+//           maxGazetteerOutputs cap causes newACMatcher to return an error.
+//   FIX 3: symlinked .txt files in operator dirs are skipped.
+//   FIX 4: global file/byte/inline-term caps across multiple dirs → error.
+//   FIX 5: pack file with empty or missing # type: header → parse error.
+//   (FIX 6 is documentation-only; no behaviour change to test.)
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/voidmind-io/voidllm/internal/config"
+)
+
+// ── FIX 1: union overlap-resolution ──────────────────────────────────────────
+
+// TestFix1_UnionOverlap_PhoneRegression is the critical regression test.
+// A gazetteer operator term "+49" (e.g. the country-code prefix) starting
+// at the same position as a PHONE span must NOT suppress the rest of the
+// phone number. The entire PHONE interval must be masked after merging.
+//
+// Text: "call +4915112345678 now"
+// PHONE regex:  [5, 19)  "+4915112345678"   (14 chars)
+// GAZ operator: [5,  8)  "+49"              (3 chars, type ORG as stand-in)
+//
+// Old deOverlap (drop later-starting): keeps [5,8) only → "+4915112345678"
+//
+//	leaks "15112345678" in cleartext. Privacy regression.
+//
+// New deOverlap (union): merges into [5,19), type PHONE (longest wins).
+//
+//	No byte of the phone number remains unmasked.
+func TestFix1_UnionOverlap_PhoneRegression(t *testing.T) {
+	t.Parallel()
+
+	// Regex detector with PHONE pattern.
+	regexDet, err := NewRegexDetector([]Pattern{
+		{
+			Type:   "PHONE",
+			Regexp: `(?:\+49|0)[0-9][0-9 \-]{5,14}[0-9]`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegexDetector: %v", err)
+	}
+
+	// Gazetteer detector with "+49" as an operator term (simulates the
+	// country-code prefix being in a company / operator custom list).
+	// Whole-token boundary: "+49" followed by digit does NOT pass the
+	// word-boundary filter (digit is alphanumeric) — so the gazetteer
+	// alone would not match "+49" when it is part of "+4915112345678".
+	// The regression scenario is slightly different: imagine the gazetteer
+	// matches "+49 151" (7 chars) as a local-code entry while the regex
+	// matches the full "+4915112345678" (14 chars) starting at the same
+	// position. We simulate this by constructing spans manually through
+	// deOverlap so the test is not dependent on gazetteer word-boundary rules.
+	//
+	// We test deOverlap directly with representative spans, then verify
+	// end-to-end through AnonymizeJSON.
+
+	// Direct deOverlap test: short gazetteer span [5,8) "ORG" precedes the
+	// regex PHONE span [5,19).
+	// Sorted by start, then by length descending → PHONE [5,19) comes first,
+	// then ORG [5,8). deOverlap merges them into [5,19) type PHONE (longest).
+	spans := []Span{
+		{Start: 5, End: 19, Type: "PHONE"}, // regex, sorted first (longest)
+		{Start: 5, End: 8, Type: "ORG"},    // gazetteer, overlaps
+	}
+	merged := deOverlap(spans)
+	if len(merged) != 1 {
+		t.Fatalf("deOverlap: expected 1 merged span, got %d: %+v", len(merged), merged)
+	}
+	if merged[0].Start != 5 || merged[0].End != 19 {
+		t.Errorf("union span = [%d,%d), want [5,19)", merged[0].Start, merged[0].End)
+	}
+	if merged[0].Type != "PHONE" {
+		t.Errorf("union type = %q, want PHONE (longest wins)", merged[0].Type)
+	}
+
+	// End-to-end: AnonymizeJSON must mask the full phone number, not just
+	// the "+49" prefix. We use only the regex detector here; the key property
+	// is that once Find returns the PHONE span [5,19), replaceSpansInText
+	// masks exactly that interval.
+	engine := NewEngine(testSecret, []Detector{regexDet})
+	f := engine.NewFilter(testOrgID)
+
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"call +4915112345678 now"}]}`)
+	anon, anonErr := f.AnonymizeJSON(body)
+	if anonErr != nil {
+		t.Fatalf("AnonymizeJSON: %v", anonErr)
+	}
+
+	// The full phone number must be absent from the anonymized body.
+	if strings.Contains(string(anon), "+4915112345678") {
+		t.Error("full phone number still present in anonymized body (regression: FIX 1)")
+	}
+	// Any suffix of the number must also be absent (the "+49" prefix might
+	// be masked but the tail "15112345678" must not leak).
+	if strings.Contains(string(anon), "15112345678") {
+		t.Error("phone number tail '15112345678' leaks in anonymized body (FIX 1 regression)")
+	}
+
+	// Restore must recover the original.
+	restored := f.Restore(anon)
+	if !strings.Contains(string(restored), "+4915112345678") {
+		t.Errorf("restore: phone number missing from restored body: %s", restored)
+	}
+}
+
+// TestFix1_UnionMergeRestoreRoundTrip verifies that the union-merged span's
+// original substring is preserved exactly through Restore.
+func TestFix1_UnionMergeRestoreRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	// Build spans that overlap: A=[0,5) and B=[3,10) → union [0,10).
+	// The value at [0,10) in text "hello world!" is "hello worl".
+	// We pass them already sorted: B (longer) first so deOverlap picks B's type.
+	text := "hello world!"
+	sorted := []Span{
+		{Start: 0, End: 10, Type: "B"}, // B is longer, comes first after sort
+		{Start: 0, End: 5, Type: "A"},
+	}
+	merged := deOverlap(sorted)
+	if len(merged) != 1 {
+		t.Fatalf("deOverlap: expected 1 merged span, got %d", len(merged))
+	}
+	wantStart, wantEnd := 0, 10
+	if merged[0].Start != wantStart || merged[0].End != wantEnd {
+		t.Fatalf("merged span = [%d,%d), want [%d,%d)", merged[0].Start, merged[0].End, wantStart, wantEnd)
+	}
+	// The union substring is text[0:10] = "hello worl".
+	unionSubstr := text[merged[0].Start:merged[0].End]
+	if unionSubstr != "hello worl" {
+		t.Errorf("union substring = %q, want %q", unionSubstr, "hello worl")
+	}
+	// The type is B (longest span wins: len(B)=10 > len(A)=5).
+	if merged[0].Type != "B" {
+		t.Errorf("union type = %q, want B (longest wins)", merged[0].Type)
+	}
+}
+
+// TestFix1_PureStage0NoOverlapUnchanged verifies that the union-merge path
+// does not alter behavior when there are no overlapping spans. Existing
+// Stage 0 tests continue to pass unchanged.
+func TestFix1_PureStage0NoOverlapUnchanged(t *testing.T) {
+	t.Parallel()
+
+	// Three disjoint spans: result must be identical to input.
+	spans := []Span{
+		{Start: 0, End: 5, Type: "EMAIL"},
+		{Start: 10, End: 20, Type: "PHONE"},
+		{Start: 25, End: 35, Type: "IBAN"},
+	}
+	result := deOverlap(spans)
+	if len(result) != 3 {
+		t.Fatalf("non-overlapping: expected 3 spans, got %d: %+v", len(result), result)
+	}
+	for i, want := range spans {
+		if result[i] != want {
+			t.Errorf("result[%d] = %+v, want %+v", i, result[i], want)
+		}
+	}
+}
+
+// ── FIX 2: match cap and output-link cap ──────────────────────────────────────
+
+// TestFix2_MatchCapFailClosed verifies that Find returns a non-nil error
+// (never partial/truncated results) when the number of raw automaton hits
+// for a single input exceeds maxGazetteerMatches. The request must be
+// rejected, not silently truncated.
+func TestFix2_MatchCapFailClosed(t *testing.T) {
+	t.Parallel()
+
+	// Build a single 1-rune term "a". In an input of maxGazetteerMatches+1
+	// 'a' characters with spaces for word boundaries, every 'a' produces a
+	// boundary-passing hit. To exceed the cap we need more than
+	// maxGazetteerMatches hits.
+	//
+	// Strategy: use a very short term " a " (with spaces so every occurrence
+	// is boundary-clean) and build input that contains maxGazetteerMatches+1
+	// such occurrences. Each 3-char triple " a " is a match.
+	// Total chars ≈ (maxGazetteerMatches+1)*3 ≈ 600 003 chars — acceptable
+	// for a test, it runs once.
+	const n = maxGazetteerMatches + 1
+
+	det, err := NewGazetteerDetector(
+		[]Gazetteer{{Name: "t", Type: "TEST", Terms: []string{"a"}}},
+		GazetteerOptions{CaseInsensitive: false},
+	)
+	if err != nil {
+		t.Fatalf("NewGazetteerDetector: %v", err)
+	}
+
+	// Build input: "a a a a ..." with n 'a' tokens separated by spaces.
+	// Each 'a' is at a word boundary (preceded and followed by ' ' or start/end).
+	// That gives exactly n hits.
+	var sb strings.Builder
+	sb.Grow(n * 2)
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteByte('a')
+	}
+	input := sb.String()
+
+	resultSpans, findErr := det.Find(input)
+	if findErr == nil {
+		t.Errorf("Find: expected fail-closed error for %d matches, got nil (spans=%d)", n, len(resultSpans))
+		return
+	}
+	// The error must be non-nil and no partial results returned.
+	if resultSpans != nil {
+		t.Errorf("Find: expected nil spans on error, got %d spans", len(resultSpans))
+	}
+	// The error must mention the cap.
+	if !strings.Contains(findErr.Error(), "match count exceeded") {
+		t.Errorf("Find error: expected 'match count exceeded', got: %v", findErr)
+	}
+}
+
+// TestFix2_OutputLinkCapFailsClosed verifies that newACMatcher returns a
+// non-nil error when the total number of output-link entries during BFS
+// would exceed maxGazetteerOutputs. This prevents quadratic memory growth
+// for prefix-heavy dictionaries.
+func TestFix2_OutputLinkCapFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	// A prefix-heavy dictionary: "a", "aa", "aaa", ..., up to maxGazetteerStates
+	// states worth of terms. The Aho-Corasick BFS output-link flattening copies
+	// the failure outputs of every ancestor into each state; for a chain of
+	// length L, state i inherits i entries. The total is roughly L*(L+1)/2.
+	//
+	// We need enough terms so that the quadratic growth hits maxGazetteerOutputs
+	// before the state cap. With maxGazetteerOutputs=1_000_000, the break-even
+	// is at L ≈ sqrt(2*1_000_000) ≈ 1414. Use 1500 terms to be safe, and the
+	// state cap of 500_000 won't interfere (1500 states for a chain).
+	const chainLen = 1500
+	terms := make([]acTerm, chainLen)
+	for i := range terms {
+		terms[i] = acTerm{norm: strings.Repeat("a", i+1), typ: "TEST"}
+	}
+	terms[0].runeLen = 1 // normally set by newACMatcher; pre-set for clarity
+
+	_, err := newACMatcher(terms)
+	if err == nil {
+		t.Error("newACMatcher: expected output-link cap error for prefix dictionary, got nil")
+		return
+	}
+	// The error must mention the output-link cap.
+	if !strings.Contains(err.Error(), "output links exceed") {
+		t.Errorf("error should mention 'output links exceed', got: %v", err)
+	}
+}
+
+// ── FIX 3: symlink / special-file skipping ────────────────────────────────────
+
+// TestFix3_SymlinkSkipped verifies that a symlinked .txt file in an operator
+// directory is silently skipped (not read, not counted against limits).
+func TestFix3_SymlinkSkipped(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	// Write a real .txt file with a proper type header.
+	realFile := filepath.Join(dir, "real.txt")
+	if err := os.WriteFile(realFile, []byte("# type: ORG\nRealTerm\n"), 0o600); err != nil {
+		t.Fatalf("write real.txt: %v", err)
+	}
+
+	// Create a symlink pointing to a file that doesn't exist (or elsewhere).
+	// The symlink target need not exist for os.Lstat to see the symlink itself.
+	symFile := filepath.Join(dir, "symlink.txt")
+	if err := os.Symlink("/etc/hostname", symFile); err != nil {
+		// Symlink creation may be disallowed in some environments (e.g. Windows).
+		// Skip the test rather than failing; the behaviour being tested is
+		// the skip guard, not the OS capability to create symlinks.
+		t.Skipf("os.Symlink not available: %v", err)
+	}
+
+	var gazes []Gazetteer
+	var fc int
+	var tb int64
+	if err := loadGazetteerDir(dir, &gazes, &fc, &tb); err != nil {
+		t.Fatalf("loadGazetteerDir: unexpected error: %v", err)
+	}
+
+	// Only the real file should have been loaded; the symlink must be skipped.
+	if len(gazes) != 1 {
+		t.Fatalf("expected 1 gazetteer (real.txt only), got %d: %+v", len(gazes), gazes)
+	}
+	if fc != 1 {
+		t.Errorf("fileCount = %d, want 1 (symlink not counted)", fc)
+	}
+	found := false
+	for _, g := range gazes {
+		for _, term := range g.Terms {
+			if term == "RealTerm" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Error("expected 'RealTerm' from real.txt to be loaded")
+	}
+}
+
+// TestFix3_RegularFileRead verifies that a regular .txt file in the same dir
+// as a symlink is still read correctly.
+func TestFix3_RegularFileRead(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	content := "# type: CITY\nBerlin\nHamburg\n"
+	if err := os.WriteFile(filepath.Join(dir, "cities.txt"), []byte(content), 0o600); err != nil {
+		t.Fatalf("write cities.txt: %v", err)
+	}
+
+	var gazes []Gazetteer
+	var fc int
+	var tb int64
+	if err := loadGazetteerDir(dir, &gazes, &fc, &tb); err != nil {
+		t.Fatalf("loadGazetteerDir: %v", err)
+	}
+	if len(gazes) != 1 {
+		t.Fatalf("expected 1 gazetteer, got %d", len(gazes))
+	}
+	allTerms := make(map[string]bool)
+	for _, term := range gazes[0].Terms {
+		allTerms[term] = true
+	}
+	for _, want := range []string{"Berlin", "Hamburg"} {
+		if !allTerms[want] {
+			t.Errorf("expected term %q, not found in %v", want, gazes[0].Terms)
+		}
+	}
+}
+
+// ── FIX 4: global file/byte/inline-term caps ──────────────────────────────────
+
+// TestFix4_GlobalFileCapAcrossMultipleDirs verifies that the file count limit
+// is enforced globally across all operator directories in one LoadGazetteerDetector
+// call, not per-directory. Two directories each containing half the limit + 1
+// file together exceed the global cap.
+func TestFix4_GlobalFileCapAcrossMultipleDirs(t *testing.T) {
+	t.Parallel()
+
+	// Each directory contributes maxGazetteerFiles/2 + 1 files.
+	// Together they exceed maxGazetteerFiles.
+	const perDir = maxGazetteerFiles/2 + 1
+
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	for _, dir := range []string{dir1, dir2} {
+		for i := 0; i < perDir; i++ {
+			name := filepath.Join(dir, fmt.Sprintf("pack%04d.txt", i))
+			if err := os.WriteFile(name, []byte("# type: ORG\nterm\n"), 0o600); err != nil {
+				t.Fatalf("write file: %v", err)
+			}
+		}
+	}
+
+	cfg := config.PIIGazetteerConfig{
+		Dirs: []string{dir1, dir2},
+	}
+	_, err := LoadGazetteerDetector(cfg)
+	if err == nil {
+		t.Fatal("expected error when global file count exceeds limit across two dirs, got nil")
+	}
+	if !strings.Contains(err.Error(), "file limit") {
+		t.Errorf("error should mention 'file limit', got: %v", err)
+	}
+}
+
+// TestFix4_GlobalByteCapAcrossMultipleDirs verifies that the byte-volume limit
+// is enforced globally across all operator directories.
+func TestFix4_GlobalByteCapAcrossMultipleDirs(t *testing.T) {
+	t.Parallel()
+
+	// Split into two directories each contributing just over 1/4 of the byte cap;
+	// together they exceed the 1/2 cap needed to trigger across two files total.
+	// Each directory has one file of (maxGazetteerBytes/4 + 1) bytes.
+	// Total across both dirs = maxGazetteerBytes/2 + 2 — still under the cap.
+	// We need total > maxGazetteerBytes, so use 2 files each > maxGazetteerBytes/2.
+	const fileSize = maxGazetteerBytes/2 + 1
+	const lineContent = "# type: ORG\n"
+	filler := strings.Repeat("t\n", (fileSize-len(lineContent))/2+1)
+	content := lineContent + filler
+
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	for i, dir := range []string{dir1, dir2} {
+		name := filepath.Join(dir, fmt.Sprintf("big%d.txt", i))
+		if err := os.WriteFile(name, []byte(content), 0o600); err != nil {
+			t.Fatalf("write file: %v", err)
+		}
+	}
+
+	cfg := config.PIIGazetteerConfig{
+		Dirs: []string{dir1, dir2},
+	}
+	_, err := LoadGazetteerDetector(cfg)
+	if err == nil {
+		t.Fatal("expected error when global byte count exceeds limit across two dirs, got nil")
+	}
+	if !strings.Contains(err.Error(), "byte limit") {
+		t.Errorf("error should mention 'byte limit', got: %v", err)
+	}
+}
+
+// TestFix4_InlineTermCapExceeded verifies that exceeding maxGazetteerInlineTerms
+// across all inline term entries causes a startup error.
+func TestFix4_InlineTermCapExceeded(t *testing.T) {
+	t.Parallel()
+
+	// Build maxGazetteerInlineTerms+1 inline values across two entries.
+	half := maxGazetteerInlineTerms/2 + 1
+	vals1 := make([]string, half)
+	vals2 := make([]string, half)
+	for i := range vals1 {
+		vals1[i] = fmt.Sprintf("term%d", i)
+	}
+	for i := range vals2 {
+		vals2[i] = fmt.Sprintf("other%d", i)
+	}
+
+	cfg := config.PIIGazetteerConfig{
+		Terms: []config.PIIGazetteerTermConfig{
+			{Type: "ORG", Values: vals1},
+			{Type: "CITY", Values: vals2},
+		},
+	}
+	_, err := LoadGazetteerDetector(cfg)
+	if err == nil {
+		t.Fatal("expected error when inline term count exceeds limit, got nil")
+	}
+	if !strings.Contains(err.Error(), "inline terms exceed") {
+		t.Errorf("error should mention 'inline terms exceed', got: %v", err)
+	}
+}
+
+// ── FIX 5: empty type in pack files ───────────────────────────────────────────
+
+// TestFix5_EmptyTypeHeaderError verifies that a pack file with an explicit
+// empty # type: header (e.g. "# type:   ") is rejected.
+func TestFix5_EmptyTypeHeaderError(t *testing.T) {
+	t.Parallel()
+
+	content := "# type:   \nFoo\nBar\n" // type value is empty after trim
+	_, err := parseGazetteerFile(strings.NewReader(content), "x")
+	if err == nil {
+		t.Fatal("expected error for empty # type: header, got nil")
+	}
+	if !strings.Contains(err.Error(), "type") {
+		t.Errorf("error should mention 'type', got: %v", err)
+	}
+}
+
+// TestFix5_MissingTypeHeaderError verifies that a pack file with no # type:
+// header at all is rejected.
+func TestFix5_MissingTypeHeaderError(t *testing.T) {
+	t.Parallel()
+
+	content := "# locale: de\nFoo\nBar\n" // no # type: header
+	_, err := parseGazetteerFile(strings.NewReader(content), "x")
+	if err == nil {
+		t.Fatal("expected error for missing # type: header, got nil")
+	}
+	if !strings.Contains(err.Error(), "type") {
+		t.Errorf("error should mention 'type', got: %v", err)
+	}
+}
+
+// TestFix5_ValidTypeHeaderOK verifies that a pack file with a non-empty
+// # type: header continues to parse correctly (regression guard).
+func TestFix5_ValidTypeHeaderOK(t *testing.T) {
+	t.Parallel()
+
+	content := "# type: ORG\nGmbH\nAG\n"
+	g, err := parseGazetteerFile(strings.NewReader(content), "x")
+	if err != nil {
+		t.Fatalf("parseGazetteerFile: unexpected error: %v", err)
+	}
+	if g.Type != "ORG" {
+		t.Errorf("Type = %q, want ORG", g.Type)
+	}
+	if len(g.Terms) != 2 {
+		t.Errorf("Terms = %v, want [GmbH AG]", g.Terms)
+	}
+}
+
+// ── Sort tie-break determinism ────────────────────────────────────────────────
+
+// TestSortTieBreak_DeterministicTypeOnIdenticalInterval verifies that when two
+// spans share the same Start and End but carry different Types, the sort
+// tie-break on Type (ascending lexicographic) produces the same winner
+// regardless of which detector emits the spans first or in what order they
+// arrive in the combined slice.
+//
+// Without the tertiary Type tie-break the sort is unstable on identical
+// intervals, so deOverlap's "keep first-seen type on tie" rule can pick a
+// different Type across identical requests, changing the 2-char pseudonym
+// abbreviation and breaking multi-turn consistency.
+//
+// The test constructs the same two spans in both possible input orders and
+// asserts that deOverlap produces the same winning Type in every case.
+func TestSortTieBreak_DeterministicTypeOnIdenticalInterval(t *testing.T) {
+	t.Parallel()
+
+	// Two spans with identical [Start, End) but different Types.
+	// Lexicographically: "CITY" < "NAME", so "CITY" must always win.
+	spanCity := Span{Start: 3, End: 10, Type: "CITY"}
+	spanName := Span{Start: 3, End: 10, Type: "NAME"}
+
+	orderAB := []Span{spanCity, spanName}
+	orderBA := []Span{spanName, spanCity}
+
+	// Sort and deOverlap with both input orders; the result must be identical.
+	sort.Slice(orderAB, func(i, j int) bool {
+		if orderAB[i].Start != orderAB[j].Start {
+			return orderAB[i].Start < orderAB[j].Start
+		}
+		if orderAB[i].End != orderAB[j].End {
+			return orderAB[i].End > orderAB[j].End
+		}
+		return orderAB[i].Type < orderAB[j].Type
+	})
+	sort.Slice(orderBA, func(i, j int) bool {
+		if orderBA[i].Start != orderBA[j].Start {
+			return orderBA[i].Start < orderBA[j].Start
+		}
+		if orderBA[i].End != orderBA[j].End {
+			return orderBA[i].End > orderBA[j].End
+		}
+		return orderBA[i].Type < orderBA[j].Type
+	})
+
+	mergedAB := deOverlap(orderAB)
+	mergedBA := deOverlap(orderBA)
+
+	if len(mergedAB) != 1 {
+		t.Fatalf("orderAB: expected 1 merged span, got %d: %+v", len(mergedAB), mergedAB)
+	}
+	if len(mergedBA) != 1 {
+		t.Fatalf("orderBA: expected 1 merged span, got %d: %+v", len(mergedBA), mergedBA)
+	}
+
+	const wantType = "CITY" // lexicographically smallest of "CITY" and "NAME"
+	if mergedAB[0].Type != wantType {
+		t.Errorf("orderAB: winner type = %q, want %q", mergedAB[0].Type, wantType)
+	}
+	if mergedBA[0].Type != wantType {
+		t.Errorf("orderBA: winner type = %q, want %q", mergedBA[0].Type, wantType)
+	}
+	if mergedAB[0].Type != mergedBA[0].Type {
+		t.Errorf("non-deterministic: orderAB=%q, orderBA=%q", mergedAB[0].Type, mergedBA[0].Type)
+	}
+}
+
+// TestSortTieBreak_EndToEndConsistentPseudonym verifies that the sort tie-break
+// propagates end-to-end: when two detectors both match the same substring at
+// the same offsets but assign different Types, repeated calls to AnonymizeJSON
+// with the same input always produce the same pseudonym abbreviation, ensuring
+// multi-turn Restore round-trips are stable.
+func TestSortTieBreak_EndToEndConsistentPseudonym(t *testing.T) {
+	t.Parallel()
+
+	// Build two detectors that each match the same token "Berlin" in the input
+	// but label it with a different Type.
+	detCity, err := NewRegexDetector([]Pattern{
+		{Type: "CITY", Regexp: `Berlin`},
+	})
+	if err != nil {
+		t.Fatalf("NewRegexDetector CITY: %v", err)
+	}
+	detName, err := NewRegexDetector([]Pattern{
+		{Type: "NAME", Regexp: `Berlin`},
+	})
+	if err != nil {
+		t.Fatalf("NewRegexDetector NAME: %v", err)
+	}
+
+	body := []byte(`{"model":"gpt-4","messages":[{"role":"user","content":"I live in Berlin."}]}`)
+
+	// Run with detectors in both orders; the anonymized bodies must be identical
+	// (same pseudonym = same abbreviation = same content bytes).
+	runAnon := func(detectors []Detector) []byte {
+		t.Helper()
+		eng := NewEngine(testSecret, detectors)
+		f := eng.NewFilter(testOrgID)
+		out, anonErr := f.AnonymizeJSON(body)
+		if anonErr != nil {
+			t.Fatalf("AnonymizeJSON: %v", anonErr)
+		}
+		return out
+	}
+
+	outCityFirst := runAnon([]Detector{detCity, detName})
+	outNameFirst := runAnon([]Detector{detName, detCity})
+
+	if string(outCityFirst) != string(outNameFirst) {
+		t.Errorf("pseudonym differs by detector order:\n  CITY first: %s\n  NAME first: %s",
+			outCityFirst, outNameFirst)
+	}
+
+	// Neither output should contain the original value.
+	if strings.Contains(string(outCityFirst), "Berlin") {
+		t.Error("original value 'Berlin' not masked in anonymized output")
+	}
+}

--- a/internal/pii/pii_test.go
+++ b/internal/pii/pii_test.go
@@ -105,7 +105,10 @@ func TestRegexDetector_DefaultPatterns_Recognition(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			spans := d.Find(tc.text)
+			spans, err := d.Find(tc.text)
+			if err != nil {
+				t.Fatalf("Find(%q): unexpected error: %v", tc.text, err)
+			}
 			if len(spans) == 0 {
 				t.Fatalf("Find(%q): no spans, want at least one", tc.text)
 			}
@@ -134,7 +137,10 @@ func TestRegexDetector_NoMatchInCleanText(t *testing.T) {
 	}
 
 	text := "the quick brown fox jumps over the lazy dog"
-	spans := d.Find(text)
+	spans, err := d.Find(text)
+	if err != nil {
+		t.Fatalf("Find(%q): unexpected error: %v", text, err)
+	}
 	if len(spans) != 0 {
 		t.Errorf("Find(%q) = %+v, want no spans", text, spans)
 	}
@@ -152,7 +158,10 @@ func TestRegexDetector_NonOverlappingSpans(t *testing.T) {
 	}
 
 	text := "send to alice@example.com and bob@example.com today"
-	spans := d.Find(text)
+	spans, err := d.Find(text)
+	if err != nil {
+		t.Fatalf("Find(%q): unexpected error: %v", text, err)
+	}
 	if len(spans) != 2 {
 		t.Fatalf("Find(%q) = %+v, want 2 non-overlapping spans", text, spans)
 	}
@@ -999,13 +1008,25 @@ func TestTypeAbbrev(t *testing.T) {
 		typ  string
 		want string
 	}{
+		// Built-in Stage 0 regex types — fixed codes, unchanged.
 		{"EMAIL", "EM"},
 		{"IBAN", "IB"},
 		{"PHONE", "PH"},
 		{"CREDIT_CARD", "CC"},
 		{"TAX_ID", "TX"},
-		{"UNKNOWN_TYPE", "XX"},
-		{"", "XX"},
+		// Stage 1a gazetteer types — fixed codes.
+		{"NAME", "NM"},
+		{"PERSON", "PN"},
+		{"CITY", "CT"},
+		{"LOCATION", "LO"},
+		{"ORG", "OR"},
+		{"COMPANY", "CO"},
+		// Operator custom types — stable derivation from first two alnum chars of
+		// the uppercased type. The result is always 2 chars in [A-Z0-9].
+		{"UNKNOWN_TYPE", "UN"},
+		// Empty type: no alnum chars → derived from FNV-1a hash. The exact value
+		// is stable (deterministic hash), verified here as a regression anchor.
+		{"", string(stableAbbrev(""))},
 	}
 
 	for _, tc := range tests {
@@ -1063,17 +1084,26 @@ func TestReplaceSpansInText_Substitution(t *testing.T) {
 func TestDeOverlap(t *testing.T) {
 	t.Parallel()
 
+	// FIX 1: deOverlap now merges overlapping spans into their union instead
+	// of dropping later-starting spans. This prevents a short gazetteer span
+	// from suppressing a longer regex PII span (the phone-number regression).
+	//
+	// Scenario: A=[0,10) type A, B=[5,15) type B overlap; C=[15,20) is disjoint.
+	// Union of A and B is [0,15). Type is A (both have length 10, first wins).
+	// C passes through unchanged. Result: 2 spans: [0,15)/"A", [15,20)/"C".
 	spans := []Span{
 		{Start: 0, End: 10, Type: "A"},
-		{Start: 5, End: 15, Type: "B"},  // overlaps A
-		{Start: 15, End: 20, Type: "C"}, // non-overlapping
+		{Start: 5, End: 15, Type: "B"},  // overlaps A → merged into union
+		{Start: 15, End: 20, Type: "C"}, // non-overlapping, passes through
 	}
 	result := deOverlap(spans)
 	if len(result) != 2 {
 		t.Fatalf("deOverlap: got %d spans, want 2: %+v", len(result), result)
 	}
-	if result[0] != spans[0] {
-		t.Errorf("result[0] = %+v, want %+v", result[0], spans[0])
+	// The union of A and B spans [0,15); type is "A" (tie → first-seen wins).
+	wantUnion := Span{Start: 0, End: 15, Type: "A"}
+	if result[0] != wantUnion {
+		t.Errorf("result[0] = %+v, want %+v (union of overlapping spans)", result[0], wantUnion)
 	}
 	if result[1] != spans[2] {
 		t.Errorf("result[1] = %+v, want %+v", result[1], spans[2])

--- a/internal/pii/pseudonym.go
+++ b/internal/pii/pseudonym.go
@@ -103,10 +103,18 @@ func normalizeValue(typ, value string) string {
 }
 
 // typeAbbrev maps a PII type name to a stable two-character uppercase
-// abbreviation used in the token format. Unknown types fall back to "XX"
-// so that new detector types do not break the token format.
+// abbreviation used in the token format. The returned value is always exactly
+// two characters in [A-Z0-9], which keeps the canonical pseudonym shape
+// (PII_<2 alnum>_<24 hex>) valid regardless of detector type.
+//
+// Known built-in and gazetteer types have fixed codes. For operator-supplied
+// custom types, the first two [A-Za-z0-9] characters of the uppercased type
+// are used; if fewer than two such characters exist, the shortfall is padded
+// using a byte from the FNV-1a hash of the type so distinct types get
+// distinct codes where possible.
 func typeAbbrev(typ string) string {
 	switch typ {
+	// Stage 0 regex types (unchanged).
 	case "EMAIL":
 		return "EM"
 	case "IBAN":
@@ -117,7 +125,67 @@ func typeAbbrev(typ string) string {
 		return "CC"
 	case "TAX_ID":
 		return "TX"
+	// Gazetteer types.
+	case "NAME":
+		return "NM"
+	case "PERSON":
+		return "PN"
+	case "CITY":
+		return "CT"
+	case "LOCATION":
+		return "LO"
+	case "ORG":
+		return "OR"
+	case "COMPANY":
+		return "CO"
 	default:
-		return "XX"
+		return stableAbbrev(typ)
 	}
+}
+
+// stableAbbrev derives a stable two-character [A-Z0-9] abbreviation for an
+// arbitrary PII type string. It takes the first two alphanumeric characters
+// from the uppercased type; if fewer than two are available, it pads using a
+// character derived from the FNV-1a hash of the full type name so that
+// distinct types produce distinct codes where possible.
+func stableAbbrev(typ string) string {
+	upper := strings.ToUpper(typ)
+	var chars [2]byte
+
+	idx := 0
+	for _, r := range upper {
+		if idx >= 2 {
+			break
+		}
+		if (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			chars[idx] = byte(r)
+			idx++
+		}
+	}
+
+	if idx < 2 {
+		// Pad with a character derived from FNV-1a so distinct types differ.
+		h := fnv1a(typ)
+		const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+		for ; idx < 2; idx++ {
+			chars[idx] = alphabet[h%uint32(len(alphabet))]
+			h = (h >> 5) | (h << 27) // cheap rotation to get a second character
+		}
+	}
+
+	return string(chars[:])
+}
+
+// fnv1a returns a 32-bit FNV-1a hash of s.
+func fnv1a(s string) uint32 {
+	const (
+		offset uint32 = 2166136261
+		prime  uint32 = 16777619
+	)
+	h := offset
+	for i := 0; i < len(s); i++ {
+		h ^= uint32(s[i])
+		h *= prime
+	}
+	return h
 }

--- a/internal/pii/regex.go
+++ b/internal/pii/regex.go
@@ -60,7 +60,10 @@ func NewRegexDetector(patterns []Pattern) (*RegexDetector, error) {
 // priority; among matches starting at the same position, the longest
 // match wins. This policy is equivalent to scanning the text left-to-right
 // and advancing past each accepted match.
-func (d *RegexDetector) Find(text string) []Span {
+//
+// RegexDetector never returns an error; the error return satisfies the
+// Detector interface and is always nil.
+func (d *RegexDetector) Find(text string) ([]Span, error) {
 	// Collect all raw matches from every pattern.
 	var raw []Span
 	for _, cp := range d.compiled {
@@ -70,7 +73,7 @@ func (d *RegexDetector) Find(text string) []Span {
 		}
 	}
 	if len(raw) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// Sort: leftmost first; on tie, longest first (largest End first).
@@ -91,7 +94,7 @@ func (d *RegexDetector) Find(text string) []Span {
 		result = append(result, s)
 		cursor = s.End
 	}
-	return result
+	return result, nil
 }
 
 // DefaultPatterns returns the built-in set of conservative PII detection


### PR DESCRIPTION
PII Stage 1a: a locale-neutral gazetteer detector that catches unstructured PII (names, places, company forms, operator-supplied terms) the Stage 0 regex misses. Pure Go, CGO-free, opt-in within PII (`settings.pii.gazetteer.enabled`, default off). Targets `0.0.22-beta.2`.

## Design
- One pure-Go **Aho-Corasick** automaton matches all terms in O(input). The engine is **language-blind** — locales are just data; multiple locales coexist in one automaton.
- Terms from three sources: opt-in **embedded packs** (universal `company-forms` + a `de-cities` template), operator **directories** (`*.txt`, any language), and **inline** config terms/blacklist. Hybrid delivery keeps the single binary slim and fully extensible.
- Per-rune case folding (`unicode.ToLower`, strict 1:1) so Span **byte offsets into the original text stay exact**; whole-token Unicode boundaries; leftmost-longest overlap resolution. Spans flow through the existing HMAC pseudonymize/restore pipeline unchanged. Arbitrary operator types map to a stable 2-char code, keeping the canonical token valid for the 0c restorer.

## Reviews (external round caught real issues — all fixed)
Internal code-review + security-audit, then an external round (Codex + Antigravity). Codex found, and we fixed:
- **High (privacy regression):** the shared overlap resolution dropped a later-starting span, so a gazetteer span could leave part of an overlapping Stage-0 PII span (e.g. a phone number) unmasked. Now overlapping spans are **merged into their union** — no detected byte is ever left in cleartext.
- **High (DoS):** unbounded match/output growth on short terms. Added a per-scan match cap (the `Detector` interface now returns an error and **fails the request closed**), plus build-time trie-state / output-link / file / byte / inline-term caps (fail closed at startup).
- **Medium:** only regular files are read from operator dirs (no symlink/FIFO follow); load caps are global across all dirs + inline.
- **Medium (documented):** simple case folding does not cover ß↔ss / final sigma / NFC-NFD (full folding would break the 1:1 offset invariant) — operators add spelling variants.

A focused re-review confirmed (a) the union-merge leaves no PII byte unmasked and round-trips, and (b) a `Find` error fails the request closed (422, never forwards unmasked content).

`go build ./...`, `go vet ./...`, full `go test ./...` and `go test -race ./internal/pii/ ./internal/config/ ./internal/proxy/` green.