### PR TITLE
feat(proxy): fail-closed abort signal + multi-line output for stream adapters (L-018)

### DIFF
--- a/internal/proxy/adapter.go
+++ b/internal/proxy/adapter.go
@@ -1,10 +1,17 @@
 package proxy
 
 import (
+	"errors"
 	"net/http"
 	"regexp"
 	"strings"
 )
+
+// errStreamTransformAborted is returned by TransformStreamLine when the
+// adapter detects a protocol violation that requires the stream to be torn
+// down fail-closed. It carries no content or caller values; the handler
+// converts it into a content-free SSE error event for the client.
+var errStreamTransformAborted = errors.New("stream transform aborted")
 
 // forwardedPseudonymRe matches the canonical PII pseudonym shape produced by
 // the PII pipeline: PII_ followed by exactly 2 alphanumeric characters, then
@@ -74,9 +81,22 @@ type Adapter interface {
 	TransformResponse(body []byte) ([]byte, error)
 
 	// TransformStreamLine processes a single line from an upstream SSE stream.
-	// It returns the (possibly rewritten) line to write to the client, or nil
-	// to signal that the line should be silently dropped.
-	TransformStreamLine(line []byte) []byte
+	// It returns zero or more OpenAI-shaped SSE output lines and an error:
+	//
+	//   - (lines, nil): emit the returned lines to the client. A nil or empty
+	//     slice means the upstream line is silently dropped (e.g. a Anthropic
+	//     ping or SSE event-type line that has no OpenAI equivalent).
+	//   - (nil, err): the stream must be aborted fail-closed. The error is a
+	//     sentinel (errStreamTransformAborted) that carries no content or PII;
+	//     it signals that the upstream produced a malformed or protocol-violating
+	//     line that cannot be safely forwarded. The handler tears the stream down
+	//     and emits a content-free error event to the client.
+	//
+	// A single-line result is the common case (one upstream line → one output
+	// line). Multiple output lines arise when a single upstream line must produce
+	// more than one downstream SSE event (e.g. a Gemini chunk that contains both
+	// text content and a functionCall part).
+	TransformStreamLine(line []byte) ([][]byte, error)
 
 	// StreamUsage returns the token counts accumulated during streaming.
 	// It is only meaningful after all TransformStreamLine calls have completed.

--- a/internal/proxy/anthropic.go
+++ b/internal/proxy/anthropic.go
@@ -703,31 +703,31 @@ func (a *AnthropicAdapter) TransformResponse(body []byte) ([]byte, error) {
 //     carrying index and function.arguments:<partial_json>.
 //
 // FIX 4: the total number of distinct tool_use blocks is capped at
-// maxAnthropicToolBlocks. Blocks beyond the cap are dropped (nil returned).
-// Negative or oversized content-block indices are also rejected (nil returned).
+// maxAnthropicToolBlocks. Blocks beyond the cap abort the stream
+// (errStreamTransformAborted) rather than silently dropping a tool call.
+// Negative content-block indices are also rejected with abort.
 //
 // FIX 8: a duplicate content_block_start for an already-seen content-block
-// index is dropped (nil returned) rather than overwriting the mapping.
-// Residual: TransformStreamLine cannot signal a hard abort because it returns
-// []byte only; a malformed upstream tool stream may silently drop an affected
-// tool call. This is a correctness limitation, not a PII leak, tracked as a
-// follow-up (adapter abort-signal requires an interface change).
-func (a *AnthropicAdapter) TransformStreamLine(line []byte) []byte {
+// index aborts the stream (errStreamTransformAborted) rather than silently
+// overwriting or dropping the mapping. A duplicate indicates a malformed
+// upstream stream and the fail-closed signal lets the handler emit a
+// content-free error event instead of continuing with inconsistent state.
+func (a *AnthropicAdapter) TransformStreamLine(line []byte) ([][]byte, error) {
 	s := string(line)
 
 	// Blank line — SSE event delimiter, pass through.
 	if s == "" {
-		return line
+		return [][]byte{line}, nil
 	}
 
 	// Drop Anthropic event-type lines; OpenAI does not use them.
 	if strings.HasPrefix(s, "event:") {
-		return nil
+		return nil, nil
 	}
 
 	const dataPrefix = "data: "
 	if !strings.HasPrefix(s, dataPrefix) {
-		return line
+		return [][]byte{line}, nil
 	}
 
 	payload := []byte(s[len(dataPrefix):])
@@ -735,7 +735,7 @@ func (a *AnthropicAdapter) TransformStreamLine(line []byte) []byte {
 	var event map[string]jsonx.RawMessage
 	if err := jsonx.Unmarshal(payload, &event); err != nil {
 		// Not valid JSON — pass through unchanged so the client can observe it.
-		return line
+		return [][]byte{line}, nil
 	}
 
 	var eventType string
@@ -764,7 +764,7 @@ func (a *AnthropicAdapter) TransformStreamLine(line []byte) []byte {
 			a.msgID = "chatcmpl-proxy"
 		}
 		chunk := a.buildChunk(openAIChunkDelta{Role: "assistant"}, nil)
-		return appendDataPrefix(chunk)
+		return [][]byte{appendDataPrefix(chunk)}, nil
 
 	case "content_block_start":
 		// Only tool_use blocks produce output at this stage; text content_block_start
@@ -778,37 +778,36 @@ func (a *AnthropicAdapter) TransformStreamLine(line []byte) []byte {
 			} `json:"content_block"`
 		}
 		if err := jsonx.Unmarshal(payload, &cbs); err != nil {
-			return nil
+			// Unparseable content_block_start — abort; we cannot track block state.
+			return nil, errStreamTransformAborted
 		}
 		if cbs.ContentBlock.Type != "tool_use" {
-			return nil
+			return nil, nil
 		}
 
-		// FIX 4: reject negative content-block indices.
+		// FIX 4: reject negative content-block indices — abort fail-closed.
 		if cbs.Index < 0 {
-			return nil
+			return nil, errStreamTransformAborted
 		}
-		// FIX 4: cap the total number of distinct tool_use blocks.
+		// FIX 4: cap the total number of distinct tool_use blocks — abort.
 		if a.toolCallCounter >= maxAnthropicToolBlocks {
-			return nil
+			return nil, errStreamTransformAborted
 		}
 
-		// FIX 8: reject duplicate content-block indices (do not overwrite).
+		// FIX 8: duplicate content-block index — abort (stream state is corrupt).
 		if a.blockToToolCall != nil {
 			if _, exists := a.blockToToolCall[cbs.Index]; exists {
-				// Duplicate — drop silently. See residual note in TransformStreamLine doc.
-				return nil
+				return nil, errStreamTransformAborted
 			}
 		}
 
 		// FIX 1 (streaming): charset-validate tool_use id and name before registering
-		// the block. Invalid values may carry PII pseudonyms; drop the block (nil)
-		// rather than forwarding it, consistent with other streaming drop behavior.
+		// the block. Invalid values may carry PII pseudonyms; abort fail-closed.
 		if cbs.ContentBlock.ID != "" && !anthropicToolIDRe.MatchString(cbs.ContentBlock.ID) {
-			return nil
+			return nil, errStreamTransformAborted
 		}
 		if cbs.ContentBlock.Name != "" && !anthropicToolIDRe.MatchString(cbs.ContentBlock.Name) {
-			return nil
+			return nil, errStreamTransformAborted
 		}
 
 		// Assign the next tool-call index to this content-block index.
@@ -832,7 +831,7 @@ func (a *AnthropicAdapter) TransformStreamLine(line []byte) []byte {
 			},
 		}
 		chunk := a.buildChunk(openAIChunkDelta{ToolCalls: []openAIToolCall{tc}}, nil)
-		return appendDataPrefix(chunk)
+		return [][]byte{appendDataPrefix(chunk)}, nil
 
 	case "content_block_delta":
 		var cbd struct {
@@ -844,20 +843,23 @@ func (a *AnthropicAdapter) TransformStreamLine(line []byte) []byte {
 			} `json:"delta"`
 		}
 		if err := jsonx.Unmarshal(payload, &cbd); err != nil {
-			return nil
+			// Unparseable delta — abort; content may be corrupted or malformed.
+			return nil, errStreamTransformAborted
 		}
 		switch cbd.Delta.Type {
 		case "text_delta":
 			chunk := a.buildChunk(openAIChunkDelta{Content: cbd.Delta.Text}, nil)
-			return appendDataPrefix(chunk)
+			return [][]byte{appendDataPrefix(chunk)}, nil
 		case "input_json_delta":
 			// Look up the tool-call index for this content-block index.
 			if a.blockToToolCall == nil {
-				return nil
+				// input_json_delta before any content_block_start — protocol violation.
+				return nil, errStreamTransformAborted
 			}
 			toolCallIdx, ok := a.blockToToolCall[cbd.Index]
 			if !ok {
-				return nil
+				// Delta references an unknown block index — protocol violation.
+				return nil, errStreamTransformAborted
 			}
 			// Emit arguments fragment delta: index + function.arguments only.
 			tcIdx := toolCallIdx
@@ -868,9 +870,10 @@ func (a *AnthropicAdapter) TransformStreamLine(line []byte) []byte {
 				},
 			}
 			chunk := a.buildChunk(openAIChunkDelta{ToolCalls: []openAIToolCall{tc}}, nil)
-			return appendDataPrefix(chunk)
+			return [][]byte{appendDataPrefix(chunk)}, nil
 		default:
-			return nil
+			// Unknown delta type — drop silently (no state impact).
+			return nil, nil
 		}
 
 	case "message_delta":
@@ -883,21 +886,22 @@ func (a *AnthropicAdapter) TransformStreamLine(line []byte) []byte {
 			} `json:"usage"`
 		}
 		if err := jsonx.Unmarshal(payload, &md); err != nil {
-			return nil
+			// Unparseable message_delta — abort; finish_reason would be lost.
+			return nil, errStreamTransformAborted
 		}
 		a.outputTokens = md.Usage.OutputTokens
 		reason := mapStopReason(md.Delta.StopReason)
 		chunk := a.buildChunk(openAIChunkDelta{}, &reason)
-		return appendDataPrefix(chunk)
+		return [][]byte{appendDataPrefix(chunk)}, nil
 
 	case "message_stop":
-		return []byte("data: [DONE]")
+		return [][]byte{[]byte("data: [DONE]")}, nil
 
 	case "ping", "content_block_stop":
-		return nil
+		return nil, nil
 
 	default:
-		return nil
+		return nil, nil
 	}
 }
 

--- a/internal/proxy/anthropic_test.go
+++ b/internal/proxy/anthropic_test.go
@@ -728,13 +728,20 @@ func transformRequest(t *testing.T, input string) map[string]json.RawMessage {
 }
 
 // runStream feeds each event line through a fresh AnthropicAdapter and returns
-// the non-nil outputs and the adapter itself for further inspection.
+// the non-nil outputs and the adapter itself for further inspection. It collects
+// all output lines from each call (multi-line output is flattened).
 func runStream(t *testing.T, a *AnthropicAdapter, events []string) [][]byte {
 	t.Helper()
 	var out [][]byte
 	for _, ev := range events {
-		if b := a.TransformStreamLine([]byte(ev)); b != nil {
-			out = append(out, b)
+		lines, err := a.TransformStreamLine([]byte(ev))
+		if err != nil {
+			t.Fatalf("runStream: TransformStreamLine returned error on %q: %v", ev, err)
+		}
+		for _, b := range lines {
+			if b != nil {
+				out = append(out, b)
+			}
 		}
 	}
 	return out
@@ -1741,10 +1748,10 @@ func TestAnthropicStream_ToolUseHeaderDelta(t *testing.T) {
 
 	a := &AnthropicAdapter{}
 	// Prime the adapter with a message_start to set the ID.
-	_ = a.TransformStreamLine([]byte(`data: {"type":"message_start","message":{"id":"msg_hdr","usage":{"input_tokens":5}}}`))
+	transformLineIgnore(a, []byte(`data: {"type":"message_start","message":{"id":"msg_hdr","usage":{"input_tokens":5}}}`))
 
 	line := `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_hdr","name":"get_data","input":{}}}`
-	out := a.TransformStreamLine([]byte(line))
+	out := transformLine1(a, []byte(line))
 	if out == nil {
 		t.Fatal("content_block_start(tool_use) returned nil, want header delta")
 	}
@@ -1791,10 +1798,10 @@ func TestAnthropicStream_ToolUseHeaderDelta_WireFormat(t *testing.T) {
 	t.Parallel()
 
 	a := &AnthropicAdapter{}
-	_ = a.TransformStreamLine([]byte(`data: {"type":"message_start","message":{"id":"msg_wire","usage":{"input_tokens":2}}}`))
+	transformLineIgnore(a, []byte(`data: {"type":"message_start","message":{"id":"msg_wire","usage":{"input_tokens":2}}}`))
 
 	line := `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_wire","name":"my_fn","input":{}}}`
-	out := a.TransformStreamLine([]byte(line))
+	out := transformLine1(a, []byte(line))
 	if out == nil {
 		t.Fatal("content_block_start(tool_use) returned nil, want header delta")
 	}
@@ -1825,11 +1832,11 @@ func TestAnthropicStream_InputJsonDeltaFragment_WireFormat(t *testing.T) {
 	t.Parallel()
 
 	a := &AnthropicAdapter{}
-	_ = a.TransformStreamLine([]byte(`data: {"type":"message_start","message":{"id":"msg_fwire","usage":{"input_tokens":2}}}`))
-	_ = a.TransformStreamLine([]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_fwire","name":"do_thing","input":{}}}`))
+	transformLineIgnore(a, []byte(`data: {"type":"message_start","message":{"id":"msg_fwire","usage":{"input_tokens":2}}}`))
+	transformLineIgnore(a, []byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_fwire","name":"do_thing","input":{}}}`))
 
 	fragLine := `data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"x\":1}"}}`
-	out := a.TransformStreamLine([]byte(fragLine))
+	out := transformLine1(a, []byte(fragLine))
 	if out == nil {
 		t.Fatal("input_json_delta returned nil, want fragment delta")
 	}
@@ -1856,11 +1863,11 @@ func TestAnthropicStream_InputJsonDeltaFragment(t *testing.T) {
 
 	a := &AnthropicAdapter{}
 	// Register block 0 → tool-call 0 by sending a content_block_start first.
-	_ = a.TransformStreamLine([]byte(`data: {"type":"message_start","message":{"id":"msg_frag","usage":{"input_tokens":3}}}`))
-	_ = a.TransformStreamLine([]byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_frag","name":"fn","input":{}}}`))
+	transformLineIgnore(a, []byte(`data: {"type":"message_start","message":{"id":"msg_frag","usage":{"input_tokens":3}}}`))
+	transformLineIgnore(a, []byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_frag","name":"fn","input":{}}}`))
 
 	fragLine := `data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"x\":1}"}}`
-	out := a.TransformStreamLine([]byte(fragLine))
+	out := transformLine1(a, []byte(fragLine))
 	if out == nil {
 		t.Fatal("input_json_delta returned nil, want fragment delta")
 	}
@@ -1916,7 +1923,7 @@ func TestAnthropicStream_TextBlockThenToolUse_IndexMapping(t *testing.T) {
 	}
 	var results []result
 	for _, ev := range events {
-		out := a.TransformStreamLine([]byte(ev))
+		out := transformLine1(a, []byte(ev))
 		results = append(results, result{out: out, drop: out == nil})
 	}
 
@@ -1999,7 +2006,7 @@ func TestAnthropicStream_TwoToolUseBlocks_IndexMapping(t *testing.T) {
 
 	var chunks []openAIChunk
 	for _, ev := range events {
-		out := a.TransformStreamLine([]byte(ev))
+		out := transformLine1(a, []byte(ev))
 		if out != nil && !strings.HasPrefix(string(out), "data: [DONE]") {
 			chunks = append(chunks, parseChunk(t, out))
 		}
@@ -2096,9 +2103,9 @@ func TestAnthropicStream_TerminalEvents(t *testing.T) {
 
 			a := &AnthropicAdapter{}
 			// Set a known message ID so parseChunk can be used.
-			_ = a.TransformStreamLine([]byte(`data: {"type":"message_start","message":{"id":"msg_term","usage":{"input_tokens":5}}}`))
+			transformLineIgnore(a, []byte(`data: {"type":"message_start","message":{"id":"msg_term","usage":{"input_tokens":5}}}`))
 
-			out := a.TransformStreamLine([]byte(tc.line))
+			out := transformLine1(a, []byte(tc.line))
 
 			if tc.wantNil {
 				if out != nil {
@@ -2293,8 +2300,10 @@ func TestAnthropicTransformStreamLine(t *testing.T) {
 		name string
 		// line is the raw SSE line bytes sent by Anthropic's server.
 		line string
-		// wantNil means the adapter should drop this line.
+		// wantNil means the adapter should silently drop this line (no output, no error).
 		wantNil bool
+		// wantAbort means the adapter should return errStreamTransformAborted.
+		wantAbort bool
 		// wantExact, if non-empty, is the exact byte slice expected (for simple cases).
 		wantExact string
 		// checkFn performs structured assertions on the returned line.
@@ -2450,20 +2459,13 @@ func TestAnthropicTransformStreamLine(t *testing.T) {
 			},
 		},
 		{
-			name: "input_json_delta emits arguments fragment with correct tool-call index",
+			name: "input_json_delta on fresh adapter aborts (no block registered)",
 			line: `data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"loc"}}`,
-			checkFn: func(t *testing.T, out []byte) {
-				t.Helper()
-				// This test requires the adapter to have already seen a content_block_start
-				// for index 0. We prime the adapter inline.
-				// NOTE: This test is intended to be called after the adapter has seen the
-				// content_block_start; the standalone test uses a fresh adapter so it will
-				// drop the delta (no known mapping). The intent is verified via the
-				// integration flow test below.
-				// Here we verify that a nil is returned when no block is registered.
-				// That behavior is tested in TestAnthropicStreamToolCallFlow.
-			},
-			wantNil: true, // fresh adapter has no block→toolcall mapping
+			// A fresh adapter has no block→toolcall mapping. An input_json_delta
+			// for an unregistered block index is a protocol violation — abort.
+			// The integration flow (with a primed adapter) is tested in
+			// TestAnthropicStreamToolCallFlow.
+			wantAbort: true,
 		},
 		{
 			name: "message_delta with stop_reason tool_use produces finish_reason tool_calls",
@@ -2490,7 +2492,25 @@ func TestAnthropicTransformStreamLine(t *testing.T) {
 			t.Parallel()
 
 			a := &AnthropicAdapter{}
-			out := a.TransformStreamLine([]byte(tc.line))
+			outLines, err := a.TransformStreamLine([]byte(tc.line))
+
+			if tc.wantAbort {
+				if err == nil {
+					t.Errorf("TransformStreamLine() error = nil, want errStreamTransformAborted")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("TransformStreamLine() unexpected error: %v", err)
+			}
+
+			out := func() []byte {
+				if len(outLines) == 0 {
+					return nil
+				}
+				return outLines[0]
+			}()
 
 			if tc.wantNil {
 				if out != nil {
@@ -2526,10 +2546,10 @@ func TestAnthropicTransformStreamLine_IDPropagation(t *testing.T) {
 	a := &AnthropicAdapter{}
 
 	startLine := []byte(`data: {"type":"message_start","message":{"id":"msg_propagate","type":"message","role":"assistant","content":[],"model":"claude-3-5-sonnet-20240620"}}`)
-	_ = a.TransformStreamLine(startLine)
+	transformLineIgnore(a, startLine)
 
 	deltaLine := []byte(`data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"world"}}`)
-	out := a.TransformStreamLine(deltaLine)
+	out := transformLine1(a, deltaLine)
 	if out == nil {
 		t.Fatal("TransformStreamLine(content_block_delta) = nil, want non-nil")
 	}
@@ -2572,7 +2592,7 @@ func TestAnthropicStreamToolCallFlow(t *testing.T) {
 	}
 	var results []result
 	for _, ev := range events {
-		out := a.TransformStreamLine([]byte(ev))
+		out := transformLine1(a, []byte(ev))
 		results = append(results, result{line: out, drop: out == nil})
 	}
 
@@ -2705,7 +2725,7 @@ func TestAnthropicStreamMultipleToolCalls(t *testing.T) {
 
 	var chunks []openAIChunk
 	for _, ev := range events {
-		out := a.TransformStreamLine([]byte(ev))
+		out := transformLine1(a, []byte(ev))
 		if out != nil && !strings.HasPrefix(string(out), "data: [DONE]") {
 			chunks = append(chunks, parseChunk(t, out))
 		}
@@ -2770,7 +2790,7 @@ func TestAnthropicStreamTextAndToolMixed(t *testing.T) {
 	}
 	var results []lineResult
 	for _, ev := range events {
-		out := a.TransformStreamLine([]byte(ev))
+		out := transformLine1(a, []byte(ev))
 		results = append(results, lineResult{out: out, drop: out == nil})
 	}
 
@@ -3039,36 +3059,41 @@ func TestAnthropicErrorStrings(t *testing.T) {
 // ── FIX 4: streaming state cap ────────────────────────────────────────────────
 
 // TestAnthropicStream_ToolBlockCap verifies that streaming content_block_start
-// events for more than maxAnthropicToolBlocks distinct tool_use blocks are
-// silently dropped — the adapter does not grow the map beyond the cap.
+// events for exactly maxAnthropicToolBlocks distinct tool_use blocks are accepted,
+// and that the first block beyond the cap causes errStreamTransformAborted (the
+// adapter signals fail-closed rather than silently dropping the excess call).
 func TestAnthropicStream_ToolBlockCap(t *testing.T) {
 	t.Parallel()
 
 	a := &AnthropicAdapter{}
 	// Prime with message_start.
-	_ = a.TransformStreamLine([]byte(`data: {"type":"message_start","message":{"id":"msg_cap","usage":{"input_tokens":1}}}`))
+	transformLineIgnore(a, []byte(`data: {"type":"message_start","message":{"id":"msg_cap","usage":{"input_tokens":1}}}`))
 
-	accepted := 0
-	dropped := 0
-	for i := 0; i < maxAnthropicToolBlocks+10; i++ {
+	// Accept exactly maxAnthropicToolBlocks blocks.
+	for i := 0; i < maxAnthropicToolBlocks; i++ {
 		line := fmt.Sprintf(
 			`data: {"type":"content_block_start","index":%d,"content_block":{"type":"tool_use","id":"toolu_%d","name":"fn_%d","input":{}}}`,
 			i, i, i,
 		)
-		out := a.TransformStreamLine([]byte(line))
-		if out != nil {
-			accepted++
-		} else {
-			dropped++
+		lines, err := a.TransformStreamLine([]byte(line))
+		if err != nil {
+			t.Fatalf("block %d (within cap): got error %v, want nil", i, err)
+		}
+		if len(lines) == 0 {
+			t.Errorf("block %d (within cap): got no output, want header delta", i)
 		}
 	}
 
-	if accepted != maxAnthropicToolBlocks {
-		t.Errorf("accepted = %d, want %d (cap)", accepted, maxAnthropicToolBlocks)
+	// The next block must abort.
+	overCapLine := fmt.Sprintf(
+		`data: {"type":"content_block_start","index":%d,"content_block":{"type":"tool_use","id":"toolu_%d","name":"fn_%d","input":{}}}`,
+		maxAnthropicToolBlocks, maxAnthropicToolBlocks, maxAnthropicToolBlocks,
+	)
+	_, overErr := a.TransformStreamLine([]byte(overCapLine))
+	if overErr == nil {
+		t.Error("block over cap: got nil error, want errStreamTransformAborted")
 	}
-	if dropped != 10 {
-		t.Errorf("dropped = %d, want 10 (excess beyond cap)", dropped)
-	}
+
 	// The map must not exceed the cap.
 	if len(a.blockToToolCall) > maxAnthropicToolBlocks {
 		t.Errorf("blockToToolCall len = %d, exceeds cap %d", len(a.blockToToolCall), maxAnthropicToolBlocks)
@@ -3076,17 +3101,18 @@ func TestAnthropicStream_ToolBlockCap(t *testing.T) {
 }
 
 // TestAnthropicStream_NegativeIndex verifies that a content_block_start with a
-// negative index is silently dropped (FIX 4 defense against oversized indices).
+// negative index aborts the stream fail-closed (FIX 4 defense against malformed
+// upstream tool streams).
 func TestAnthropicStream_NegativeIndex(t *testing.T) {
 	t.Parallel()
 
 	a := &AnthropicAdapter{}
-	_ = a.TransformStreamLine([]byte(`data: {"type":"message_start","message":{"id":"msg_neg","usage":{"input_tokens":1}}}`))
+	transformLineIgnore(a, []byte(`data: {"type":"message_start","message":{"id":"msg_neg","usage":{"input_tokens":1}}}`))
 
 	line := `data: {"type":"content_block_start","index":-1,"content_block":{"type":"tool_use","id":"toolu_neg","name":"fn","input":{}}}`
-	out := a.TransformStreamLine([]byte(line))
-	if out != nil {
-		t.Errorf("negative index: got %q, want nil (drop)", out)
+	_, err := a.TransformStreamLine([]byte(line))
+	if err == nil {
+		t.Error("negative index: got nil error, want errStreamTransformAborted")
 	}
 	if a.toolCallCounter != 0 {
 		t.Errorf("toolCallCounter = %d, want 0 (negative index must not increment counter)", a.toolCallCounter)
@@ -3413,56 +3439,33 @@ func TestAnthropicFix7_ResponseInputValidation(t *testing.T) {
 // ── FIX 8: duplicate content-block index ──────────────────────────────────────
 
 // TestAnthropicStream_DuplicateContentBlockIndex verifies that a duplicate
-// content_block_start for an already-seen content-block index is silently
-// dropped (returns nil) rather than overwriting the existing mapping.
-// The first registration remains intact; subsequent deltas continue to route
-// correctly to the original tool call.
+// content_block_start for an already-seen content-block index aborts the stream
+// (returns errStreamTransformAborted) rather than silently overwriting the
+// existing mapping. A duplicate indicates a malformed upstream tool stream and
+// must be treated as a protocol violation fail-closed.
 func TestAnthropicStream_DuplicateContentBlockIndex(t *testing.T) {
 	t.Parallel()
 
 	a := &AnthropicAdapter{}
-	_ = a.TransformStreamLine([]byte(`data: {"type":"message_start","message":{"id":"msg_dup","usage":{"input_tokens":1}}}`))
+	transformLineIgnore(a, []byte(`data: {"type":"message_start","message":{"id":"msg_dup","usage":{"input_tokens":1}}}`))
 
 	// Register content-block index 0 → tool-call index 0.
-	first := a.TransformStreamLine([]byte(
+	firstLines, firstErr := a.TransformStreamLine([]byte(
 		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_first","name":"fn_first","input":{}}}`,
 	))
-	if first == nil {
-		t.Fatal("first content_block_start: got nil, want header delta")
+	if firstErr != nil {
+		t.Fatalf("first content_block_start: got error %v, want nil", firstErr)
+	}
+	if len(firstLines) == 0 {
+		t.Fatal("first content_block_start: got no lines, want header delta")
 	}
 
-	// Duplicate registration for the same index — must be dropped.
-	dup := a.TransformStreamLine([]byte(
+	// Duplicate registration for the same index — must abort.
+	_, dupErr := a.TransformStreamLine([]byte(
 		`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_dup","name":"fn_dup","input":{}}}`,
 	))
-	if dup != nil {
-		t.Errorf("duplicate content_block_start: got %q, want nil (must be dropped)", dup)
-	}
-
-	// toolCallCounter must still be 1 (the duplicate must not increment it).
-	if a.toolCallCounter != 1 {
-		t.Errorf("toolCallCounter = %d after duplicate, want 1", a.toolCallCounter)
-	}
-
-	// The mapping for index 0 must still point to the first tool call (0).
-	if a.blockToToolCall[0] != 0 {
-		t.Errorf("blockToToolCall[0] = %d after duplicate, want 0 (original mapping preserved)", a.blockToToolCall[0])
-	}
-
-	// Subsequent input_json_delta for index 0 must still route to tool-call 0.
-	frag := a.TransformStreamLine([]byte(
-		`data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"x\":1}"}}`,
-	))
-	if frag == nil {
-		t.Fatal("input_json_delta after duplicate: got nil, want fragment delta")
-	}
-	chunk := parseChunk(t, frag)
-	if len(chunk.Choices) != 1 || len(chunk.Choices[0].Delta.ToolCalls) != 1 {
-		t.Fatalf("fragment chunk structure unexpected: %+v", chunk)
-	}
-	tc := chunk.Choices[0].Delta.ToolCalls[0]
-	if tc.Index == nil || *tc.Index != 0 {
-		t.Errorf("fragment tool-call index = %v, want 0", tc.Index)
+	if dupErr == nil {
+		t.Error("duplicate content_block_start: got nil error, want errStreamTransformAborted")
 	}
 }
 
@@ -3470,35 +3473,35 @@ func TestAnthropicStream_DuplicateContentBlockIndex(t *testing.T) {
 
 // TestAnthropicStream_ToolUseCharsetValidation verifies that a streaming
 // content_block_start event for a tool_use block whose id or name contains
-// invalid characters is silently dropped (returns nil), matching the fail-closed
-// behavior of the non-streaming TransformResponse path.
+// invalid characters aborts the stream fail-closed (errStreamTransformAborted),
+// matching the fail-closed behavior of the non-streaming TransformResponse path.
 func TestAnthropicStream_ToolUseCharsetValidation(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		line    string
-		wantNil bool
+		name      string
+		line      string
+		wantAbort bool
 	}{
 		{
-			name:    "invalid id with @ is dropped",
-			line:    `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"bad@id","name":"good_name","input":{}}}`,
-			wantNil: true,
+			name:      "invalid id with @ aborts stream",
+			line:      `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"bad@id","name":"good_name","input":{}}}`,
+			wantAbort: true,
 		},
 		{
-			name:    "invalid name with space is dropped",
-			line:    `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_ok","name":"bad name","input":{}}}`,
-			wantNil: true,
+			name:      "invalid name with space aborts stream",
+			line:      `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_ok","name":"bad name","input":{}}}`,
+			wantAbort: true,
 		},
 		{
-			name:    "invalid id with @ in name position is dropped",
-			line:    `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_ok","name":"a@b","input":{}}}`,
-			wantNil: true,
+			name:      "invalid id with @ in name position aborts stream",
+			line:      `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_ok","name":"a@b","input":{}}}`,
+			wantAbort: true,
 		},
 		{
-			name:    "valid id and name produces header delta",
-			line:    `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_valid","name":"get_weather","input":{}}}`,
-			wantNil: false,
+			name:      "valid id and name produces header delta",
+			line:      `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_valid","name":"get_weather","input":{}}}`,
+			wantAbort: false,
 		},
 	}
 
@@ -3508,20 +3511,23 @@ func TestAnthropicStream_ToolUseCharsetValidation(t *testing.T) {
 
 			a := &AnthropicAdapter{}
 			// Prime with message_start.
-			_ = a.TransformStreamLine([]byte(`data: {"type":"message_start","message":{"id":"msg_cs","usage":{"input_tokens":1}}}`))
+			transformLineIgnore(a, []byte(`data: {"type":"message_start","message":{"id":"msg_cs","usage":{"input_tokens":1}}}`))
 
-			out := a.TransformStreamLine([]byte(tc.line))
-			if tc.wantNil {
-				if out != nil {
-					t.Errorf("got %q, want nil (block must be dropped for invalid charset)", out)
+			outLines, err := a.TransformStreamLine([]byte(tc.line))
+			if tc.wantAbort {
+				if err == nil {
+					t.Errorf("got nil error, want errStreamTransformAborted (block must abort for invalid charset)")
 				}
 				// Verify the tool-call counter was not incremented.
 				if a.toolCallCounter != 0 {
-					t.Errorf("toolCallCounter = %d after dropped block, want 0", a.toolCallCounter)
+					t.Errorf("toolCallCounter = %d after aborted block, want 0", a.toolCallCounter)
 				}
 			} else {
-				if out == nil {
-					t.Fatal("got nil, want header delta for valid id/name")
+				if err != nil {
+					t.Fatalf("got error %v, want nil for valid id/name", err)
+				}
+				if len(outLines) == 0 {
+					t.Fatal("got no output lines, want header delta for valid id/name")
 				}
 			}
 		})

--- a/internal/proxy/azure.go
+++ b/internal/proxy/azure.go
@@ -51,9 +51,10 @@ func (a *AzureAdapter) TransformResponse(body []byte) ([]byte, error) {
 }
 
 // TransformStreamLine returns the line unchanged; Azure streams are already in
-// OpenAI SSE format.
-func (a *AzureAdapter) TransformStreamLine(line []byte) []byte {
-	return line
+// OpenAI SSE format. The single-element slice preserves the exact current
+// passthrough behaviour.
+func (a *AzureAdapter) TransformStreamLine(line []byte) ([][]byte, error) {
+	return [][]byte{line}, nil
 }
 
 // StreamUsage returns a zero UsageInfo. Azure streams the OpenAI wire format,

--- a/internal/proxy/azure_test.go
+++ b/internal/proxy/azure_test.go
@@ -258,8 +258,15 @@ func TestAzureTransformStreamLine_Passthrough(t *testing.T) {
 			t.Parallel()
 
 			a := &AzureAdapter{}
-			got := a.TransformStreamLine([]byte(tc.input))
+			outLines, err := a.TransformStreamLine([]byte(tc.input))
 
+			if err != nil {
+				t.Fatalf("TransformStreamLine() unexpected error: %v", err)
+			}
+			if len(outLines) != 1 {
+				t.Fatalf("TransformStreamLine() returned %d lines, want 1", len(outLines))
+			}
+			got := outLines[0]
 			if string(got) != tc.input {
 				t.Errorf("TransformStreamLine() = %q, want %q (passthrough unchanged)", got, tc.input)
 			}

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -733,7 +733,15 @@ func (a *GeminiAdapter) TransformResponse(body []byte) ([]byte, error) {
 //
 // The content-free-chunk drop (~line 441 in the original) is corrected: a
 // chunk that carries only functionCall parts (no text) is NOT dropped.
-func (a *GeminiAdapter) TransformStreamLine(line []byte) []byte {
+//
+// Mixed text+functionCall chunks emit two separate SSE lines: the text content
+// chunk first, then the tool_calls chunk. Stage 0c processes them as two
+// independent events. Previously the text was silently discarded.
+//
+// Invalid/excess tool call parts abort the stream (errStreamTransformAborted)
+// rather than silently dropping a call, so the client receives a content-free
+// error event instead of a quietly incomplete tool-call set.
+func (a *GeminiAdapter) TransformStreamLine(line []byte) ([][]byte, error) {
 	s := string(line)
 
 	// Blank SSE event delimiter.
@@ -743,27 +751,27 @@ func (a *GeminiAdapter) TransformStreamLine(line []byte) []byte {
 			// so the client sees it as a properly delimited event, then clear
 			// the flag so subsequent blank lines pass through normally.
 			a.doneSent = false
-			return []byte("data: [DONE]")
+			return [][]byte{[]byte("data: [DONE]")}, nil
 		}
-		return line
+		return [][]byte{line}, nil
 	}
 
 	const dataPrefix = "data: "
 	if !strings.HasPrefix(s, dataPrefix) {
-		return nil
+		return nil, nil
 	}
 
 	payload := []byte(s[len(dataPrefix):])
 
 	// Gemini may send "[DONE]" itself in some environments — pass it through.
 	if strings.TrimSpace(string(payload)) == "[DONE]" {
-		return line
+		return [][]byte{line}, nil
 	}
 
 	var gr geminiResponse
 	if err := jsonx.Unmarshal(payload, &gr); err != nil {
 		// Not a valid Gemini JSON payload — drop the line.
-		return nil
+		return nil, nil
 	}
 
 	var deltaText string
@@ -818,19 +826,19 @@ func (a *GeminiAdapter) TransformStreamLine(line []byte) []byte {
 	// original check "deltaText == "" && finishReason == nil" was broadened here
 	// to also require len(toolCallParts) == 0. This is the content-free-drop fix.
 	if deltaText == "" && finishReason == nil && len(toolCallParts) == 0 {
-		return nil
+		return nil, nil
 	}
 
-	// If there are both text content and tool call parts in the same chunk,
-	// emit a text chunk first, then the tool call chunk. However, Gemini
-	// typically does not mix text and functionCall in the same chunk. For
-	// simplicity (and because Stage 0c rejects mixed content+tool_calls in the
-	// same chunk), emit text chunks via the normal path and tool call chunks
-	// via a separate emission. When both are present, emit text first by
-	// building a text-only delta here and handling tool calls below.
+	// Build the text chunk when there is delta text. When there are also tool
+	// call parts in the same chunk, emit the text chunk first and the tool_calls
+	// chunk second (two lines returned). Stage 0c processes them as independent
+	// events: content chunk followed by tool_calls chunk is valid.
 	//
-	// In practice Gemini always sends one finishReason with either the last
-	// text part or the functionCall parts — not both simultaneously.
+	// In practice Gemini always sends one finishReason with either the last text
+	// part or the functionCall parts — not both simultaneously. When both arrive
+	// in one chunk (rare), the text chunk carries no finishReason and the
+	// tool_calls chunk carries the finishReason, preserving correct ordering.
+	var textLine []byte
 	if deltaText != "" {
 		chunk := openAIChunk{
 			ID:     fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano()),
@@ -839,8 +847,8 @@ func (a *GeminiAdapter) TransformStreamLine(line []byte) []byte {
 				{
 					Index: 0,
 					Delta: openAIChunkDelta{Content: deltaText},
-					// Do not set finishReason here when there are also tool calls
-					// to emit; set it on the tool-calls chunk below.
+					// Do not set finishReason on the text chunk when there are also
+					// tool calls to emit; the finishReason goes on the tool_calls chunk.
 					FinishReason: func() *string {
 						if len(toolCallParts) == 0 {
 							return finishReason
@@ -852,49 +860,40 @@ func (a *GeminiAdapter) TransformStreamLine(line []byte) []byte {
 		}
 		out, err := jsonx.Marshal(chunk)
 		if err != nil {
-			return nil
+			return nil, errStreamTransformAborted
 		}
 		if finishReason != nil && len(toolCallParts) == 0 {
 			a.doneSent = true
 		}
-		// If there are also tool call parts, we cannot return here — we need
-		// to emit both. For the common case (only text), return now.
 		if len(toolCallParts) == 0 {
-			return appendDataPrefix(out)
+			// Text-only chunk — return immediately.
+			return [][]byte{appendDataPrefix(out)}, nil
 		}
-		// Mixed chunk: text has been built. Fall through to emit tool calls
-		// as a separate chunk. (We discard the text chunk here — in the rare
-		// mixed case only the tool calls chunk is returned. This is acceptable
-		// because Stage 0c cannot handle mixed content+tool_calls in one chunk,
-		// and Gemini should not produce this combination in practice.)
-		_ = out
+		// Mixed chunk: save the text line; fall through to build the tool_calls
+		// chunk and return both.
+		textLine = appendDataPrefix(out)
 	}
 
 	// Emit tool call deltas.
 	if len(toolCallParts) > 0 {
 		var tcs []openAIToolCall
 		for _, fc := range toolCallParts {
-			// Cap per-stream tool-call count (defence-in-depth).
+			// Cap per-stream tool-call count (defence-in-depth) — abort fail-closed.
 			if a.streamToolCallCounter >= maxGeminiToolBlocks {
-				// Excess blocks are dropped.
-				break
+				return nil, errStreamTransformAborted
 			}
-			// FIX 3: reject empty function name — fail-closed (drop this block).
+			// FIX 3: reject empty function name — abort fail-closed.
 			if fc.Name == "" {
-				a.streamToolCallCounter++
-				continue
+				return nil, errStreamTransformAborted
 			}
-			// Charset-validate the name received from upstream.
+			// Charset-validate the name received from upstream — abort fail-closed.
 			if !anthropicToolIDRe.MatchString(fc.Name) {
-				// Invalid name — drop this block, continue with others.
-				a.streamToolCallCounter++
-				continue
+				return nil, errStreamTransformAborted
 			}
-			// Serialise args → JSON string.
+			// Serialise args → JSON string — abort on failure.
 			argsStr, err := serializeInputToArguments(fc.Args)
 			if err != nil {
-				a.streamToolCallCounter++
-				continue
+				return nil, errStreamTransformAborted
 			}
 			id := geminiSynthesiseToolCallID(a.streamToolCallCounter)
 			tcIdx := a.streamToolCallCounter
@@ -917,50 +916,30 @@ func (a *GeminiAdapter) TransformStreamLine(line []byte) []byte {
 			a.sawFunctionCall = true
 		}
 
-		if len(tcs) > 0 {
-			chunk := openAIChunk{
-				ID:     fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano()),
-				Object: "chat.completion.chunk",
-				Choices: []openAIChunkChoice{
-					{
-						Index:        0,
-						Delta:        openAIChunkDelta{ToolCalls: tcs},
-						FinishReason: finishReason,
-					},
+		chunk := openAIChunk{
+			ID:     fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano()),
+			Object: "chat.completion.chunk",
+			Choices: []openAIChunkChoice{
+				{
+					Index:        0,
+					Delta:        openAIChunkDelta{ToolCalls: tcs},
+					FinishReason: finishReason,
 				},
-			}
-			out, err := jsonx.Marshal(chunk)
-			if err != nil {
-				return nil
-			}
-			if finishReason != nil {
-				a.doneSent = true
-			}
-			return appendDataPrefix(out)
+			},
 		}
-
-		// All tool call parts were dropped (invalid names or args). If we have a
-		// finishReason, still need to emit the finish chunk with no delta.
+		out, err := jsonx.Marshal(chunk)
+		if err != nil {
+			return nil, errStreamTransformAborted
+		}
 		if finishReason != nil {
-			chunk := openAIChunk{
-				ID:     fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano()),
-				Object: "chat.completion.chunk",
-				Choices: []openAIChunkChoice{
-					{
-						Index:        0,
-						Delta:        openAIChunkDelta{},
-						FinishReason: finishReason,
-					},
-				},
-			}
-			out, err := jsonx.Marshal(chunk)
-			if err != nil {
-				return nil
-			}
 			a.doneSent = true
-			return appendDataPrefix(out)
 		}
-		return nil
+		toolLine := appendDataPrefix(out)
+		if textLine != nil {
+			// Mixed chunk: return text first, then tool_calls.
+			return [][]byte{textLine, toolLine}, nil
+		}
+		return [][]byte{toolLine}, nil
 	}
 
 	// Pure finish-reason chunk (no text, no tool calls) — emit finish chunk.
@@ -978,13 +957,13 @@ func (a *GeminiAdapter) TransformStreamLine(line []byte) []byte {
 		}
 		out, err := jsonx.Marshal(chunk)
 		if err != nil {
-			return nil
+			return nil, errStreamTransformAborted
 		}
 		a.doneSent = true
-		return appendDataPrefix(out)
+		return [][]byte{appendDataPrefix(out)}, nil
 	}
 
-	return nil
+	return nil, nil
 }
 
 // StreamUsage returns the token counts accumulated during the Gemini stream.

--- a/internal/proxy/gemini_test.go
+++ b/internal/proxy/gemini_test.go
@@ -779,7 +779,7 @@ func TestGeminiTransformStreamLine(t *testing.T) {
 			t.Parallel()
 
 			a := &GeminiAdapter{}
-			out := a.TransformStreamLine([]byte(tc.line))
+			out := transformLine1(a, []byte(tc.line))
 
 			if tc.wantNil {
 				if out != nil {
@@ -812,7 +812,7 @@ func TestGeminiTransformStreamLine_DoneSequence(t *testing.T) {
 	a := &GeminiAdapter{}
 
 	// 1. A normal mid-stream delta should produce a chunk without finish_reason.
-	mid := a.TransformStreamLine([]byte(`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"word "}]},"finishReason":""}],"usageMetadata":{}}`))
+	mid := transformLine1(a, []byte(`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"word "}]},"finishReason":""}],"usageMetadata":{}}`))
 	if mid == nil {
 		t.Fatal("mid-stream TransformStreamLine() = nil, want non-nil chunk")
 	}
@@ -822,7 +822,7 @@ func TestGeminiTransformStreamLine_DoneSequence(t *testing.T) {
 	}
 
 	// 2. Terminal chunk with finishReason should emit a chunk with finish_reason.
-	terminal := a.TransformStreamLine([]byte(`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"done"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":10,"totalTokenCount":15}}`))
+	terminal := transformLine1(a, []byte(`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"done"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":10,"totalTokenCount":15}}`))
 	if terminal == nil {
 		t.Fatal("terminal TransformStreamLine() = nil, want non-nil chunk")
 	}
@@ -835,13 +835,13 @@ func TestGeminiTransformStreamLine_DoneSequence(t *testing.T) {
 	}
 
 	// 3. The blank SSE delimiter immediately after must become data: [DONE].
-	done := a.TransformStreamLine([]byte(""))
+	done := transformLine1(a, []byte(""))
 	if string(done) != "data: [DONE]" {
 		t.Errorf("blank-after-terminal TransformStreamLine() = %q, want %q", done, "data: [DONE]")
 	}
 
 	// 4. The doneSent flag must be cleared so subsequent blank lines pass through normally.
-	afterDone := a.TransformStreamLine([]byte(""))
+	afterDone := transformLine1(a, []byte(""))
 	if string(afterDone) != "" {
 		t.Errorf("second-blank TransformStreamLine() = %q, want empty string", afterDone)
 	}
@@ -855,7 +855,7 @@ func TestGeminiTransformStreamLine_UsageAccumulation(t *testing.T) {
 	a := &GeminiAdapter{}
 
 	// Feed a chunk carrying usage metadata.
-	_ = a.TransformStreamLine([]byte(`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"hi"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":20,"candidatesTokenCount":8,"totalTokenCount":28}}`))
+	transformLineIgnore(a, []byte(`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"hi"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":20,"candidatesTokenCount":8,"totalTokenCount":28}}`))
 
 	usage := a.StreamUsage()
 	if usage.PromptTokens != 20 {
@@ -915,7 +915,7 @@ func TestGeminiStreamUsage(t *testing.T) {
 
 			a := &GeminiAdapter{}
 			for _, line := range tc.lines {
-				_ = a.TransformStreamLine([]byte(line))
+				transformLineIgnore(a, []byte(line))
 			}
 
 			got := a.StreamUsage()
@@ -1445,7 +1445,7 @@ func TestGeminiTransformStreamLine_ToolCalls(t *testing.T) {
 		t.Parallel()
 		line := `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"get_weather","args":{"location":"NYC"}}}]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`
 		a := &GeminiAdapter{}
-		out := a.TransformStreamLine([]byte(line))
+		out := transformLine1(a, []byte(line))
 		if out == nil {
 			t.Fatal("TransformStreamLine() = nil, want non-nil for functionCall chunk")
 		}
@@ -1497,7 +1497,7 @@ func TestGeminiTransformStreamLine_ToolCalls(t *testing.T) {
 		// This verifies the content-free-drop fix.
 		line := `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"fn","args":{}}}]},"finishReason":""}],"usageMetadata":{}}`
 		a := &GeminiAdapter{}
-		out := a.TransformStreamLine([]byte(line))
+		out := transformLine1(a, []byte(line))
 		if out == nil {
 			t.Fatal("TransformStreamLine() = nil for functionCall-only chunk (content-free-drop bug)")
 		}
@@ -1508,7 +1508,7 @@ func TestGeminiTransformStreamLine_ToolCalls(t *testing.T) {
 		a := &GeminiAdapter{}
 
 		line1 := `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"fn_a","args":{}}}]},"finishReason":""}],"usageMetadata":{}}`
-		out1 := a.TransformStreamLine([]byte(line1))
+		out1 := transformLine1(a, []byte(line1))
 		if out1 == nil {
 			t.Fatal("first chunk: nil")
 		}
@@ -1516,7 +1516,7 @@ func TestGeminiTransformStreamLine_ToolCalls(t *testing.T) {
 		idx1 := *chunk1.Choices[0].Delta.ToolCalls[0].Index
 
 		line2 := `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"fn_b","args":{}}}]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`
-		out2 := a.TransformStreamLine([]byte(line2))
+		out2 := transformLine1(a, []byte(line2))
 		if out2 == nil {
 			t.Fatal("second chunk: nil")
 		}
@@ -1536,8 +1536,8 @@ func TestGeminiTransformStreamLine_ToolCalls(t *testing.T) {
 		a := &GeminiAdapter{}
 		// Emit terminal tool-call chunk.
 		line := `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"fn","args":{}}}]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`
-		_ = a.TransformStreamLine([]byte(line))
-		done := a.TransformStreamLine([]byte(""))
+		transformLineIgnore(a, []byte(line))
+		done := transformLine1(a, []byte(""))
 		if string(done) != "data: [DONE]" {
 			t.Errorf("blank after terminal = %q, want data: [DONE]", done)
 		}
@@ -2621,7 +2621,7 @@ func TestGeminiTransformStreamLine_ToolCalls_Detailed(t *testing.T) {
 			{"functionCall":{"name":"fn","args":{"k":"v"}}}
 		]},"finishReason":""}],"usageMetadata":{}}`
 		a := &GeminiAdapter{}
-		out := a.TransformStreamLine([]byte(line))
+		out := transformLine1(a, []byte(line))
 		if out == nil {
 			t.Fatal("functionCall-only chunk returned nil (content-free-drop bug)")
 		}
@@ -2640,7 +2640,7 @@ func TestGeminiTransformStreamLine_ToolCalls_Detailed(t *testing.T) {
 			{"functionCall":{"name":"get_weather","args":{"location":"NYC","unit":"celsius"}}}
 		]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`
 		a := &GeminiAdapter{}
-		out := a.TransformStreamLine([]byte(line))
+		out := transformLine1(a, []byte(line))
 		if out == nil {
 			t.Fatal("functionCall chunk returned nil")
 		}
@@ -2690,7 +2690,7 @@ func TestGeminiTransformStreamLine_ToolCalls_Detailed(t *testing.T) {
 		line1 := `data: {"candidates":[{"content":{"role":"model","parts":[
 			{"functionCall":{"name":"fn_a","args":{}}}
 		]},"finishReason":""}],"usageMetadata":{}}`
-		out1 := a.TransformStreamLine([]byte(line1))
+		out1 := transformLine1(a, []byte(line1))
 		if out1 == nil {
 			t.Fatal("first functionCall chunk returned nil")
 		}
@@ -2698,7 +2698,7 @@ func TestGeminiTransformStreamLine_ToolCalls_Detailed(t *testing.T) {
 		line2 := `data: {"candidates":[{"content":{"role":"model","parts":[
 			{"functionCall":{"name":"fn_b","args":{"x":2}}}
 		]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`
-		out2 := a.TransformStreamLine([]byte(line2))
+		out2 := transformLine1(a, []byte(line2))
 		if out2 == nil {
 			t.Fatal("second functionCall chunk returned nil")
 		}
@@ -2732,7 +2732,7 @@ func TestGeminiTransformStreamLine_ToolCalls_Detailed(t *testing.T) {
 			{"functionCall":{"name":"fn","args":{}}}
 		]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":4,"totalTokenCount":12}}`
 		a := &GeminiAdapter{}
-		out := a.TransformStreamLine([]byte(line))
+		out := transformLine1(a, []byte(line))
 		if out == nil {
 			t.Fatal("terminal functionCall chunk returned nil")
 		}
@@ -2747,7 +2747,7 @@ func TestGeminiTransformStreamLine_ToolCalls_Detailed(t *testing.T) {
 			t.Error("doneSent must be true after terminal functionCall chunk")
 		}
 		// Blank line after terminal chunk must become data: [DONE].
-		done := a.TransformStreamLine([]byte(""))
+		done := transformLine1(a, []byte(""))
 		if string(done) != "data: [DONE]" {
 			t.Errorf("blank-after-terminal = %q, want data: [DONE]", done)
 		}
@@ -2759,7 +2759,7 @@ func TestGeminiTransformStreamLine_ToolCalls_Detailed(t *testing.T) {
 			{"functionCall":{"name":"fn","args":{}}}
 		]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{"promptTokenCount":20,"candidatesTokenCount":10,"totalTokenCount":30}}`
 		a := &GeminiAdapter{}
-		_ = a.TransformStreamLine([]byte(line))
+		transformLineIgnore(a, []byte(line))
 		usage := a.StreamUsage()
 		if usage.PromptTokens != 20 {
 			t.Errorf("PromptTokens = %d, want 20", usage.PromptTokens)
@@ -2772,7 +2772,7 @@ func TestGeminiTransformStreamLine_ToolCalls_Detailed(t *testing.T) {
 		}
 	})
 
-	t.Run("tool-call counter cap: excess blocks beyond maxGeminiToolBlocks are dropped", func(t *testing.T) {
+	t.Run("tool-call counter cap: first block at cap aborts stream fail-closed", func(t *testing.T) {
 		t.Parallel()
 		a := &GeminiAdapter{}
 		// Prime the counter to one below the cap.
@@ -2782,7 +2782,7 @@ func TestGeminiTransformStreamLine_ToolCalls_Detailed(t *testing.T) {
 		lineAtCap := `data: {"candidates":[{"content":{"role":"model","parts":[
 			{"functionCall":{"name":"fn_last","args":{}}}
 		]},"finishReason":""}],"usageMetadata":{}}`
-		outAtCap := a.TransformStreamLine([]byte(lineAtCap))
+		outAtCap := transformLine1(a, []byte(lineAtCap))
 		if outAtCap == nil {
 			t.Fatal("chunk at cap-1 returned nil, expected to be allowed")
 		}
@@ -2791,34 +2791,28 @@ func TestGeminiTransformStreamLine_ToolCalls_Detailed(t *testing.T) {
 			t.Error("chunk at cap-1 should emit one tool call")
 		}
 
-		// Counter is now at maxGeminiToolBlocks. Next chunk must be dropped.
+		// Counter is now at maxGeminiToolBlocks. Next chunk must abort.
 		lineOverCap := `data: {"candidates":[{"content":{"role":"model","parts":[
 			{"functionCall":{"name":"fn_over","args":{}}}
 		]},"finishReason":""}],"usageMetadata":{}}`
-		outOverCap := a.TransformStreamLine([]byte(lineOverCap))
-		// When all tool call parts are dropped and there is no finishReason, result is nil.
-		if outOverCap != nil {
-			// The cap was not enforced — this is a failure.
-			// (If the chunk has no finishReason and all parts dropped, should be nil.)
-			t.Logf("note: over-cap chunk produced %q (may be empty finish chunk if finishReason present)", outOverCap)
+		_, overErr := a.TransformStreamLine([]byte(lineOverCap))
+		if overErr == nil {
+			t.Error("over-cap chunk: got nil error, want errStreamTransformAborted")
 		}
 	})
 
-	t.Run("invalid function name from upstream in stream is dropped, not panic", func(t *testing.T) {
+	t.Run("invalid function name from upstream aborts stream fail-closed", func(t *testing.T) {
 		t.Parallel()
 		// The model hallucinated a function name with spaces (invalid charset).
-		// The adapter should drop this block silently.
+		// The adapter must abort the stream rather than silently dropping the call.
 		line := `data: {"candidates":[{"content":{"role":"model","parts":[
 			{"functionCall":{"name":"bad name with spaces","args":{}}}
 		]},"finishReason":""}],"usageMetadata":{}}`
 		a := &GeminiAdapter{}
-		// Must not panic.
-		out := a.TransformStreamLine([]byte(line))
-		// When the only part has an invalid name and no finishReason, result is nil.
-		if out != nil {
-			t.Logf("note: invalid-name chunk produced %q (may be finish chunk if finishReason)", out)
+		_, err := a.TransformStreamLine([]byte(line))
+		if err == nil {
+			t.Error("invalid function name: got nil error, want errStreamTransformAborted")
 		}
-		// Counter still incremented past the invalid block.
 	})
 }
 
@@ -2836,7 +2830,7 @@ func TestGeminiTransformStreamLine_FinishReason_ToolCalls(t *testing.T) {
 	]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`
 
 	a := &GeminiAdapter{}
-	out := a.TransformStreamLine([]byte(line))
+	out := transformLine1(a, []byte(line))
 	if out == nil {
 		t.Fatal("FUNCTION_CALL terminal chunk returned nil")
 	}
@@ -2856,11 +2850,10 @@ func TestGeminiTransformStreamLine_FinishReason_ToolCalls(t *testing.T) {
 	}
 }
 
-// TestGeminiTransformStreamLine_MixedTextAndFunctionCall documents the current
-// behaviour when a single Gemini chunk contains both text and functionCall parts:
-// the implementation emits only the tool-calls chunk, dropping the text.
-// This is noted as a known limitation (Stage-0c cannot handle mixed
-// content+tool_calls in one chunk, and Gemini should not produce this in practice).
+// TestGeminiTransformStreamLine_MixedTextAndFunctionCall verifies that a single
+// Gemini chunk containing both text and functionCall parts emits TWO SSE lines:
+// the text content chunk first, then the tool_calls chunk. Stage 0c processes
+// them as two independent events (content delta followed by tool_calls delta).
 func TestGeminiTransformStreamLine_MixedTextAndFunctionCall(t *testing.T) {
 	t.Parallel()
 
@@ -2871,24 +2864,35 @@ func TestGeminiTransformStreamLine_MixedTextAndFunctionCall(t *testing.T) {
 	]},"finishReason":"FUNCTION_CALL"}],"usageMetadata":{}}`
 
 	a := &GeminiAdapter{}
-	out := a.TransformStreamLine([]byte(line))
-	if out == nil {
-		t.Fatal("mixed text+functionCall chunk returned nil, expected non-nil")
+	outLines, err := a.TransformStreamLine([]byte(line))
+	if err != nil {
+		t.Fatalf("mixed chunk returned error: %v", err)
+	}
+	if len(outLines) != 2 {
+		t.Fatalf("mixed text+functionCall chunk: got %d lines, want 2 (text + tool_calls)", len(outLines))
 	}
 
-	chunk := parseChunk(t, out)
-	// The implementation emits only the tool-calls chunk in the mixed case.
-	// Text is dropped. This is documented behaviour (see comment in TransformStreamLine).
-	if len(chunk.Choices[0].Delta.ToolCalls) == 0 {
-		// If text was emitted instead, also acceptable — just verify non-nil output.
-		t.Logf("mixed chunk produced text delta (not tool_calls); behaviour: %+v", chunk.Choices[0].Delta)
+	// First line must be the text content chunk.
+	textChunk := parseChunk(t, outLines[0])
+	if textChunk.Choices[0].Delta.Content != "Thinking..." {
+		t.Errorf("first line (text): content = %q, want %q", textChunk.Choices[0].Delta.Content, "Thinking...")
 	}
-	// Either way, the output is valid and non-nil.
-	// NOTE: This test explicitly documents that text IS dropped when a mixed
-	// chunk arrives. If the implementation is fixed to emit both, this test
-	// should be updated. Current behaviour: text chunk is built but discarded
-	// (the `_ = out` line in TransformStreamLine), and the tool-calls chunk
-	// is returned instead.
+	if len(textChunk.Choices[0].Delta.ToolCalls) != 0 {
+		t.Error("first line (text): must not contain tool_calls")
+	}
+
+	// Second line must be the tool_calls chunk.
+	toolChunk := parseChunk(t, outLines[1])
+	if len(toolChunk.Choices[0].Delta.ToolCalls) == 0 {
+		t.Error("second line (tool_calls): must contain at least one tool call")
+	}
+	if toolChunk.Choices[0].FinishReason == nil || *toolChunk.Choices[0].FinishReason != "tool_calls" {
+		var got string
+		if toolChunk.Choices[0].FinishReason != nil {
+			got = *toolChunk.Choices[0].FinishReason
+		}
+		t.Errorf("second line (tool_calls): finish_reason = %q, want tool_calls", got)
+	}
 }
 
 // ── geminiSynthesiseToolCallID unit test ─────────────────────────────────────
@@ -3527,7 +3531,7 @@ func TestGeminiTransformStreamLine_FinishReasonPresenceBased(t *testing.T) {
 		// Real Gemini stream: functionCall and finishReason STOP arrive together.
 		line := `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"get_weather","args":{"city":"NYC"}}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8}}`
 		a := &GeminiAdapter{}
-		out := a.TransformStreamLine([]byte(line))
+		out := transformLine1(a, []byte(line))
 		if out == nil {
 			t.Fatal("TransformStreamLine() = nil, want non-nil chunk")
 		}
@@ -3559,7 +3563,7 @@ func TestGeminiTransformStreamLine_FinishReasonPresenceBased(t *testing.T) {
 
 		// Chunk 1: functionCall part without finishReason (sets sawFunctionCall).
 		chunk1 := `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"fn","args":{}}}]},"finishReason":""}],"usageMetadata":{}}`
-		out1 := a.TransformStreamLine([]byte(chunk1))
+		out1 := transformLine1(a, []byte(chunk1))
 		if out1 == nil {
 			t.Fatal("chunk 1 returned nil")
 		}
@@ -3569,7 +3573,7 @@ func TestGeminiTransformStreamLine_FinishReasonPresenceBased(t *testing.T) {
 
 		// Chunk 2: empty parts with finishReason STOP (finish chunk).
 		chunk2 := `data: {"candidates":[{"content":{"role":"model","parts":[]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8}}`
-		out2 := a.TransformStreamLine([]byte(chunk2))
+		out2 := transformLine1(a, []byte(chunk2))
 		if out2 == nil {
 			t.Fatal("finish chunk returned nil")
 		}
@@ -3586,7 +3590,7 @@ func TestGeminiTransformStreamLine_FinishReasonPresenceBased(t *testing.T) {
 		t.Parallel()
 		a := &GeminiAdapter{}
 		line := `data: {"candidates":[{"content":{"role":"model","parts":[{"text":"bye"}]},"finishReason":"STOP"}],"usageMetadata":{}}`
-		out := a.TransformStreamLine([]byte(line))
+		out := transformLine1(a, []byte(line))
 		if out == nil {
 			t.Fatal("TransformStreamLine() = nil")
 		}
@@ -3605,7 +3609,7 @@ func TestGeminiTransformStreamLine_FinishReasonPresenceBased(t *testing.T) {
 
 		// Single chunk: functionCall parts + finishReason STOP (real Gemini shape).
 		line := `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"get_data","args":{"id":1}}}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":8,"candidatesTokenCount":4,"totalTokenCount":12}}`
-		out := a.TransformStreamLine([]byte(line))
+		out := transformLine1(a, []byte(line))
 		if out == nil {
 			t.Fatal("terminal functionCall chunk returned nil")
 		}
@@ -3627,7 +3631,7 @@ func TestGeminiTransformStreamLine_FinishReasonPresenceBased(t *testing.T) {
 			t.Error("doneSent should be true")
 		}
 		// Blank line converts to [DONE].
-		done := a.TransformStreamLine([]byte(""))
+		done := transformLine1(a, []byte(""))
 		if string(done) != "data: [DONE]" {
 			t.Errorf("blank-after-terminal = %q, want data: [DONE]", done)
 		}

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -972,6 +972,23 @@ func (p *ProxyHandler) buildUpstreamRequest(c fiber.Ctx, model Model, body []byt
 	return req, upstreamCancel, adapter, nil
 }
 
+// writeStreamAbortEvent writes a single content-free OpenAI-shaped SSE error
+// event to w and flushes. The event carries the provided code as both
+// "type" and "code" so that clients can distinguish abort reasons without any
+// upstream content appearing in the wire format. No trailing [DONE] is emitted;
+// the absence of [DONE] signals to well-behaved clients that the stream did not
+// complete successfully. The function intentionally ignores write errors because
+// by the time it is called the only objective is a best-effort notification —
+// the stream is already being torn down.
+func writeStreamAbortEvent(w *bufio.Writer, code string) {
+	// The message field is a static, content-free string. The code value is
+	// caller-controlled and must always be a static string constant (never
+	// derived from upstream content or user input) to ensure zero-knowledge.
+	msg := "stream aborted"
+	_, _ = fmt.Fprintf(w, "data: {\"error\":{\"message\":%q,\"type\":%q,\"code\":%q}}\n\n", msg, code, code)
+	_ = w.Flush()
+}
+
 // handleStreamingResponse sets the SSE response headers and launches the
 // SendStreamWriter goroutine that pipes the upstream event stream to the client.
 // The goroutine owns cancelUpstream, resp.Body.Close, and the trackDone call —
@@ -1084,6 +1101,10 @@ func (p *ProxyHandler) handleStreamingResponse(c fiber.Ctx, resp *http.Response,
 			// streamAborted is true when a genuine upstream or protocol error
 			// occurred — triggers breaker.RecordFailure().
 			streamAborted := false
+			// adapterAborted is true when the adapter returned errStreamTransformAborted
+			// and the abort event has already been emitted to the client. The
+			// post-loop error-event block must not emit a second event in this case.
+			adapterAborted := false
 			// clientDisconnected is true when a write to the client failed (the
 			// client hung up mid-stream). This is not an upstream fault and must
 			// NOT be recorded as a circuit-breaker failure.
@@ -1147,10 +1168,60 @@ func (p *ProxyHandler) handleStreamingResponse(c fiber.Ctx, resp *http.Response,
 				}
 
 				if adapter != nil {
-					line = adapter.TransformStreamLine(line)
-					if line == nil {
+					adaptedLines, terr := adapter.TransformStreamLine(line)
+					if terr != nil {
+						p.Log.LogAttrs(context.Background(), slog.LevelWarn,
+							"pii: adapter stream transform error; stream aborted fail-closed")
+						streamAborted = true
+						adapterAborted = true
+						if !clientDisconnected {
+							writeStreamAbortEvent(w, "stream_transform_aborted")
+						}
+						break piiScanLoop
+					}
+					if len(adaptedLines) == 0 {
 						continue // adapter says skip this line
 					}
+					for i, al := range adaptedLines {
+						extractor.observe(al)
+
+						// Inject a blank SSE event separator into the restorer before
+						// each adapter output line after the first. An adapter may return
+						// multiple data: lines from a single upstream line (e.g. Gemini
+						// mixed text+functionCall chunk → text line + tool_calls line).
+						// The StreamRestorer treats a second data: line without a preceding
+						// blank separator as a protocol violation and aborts fail-closed.
+						// Push of an empty slice always returns (nil, false, nil) — no
+						// error handling is needed here.
+						if i > 0 && len(al) > 0 {
+							_, _, _ = restorer.Push([]byte{})
+						}
+
+						// Copy: scanner.Bytes() is reused; al may alias line.
+						alCopy := make([]byte, len(al))
+						copy(alCopy, al)
+
+						outLines, terminal, pushErr := restorer.Push(alCopy)
+						if pushErr != nil {
+							p.Log.LogAttrs(context.Background(), slog.LevelWarn,
+								"pii: incremental stream restore error; stream aborted to prevent pseudonym leak",
+								slog.String("error", pushErr.Error()),
+							)
+							streamAborted = true
+							break piiScanLoop
+						}
+						if len(outLines) > 0 {
+							if !writeSSELines(outLines) {
+								clientDisconnected = true
+								break piiScanLoop
+							}
+						}
+						if terminal {
+							terminalSeen = true
+							break piiScanLoop
+						}
+					}
+					continue
 				}
 				extractor.observe(line)
 
@@ -1204,12 +1275,13 @@ func (p *ProxyHandler) handleStreamingResponse(c fiber.Ctx, resp *http.Response,
 			// Synthesize a content-free SSE error event when the stream is
 			// aborted by a PII policy violation, scanner error, timeout, or
 			// EOF-without-[DONE] — but NOT after client disconnect (the client
-			// is already gone) and NOT after a write failure (the client is
-			// also gone in that case). The error event is emitted WITHOUT a
+			// is already gone), NOT after a write failure (the client is also
+			// gone), and NOT when the adapter already emitted its own abort
+			// event (adapterAborted). The error event is emitted WITHOUT a
 			// trailing [DONE] so that clients that ignore the error object read
 			// an incomplete stream (correct signal) rather than a successful one.
 			// Never flush carry bytes before or alongside the error event.
-			if !clientDisconnected && streamIncomplete {
+			if !clientDisconnected && !adapterAborted && streamIncomplete {
 				const piiErrorEvent = "data: {\"error\":{\"message\":\"response withheld by PII policy\",\"type\":\"pii_restore_aborted\",\"code\":\"pii_restore_aborted\"}}"
 				_, _ = w.WriteString(piiErrorEvent)
 				_ = w.WriteByte('\n')
@@ -1236,6 +1308,11 @@ func (p *ProxyHandler) handleStreamingResponse(c fiber.Ctx, resp *http.Response,
 			_ = w.Flush()
 		} else {
 			// Non-buffered path: per-line passthrough with no PII overhead.
+			// plainAborted tracks adapter-abort so the post-loop block can
+			// set streamIncomplete and record a breaker failure consistently
+			// with the PII path.
+			plainAborted := false
+		plainScanLoop:
 			for scanner.Scan() {
 				line := scanner.Bytes()
 				if firstChunk && bytes.HasPrefix(line, []byte("data: ")) {
@@ -1244,11 +1321,57 @@ func (p *ProxyHandler) handleStreamingResponse(c fiber.Ctx, resp *http.Response,
 					firstChunk = false
 					metrics.ProxyTTFTSeconds.WithLabelValues(model.Name).Observe(float64(t) / 1000)
 				}
+
 				if adapter != nil {
-					line = adapter.TransformStreamLine(line)
-					if line == nil {
-						continue // adapter says skip this line
+					adaptedLines, terr := adapter.TransformStreamLine(line)
+					if terr != nil {
+						p.Log.LogAttrs(context.Background(), slog.LevelWarn,
+							"streaming: adapter stream transform error; stream aborted fail-closed")
+						plainAborted = true
+						streamIncomplete = true
+						writeStreamAbortEvent(w, "stream_transform_aborted")
+						if breaker != nil {
+							breaker.RecordFailure()
+						}
+						break plainScanLoop
 					}
+					if len(adaptedLines) == 0 {
+						continue plainScanLoop
+					}
+					// Each adapted output line is written as a self-contained SSE
+					// event: the line itself followed by "\n\n" (the SSE event
+					// terminator). Forwarded upstream blank lines (event separators)
+					// are skipped — they are now redundant because every event
+					// self-terminates.
+					//
+					// This model is byte-identical for the normal single-line case:
+					//   upstream: "data:{a}\n" + "\n"
+					//   old:      write "data:{a}\n" then forward blank as "\n"  → "data:{a}\n\n"
+					//   new:      write "data:{a}\n\n", skip blank               → "data:{a}\n\n"
+					//
+					// It also correctly terminates multi-output lines (Gemini
+					// text+functionCall → two lines), [DONE] from a blank-input
+					// adapter transform (Gemini doneSent), and the abort event
+					// injected by writeStreamAbortEvent (which already ends in \n\n).
+					for _, al := range adaptedLines {
+						if len(al) == 0 {
+							// Forwarded upstream blank line is the old event
+							// delimiter — skip it; the preceding event already
+							// self-terminated with \n\n.
+							continue
+						}
+						extractor.observe(al)
+						if _, err := w.Write(al); err != nil {
+							break plainScanLoop
+						}
+						if _, err := w.WriteString("\n\n"); err != nil {
+							break plainScanLoop
+						}
+						if err := w.Flush(); err != nil {
+							break plainScanLoop
+						}
+					}
+					continue plainScanLoop
 				}
 				// Always observe the (possibly transformed) line. Transformed
 				// lines are OpenAI-shaped (Azure passthrough, Anthropic → OpenAI),
@@ -1267,6 +1390,10 @@ func (p *ProxyHandler) handleStreamingResponse(c fiber.Ctx, resp *http.Response,
 				}
 			}
 			// Check scanner.Err() and record the circuit breaker outcome.
+			// When the adapter already aborted the stream (plainAborted=true),
+			// RecordFailure was already called inside the abort block; do not
+			// record again. A clean scanner exit after adapter abort (scanErr nil)
+			// must NOT be recorded as RecordSuccess.
 			scanErr := scanner.Err()
 			if scanErr != nil {
 				p.Log.LogAttrs(context.Background(), slog.LevelWarn,
@@ -1274,7 +1401,7 @@ func (p *ProxyHandler) handleStreamingResponse(c fiber.Ctx, resp *http.Response,
 					slog.String("error", scanErr.Error()),
 				)
 			}
-			if breaker != nil {
+			if breaker != nil && !plainAborted {
 				if scanErr != nil {
 					breaker.RecordFailure()
 				} else {

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -2118,5 +2120,92 @@ func TestHandle_FallbackChainBlockedAtMidHop(t *testing.T) {
 		body, _ := io.ReadAll(resp.Body)
 		t.Errorf("status = %d, want %d (model-b's last error); body: %s",
 			resp.StatusCode, http.StatusBadGateway, body)
+	}
+}
+
+// ── writeStreamAbortEvent unit tests ─────────────────────────────────────────
+
+// TestWriteStreamAbortEvent verifies that writeStreamAbortEvent writes a
+// content-free OpenAI-shaped SSE error event that is terminated by a blank line
+// (two newlines) and contains the caller-supplied code with no trailing [DONE].
+func TestWriteStreamAbortEvent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		code string
+	}{
+		{code: "stream_transform_aborted"},
+		{code: "pii_restore_aborted"},
+		{code: "custom_code"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.code, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			w := bufio.NewWriter(&buf)
+			writeStreamAbortEvent(w, tc.code)
+			// writeStreamAbortEvent flushes internally.
+
+			output := buf.String()
+
+			// Must start with "data: ".
+			if !strings.HasPrefix(output, "data: ") {
+				t.Errorf("output does not start with 'data: ': %q", output)
+			}
+			// Must contain the code in the error object.
+			if !strings.Contains(output, tc.code) {
+				t.Errorf("output does not contain code %q: %q", tc.code, output)
+			}
+			// Must end with double newline (SSE event terminator).
+			if !strings.HasSuffix(output, "\n\n") {
+				t.Errorf("output does not end with \\n\\n: %q", output)
+			}
+			// Must NOT contain [DONE].
+			if strings.Contains(output, "[DONE]") {
+				t.Errorf("output must not contain [DONE]: %q", output)
+			}
+			// The JSON must be parseable and contain expected fields.
+			raw := strings.TrimPrefix(strings.TrimRight(output, "\n"), "data: ")
+			var obj struct {
+				Error struct {
+					Message string `json:"message"`
+					Type    string `json:"type"`
+					Code    string `json:"code"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal([]byte(raw), &obj); err != nil {
+				t.Fatalf("output JSON unparseable: %v; output: %q", err, output)
+			}
+			if obj.Error.Type != tc.code {
+				t.Errorf("error.type = %q, want %q", obj.Error.Type, tc.code)
+			}
+			if obj.Error.Code != tc.code {
+				t.Errorf("error.code = %q, want %q", obj.Error.Code, tc.code)
+			}
+			if obj.Error.Message == "" {
+				t.Error("error.message is empty, want non-empty content-free string")
+			}
+		})
+	}
+}
+
+// TestErrStreamTransformAborted verifies that errStreamTransformAborted is a
+// non-nil, content-free sentinel error with a stable string representation.
+func TestErrStreamTransformAborted(t *testing.T) {
+	t.Parallel()
+
+	if errStreamTransformAborted == nil {
+		t.Fatal("errStreamTransformAborted is nil")
+	}
+	// Must be a simple, content-free string.
+	msg := errStreamTransformAborted.Error()
+	if msg == "" {
+		t.Error("errStreamTransformAborted.Error() is empty")
+	}
+	// Must not contain caller-controlled or upstream content.
+	if strings.Contains(msg, "PII") || strings.Contains(msg, "upstream") {
+		t.Errorf("errStreamTransformAborted.Error() contains unexpected content: %q", msg)
 	}
 }

--- a/internal/proxy/stream_abort_test.go
+++ b/internal/proxy/stream_abort_test.go
@@ -1,0 +1,1603 @@
+package proxy
+
+// stream_abort_test.go covers the test matrix for L-018: stream-adapter
+// fail-closed abort signal and multi-line output.
+//
+// Test IDs map to the task specification:
+//
+//   ADAPTER-LEVEL
+//   AZ-1  Azure: passthrough returns ([][]byte{line}, nil) for any normal line.
+//   AZ-2  Azure: drop cases return (nil, nil) — N/A for Azure (all lines pass).
+//   AN-1  Anthropic ABORT cases: errStreamTransformAborted on protocol violations.
+//   AN-2  Anthropic DROP cases: (nil, nil) for event: lines, ping, etc.
+//   AN-3  Anthropic normal cases: one output line per valid data event.
+//   GE-1  Gemini mixed text+functionCall chunk: TWO output lines (text first, tool second).
+//   GE-2  Gemini ABORT cases: errStreamTransformAborted on invalid/excess tool calls.
+//   GE-3  Gemini normal cases: functionCall-only → one line; text-only → one line; drop cases.
+//
+//   HANDLER / INTEGRATION
+//   H-8   PII path: adapter abort → exactly one error event "stream_transform_aborted",
+//          no [DONE], breaker RecordFailure, streamIncomplete → usage with BadGateway.
+//   H-9   Plain path: adapter abort → distinct self-terminated abort event (\n\n),
+//          no [DONE], abort in its own segment, breaker RecordFailure.
+//   H-10  Abort event NOT emitted after client disconnect, NOT double-emitted.
+//   H-11  Multi-line (mixed text+tool) through PII restorer: BOTH lines delivered,
+//          stream terminates cleanly with [DONE].
+//   H-12  Raw-byte cap counts raw upstream bytes before the adapter.
+//   H-13  Plain path: Gemini mixed text+functionCall chunk → at least 4 distinct
+//          \n\n-terminated events, each valid JSON; text and tool_calls both present.
+//   H-14  Azure passthrough single-line stream → byte-identical wire output (regression
+//          guard): exactly 4 events, each data line followed by \n\n.
+//   H-15  Gemini plain path: [DONE] is \n\n-terminated as a distinct segment.
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/voidmind-io/voidllm/internal/circuitbreaker"
+)
+
+// ── AZ-1: Azure passthrough returns ([][]byte{line}, nil) ─────────────────────
+
+func TestAzureTransformStreamLine_SingleLineSlice(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "normal OpenAI SSE data line",
+			input: `data: {"id":"chatcmpl-x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}`,
+		},
+		{
+			name:  "DONE sentinel",
+			input: "data: [DONE]",
+		},
+		{
+			name:  "blank SSE delimiter",
+			input: "",
+		},
+		{
+			name:  "arbitrary line (event:)",
+			input: "event: ping",
+		},
+		{
+			name:  "comment line",
+			input: ": keep-alive",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &AzureAdapter{}
+			outLines, err := a.TransformStreamLine([]byte(tc.input))
+
+			if err != nil {
+				t.Fatalf("TransformStreamLine() returned error = %v, want nil", err)
+			}
+			if len(outLines) != 1 {
+				t.Fatalf("TransformStreamLine() returned %d lines, want exactly 1", len(outLines))
+			}
+			if string(outLines[0]) != tc.input {
+				t.Errorf("TransformStreamLine() = %q, want %q (passthrough unchanged)", outLines[0], tc.input)
+			}
+		})
+	}
+}
+
+// ── AN-1: Anthropic ABORT cases ───────────────────────────────────────────────
+
+func TestAnthropicTransformStreamLine_AbortCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// setup, if non-nil, is called on a fresh adapter before the line under
+		// test is processed. Use it to prime state (e.g. register a block index).
+		setup func(a *AnthropicAdapter)
+		line  string
+	}{
+		{
+			name: "content_block_start with unparseable JSON aborts",
+			line: `data: {"type":"content_block_start","index":"not-an-int","content_block":{"type":"tool_use"}}`,
+		},
+		{
+			name: "content_block_start negative index aborts",
+			line: `data: {"type":"content_block_start","index":-1,"content_block":{"type":"tool_use","id":"toolu_neg","name":"fn","input":{}}}`,
+		},
+		{
+			name: "content_block_start over tool-block cap aborts",
+			setup: func(a *AnthropicAdapter) {
+				// Fill the adapter up to maxAnthropicToolBlocks.
+				for i := 0; i < maxAnthropicToolBlocks; i++ {
+					line := fmt.Sprintf(
+						`data: {"type":"content_block_start","index":%d,"content_block":{"type":"tool_use","id":"toolu_%d","name":"fn_%d","input":{}}}`,
+						i, i, i,
+					)
+					_, _ = a.TransformStreamLine([]byte(line))
+				}
+			},
+			line: fmt.Sprintf(
+				`data: {"type":"content_block_start","index":%d,"content_block":{"type":"tool_use","id":"toolu_over","name":"fn_over","input":{}}}`,
+				maxAnthropicToolBlocks,
+			),
+		},
+		{
+			name: "duplicate content_block_start for same index aborts",
+			setup: func(a *AnthropicAdapter) {
+				first := `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_first","name":"fn_first","input":{}}}`
+				_, _ = a.TransformStreamLine([]byte(first))
+			},
+			line: `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_dup","name":"fn_dup","input":{}}}`,
+		},
+		{
+			name: "content_block_start tool_use with invalid-charset id aborts",
+			line: `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu@bad","name":"fn","input":{}}}`,
+		},
+		{
+			name: "content_block_start tool_use with invalid-charset name aborts",
+			line: `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_ok","name":"bad name spaces","input":{}}}`,
+		},
+		{
+			name: "input_json_delta when blockToToolCall is nil aborts",
+			// Fresh adapter: no content_block_start seen yet.
+			line: `data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"x\":"}}`,
+		},
+		{
+			name: "input_json_delta referencing unknown block index aborts",
+			setup: func(a *AnthropicAdapter) {
+				// Register block 0 but send delta for block 5 (not registered).
+				first := `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_0","name":"fn","input":{}}}`
+				_, _ = a.TransformStreamLine([]byte(first))
+			},
+			line: `data: {"type":"content_block_delta","index":5,"delta":{"type":"input_json_delta","partial_json":"{\"x\":"}}`,
+		},
+		{
+			name: "message_delta with unparseable JSON aborts",
+			line: `data: {"type":"message_delta","delta":"not-an-object","usage":"bad"}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &AnthropicAdapter{}
+			// Prime the adapter ID so buildChunk never produces nil.
+			transformLineIgnore(a, []byte(`data: {"type":"message_start","message":{"id":"msg_abort_test","usage":{"input_tokens":1}}}`))
+
+			if tc.setup != nil {
+				tc.setup(a)
+			}
+
+			outLines, err := a.TransformStreamLine([]byte(tc.line))
+
+			if err == nil {
+				t.Errorf("TransformStreamLine() error = nil, want errStreamTransformAborted")
+			}
+			if !errors.Is(err, errStreamTransformAborted) {
+				t.Errorf("TransformStreamLine() error = %v, want errStreamTransformAborted", err)
+			}
+			if len(outLines) != 0 {
+				t.Errorf("TransformStreamLine() returned %d lines, want nil/empty on abort", len(outLines))
+			}
+		})
+	}
+}
+
+// ── AN-2: Anthropic DROP cases still return (nil, nil) ────────────────────────
+
+func TestAnthropicTransformStreamLine_DropCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		line string
+	}{
+		{
+			name: "event: line is dropped",
+			line: "event: content_block_delta",
+		},
+		{
+			name: "event: message_start is dropped",
+			line: "event: message_start",
+		},
+		{
+			name: "data ping is dropped",
+			line: `data: {"type":"ping"}`,
+		},
+		{
+			name: "content_block_stop is dropped",
+			line: `data: {"type":"content_block_stop","index":0}`,
+		},
+		{
+			name: "unknown event type is dropped",
+			line: `data: {"type":"some_future_event","data":{}}`,
+		},
+		{
+			name: "text content_block_start is dropped",
+			line: `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}`,
+		},
+		{
+			name: "unknown delta type within content_block_delta is dropped",
+			line: `data: {"type":"content_block_delta","index":0,"delta":{"type":"future_delta","value":"x"}}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &AnthropicAdapter{}
+			outLines, err := a.TransformStreamLine([]byte(tc.line))
+
+			if err != nil {
+				t.Fatalf("TransformStreamLine(%q) error = %v, want nil", tc.line, err)
+			}
+			if len(outLines) != 0 {
+				t.Errorf("TransformStreamLine(%q) returned %d lines, want 0 (drop)", tc.line, len(outLines))
+			}
+		})
+	}
+}
+
+// ── AN-3: Anthropic normal cases return exactly one output line ───────────────
+
+func TestAnthropicTransformStreamLine_NormalCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// setup primes the adapter state before the line under test is processed.
+		setup   func(a *AnthropicAdapter)
+		line    string
+		checkFn func(t *testing.T, out []byte)
+	}{
+		{
+			name: "message_start emits role:assistant chunk",
+			line: `data: {"type":"message_start","message":{"id":"msg_norm","type":"message","role":"assistant","content":[],"model":"claude-3-5","stop_reason":null,"usage":{"input_tokens":5,"output_tokens":0}}}`,
+			checkFn: func(t *testing.T, out []byte) {
+				t.Helper()
+				chunk := parseChunk(t, out)
+				if len(chunk.Choices) == 0 {
+					t.Fatal("len(choices) = 0, want 1")
+				}
+				if chunk.Choices[0].Delta.Role != "assistant" {
+					t.Errorf("delta.role = %q, want assistant", chunk.Choices[0].Delta.Role)
+				}
+				if chunk.ID != "msg_norm" {
+					t.Errorf("chunk.id = %q, want msg_norm", chunk.ID)
+				}
+			},
+		},
+		{
+			name: "text_delta emits content chunk",
+			setup: func(a *AnthropicAdapter) {
+				transformLineIgnore(a, []byte(`data: {"type":"message_start","message":{"id":"msg_text","usage":{"input_tokens":1}}}`))
+			},
+			line: `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello world"}}`,
+			checkFn: func(t *testing.T, out []byte) {
+				t.Helper()
+				chunk := parseChunk(t, out)
+				if len(chunk.Choices) == 0 {
+					t.Fatal("len(choices) = 0, want 1")
+				}
+				if chunk.Choices[0].Delta.Content != "Hello world" {
+					t.Errorf("delta.content = %q, want %q", chunk.Choices[0].Delta.Content, "Hello world")
+				}
+			},
+		},
+		{
+			name: "valid tool_use content_block_start emits header delta",
+			setup: func(a *AnthropicAdapter) {
+				transformLineIgnore(a, []byte(`data: {"type":"message_start","message":{"id":"msg_tool","usage":{"input_tokens":1}}}`))
+			},
+			line: `data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"get_weather","input":{}}}`,
+			checkFn: func(t *testing.T, out []byte) {
+				t.Helper()
+				chunk := parseChunk(t, out)
+				if len(chunk.Choices) == 0 {
+					t.Fatal("len(choices) = 0, want 1")
+				}
+				delta := chunk.Choices[0].Delta
+				if len(delta.ToolCalls) != 1 {
+					t.Fatalf("len(delta.tool_calls) = %d, want 1", len(delta.ToolCalls))
+				}
+				tc := delta.ToolCalls[0]
+				if tc.Index == nil || *tc.Index != 0 {
+					t.Errorf("tool_calls[0].index = %v, want 0", tc.Index)
+				}
+				if tc.ID != "toolu_01" {
+					t.Errorf("tool_calls[0].id = %q, want toolu_01", tc.ID)
+				}
+				if tc.Type != "function" {
+					t.Errorf("tool_calls[0].type = %q, want function", tc.Type)
+				}
+				if tc.Function.Name != "get_weather" {
+					t.Errorf("tool_calls[0].function.name = %q, want get_weather", tc.Function.Name)
+				}
+				if tc.Function.Arguments != "" {
+					t.Errorf("tool_calls[0].function.arguments = %q, want empty (header delta)", tc.Function.Arguments)
+				}
+			},
+		},
+		{
+			name: "input_json_delta emits arguments fragment",
+			setup: func(a *AnthropicAdapter) {
+				transformLineIgnore(a, []byte(`data: {"type":"message_start","message":{"id":"msg_args","usage":{"input_tokens":1}}}`))
+				transformLineIgnore(a, []byte(`data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_arg","name":"fn","input":{}}}`))
+			},
+			line: `data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"loc"}}`,
+			checkFn: func(t *testing.T, out []byte) {
+				t.Helper()
+				chunk := parseChunk(t, out)
+				if len(chunk.Choices) == 0 {
+					t.Fatal("len(choices) = 0, want 1")
+				}
+				delta := chunk.Choices[0].Delta
+				if len(delta.ToolCalls) != 1 {
+					t.Fatalf("len(delta.tool_calls) = %d, want 1", len(delta.ToolCalls))
+				}
+				tc := delta.ToolCalls[0]
+				if tc.Index == nil || *tc.Index != 0 {
+					t.Errorf("tool_calls[0].index = %v, want 0", tc.Index)
+				}
+				if tc.Function.Arguments != `{"loc` {
+					t.Errorf("tool_calls[0].function.arguments = %q, want %q", tc.Function.Arguments, `{"loc`)
+				}
+			},
+		},
+		{
+			name: "message_stop emits [DONE]",
+			setup: func(a *AnthropicAdapter) {
+				transformLineIgnore(a, []byte(`data: {"type":"message_start","message":{"id":"msg_stop","usage":{"input_tokens":1}}}`))
+			},
+			line: `data: {"type":"message_stop"}`,
+			checkFn: func(t *testing.T, out []byte) {
+				t.Helper()
+				if string(out) != "data: [DONE]" {
+					t.Errorf("message_stop output = %q, want %q", out, "data: [DONE]")
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &AnthropicAdapter{}
+			if tc.setup != nil {
+				tc.setup(a)
+			}
+
+			outLines, err := a.TransformStreamLine([]byte(tc.line))
+
+			if err != nil {
+				t.Fatalf("TransformStreamLine(%q) error = %v, want nil", tc.line, err)
+			}
+			if len(outLines) != 1 {
+				t.Fatalf("TransformStreamLine(%q) returned %d lines, want 1", tc.line, len(outLines))
+			}
+			if outLines[0] == nil {
+				t.Fatalf("TransformStreamLine(%q) outLines[0] = nil, want non-nil", tc.line)
+			}
+			if tc.checkFn != nil {
+				tc.checkFn(t, outLines[0])
+			}
+		})
+	}
+}
+
+// ── GE-1: Gemini mixed text+functionCall returns TWO lines ───────────────────
+
+// TestGeminiTransformStreamLine_MixedTextAndFunctionCall_TwoLines is the
+// headline fix test (test 5 in the task specification). A single Gemini chunk
+// that carries both text content and a functionCall part must produce exactly
+// two SSE lines: the text content chunk first, then the tool_calls chunk.
+// Previously the text was silently discarded.
+func TestGeminiTransformStreamLine_MixedTextAndFunctionCall_TwoLines(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		line      string
+		wantText  string
+		wantFnArg string // partial expected content in tool_calls JSON
+	}{
+		{
+			name:      "text and single functionCall",
+			line:      `data: {"candidates":[{"content":{"role":"model","parts":[{"text":"Let me check that."},{"functionCall":{"name":"lookup","args":{"q":"test"}}}]},"finishReason":"STOP"}],"usageMetadata":{}}`,
+			wantText:  "Let me check that.",
+			wantFnArg: "lookup",
+		},
+		{
+			name:      "text and functionCall without finishReason",
+			line:      `data: {"candidates":[{"content":{"role":"model","parts":[{"text":"Thinking..."},{"functionCall":{"name":"fn","args":{}}}]},"finishReason":""}],"usageMetadata":{}}`,
+			wantText:  "Thinking...",
+			wantFnArg: "fn",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &GeminiAdapter{}
+			outLines, err := a.TransformStreamLine([]byte(tc.line))
+
+			if err != nil {
+				t.Fatalf("TransformStreamLine() returned unexpected error: %v", err)
+			}
+			if len(outLines) != 2 {
+				t.Fatalf("TransformStreamLine() returned %d lines, want exactly 2 (text + tool_calls)", len(outLines))
+			}
+
+			// Line 0 must be the text content chunk.
+			textChunk := parseChunk(t, outLines[0])
+			if len(textChunk.Choices) == 0 {
+				t.Fatal("first line: choices is empty")
+			}
+			if textChunk.Choices[0].Delta.Content != tc.wantText {
+				t.Errorf("first line (text): content = %q, want %q",
+					textChunk.Choices[0].Delta.Content, tc.wantText)
+			}
+			if len(textChunk.Choices[0].Delta.ToolCalls) != 0 {
+				t.Error("first line (text): must not contain tool_calls")
+			}
+
+			// Line 1 must be the tool_calls chunk.
+			toolChunk := parseChunk(t, outLines[1])
+			if len(toolChunk.Choices) == 0 {
+				t.Fatal("second line: choices is empty")
+			}
+			if len(toolChunk.Choices[0].Delta.ToolCalls) == 0 {
+				t.Error("second line (tool_calls): must contain at least one tool call")
+			}
+			tc2 := toolChunk.Choices[0].Delta.ToolCalls[0]
+			if tc2.Function.Name != tc.wantFnArg {
+				t.Errorf("second line tool_calls[0].function.name = %q, want %q",
+					tc2.Function.Name, tc.wantFnArg)
+			}
+
+			// The second line (tool_calls chunk) carries the finishReason when present.
+			// The text chunk must NOT carry a finishReason when there are tool calls.
+			if textChunk.Choices[0].FinishReason != nil {
+				t.Errorf("first line (text): finish_reason = %q, want nil (must not carry finish reason when tool calls follow)",
+					*textChunk.Choices[0].FinishReason)
+			}
+		})
+	}
+}
+
+// ── GE-2: Gemini ABORT cases ─────────────────────────────────────────────────
+
+func TestGeminiTransformStreamLine_AbortCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		setup func(a *GeminiAdapter)
+		line  string
+	}{
+		{
+			name: "functionCall over streamToolCallCounter cap aborts",
+			setup: func(a *GeminiAdapter) {
+				// Fill to cap.
+				for i := 0; i < maxGeminiToolBlocks; i++ {
+					line := fmt.Sprintf(
+						`data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"fn_%d","args":{}}}]},"finishReason":""}],"usageMetadata":{}}`,
+						i,
+					)
+					_, _ = a.TransformStreamLine([]byte(line))
+				}
+			},
+			line: `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"fn_over","args":{}}}]},"finishReason":""}],"usageMetadata":{}}`,
+		},
+		{
+			name: "empty function name aborts",
+			line: `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"","args":{}}}]},"finishReason":""}],"usageMetadata":{}}`,
+		},
+		{
+			name: "invalid-charset function name aborts",
+			line: `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"bad name spaces","args":{}}}]},"finishReason":""}],"usageMetadata":{}}`,
+		},
+		{
+			name: "serializeInputToArguments error on non-object args aborts",
+			// args is a JSON array, not an object — serializeInputToArguments returns error.
+			line: `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"fn","args":[1,2,3]}}]},"finishReason":""}],"usageMetadata":{}}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &GeminiAdapter{}
+			if tc.setup != nil {
+				tc.setup(a)
+			}
+
+			outLines, err := a.TransformStreamLine([]byte(tc.line))
+
+			if err == nil {
+				t.Errorf("TransformStreamLine() error = nil, want errStreamTransformAborted")
+			}
+			if !errors.Is(err, errStreamTransformAborted) {
+				t.Errorf("TransformStreamLine() error = %v, want errStreamTransformAborted", err)
+			}
+			if len(outLines) != 0 {
+				t.Errorf("TransformStreamLine() returned %d lines, want nil/empty on abort", len(outLines))
+			}
+		})
+	}
+}
+
+// ── GE-3: Gemini normal cases ─────────────────────────────────────────────────
+
+func TestGeminiTransformStreamLine_NormalCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		line    string
+		wantLen int // expected number of output lines (0 = drop, 1 = single line)
+		checkFn func(t *testing.T, outLines [][]byte)
+	}{
+		{
+			name:    "functionCall-only chunk emits one tool_calls line",
+			line:    `data: {"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"fn","args":{"x":1}}}]},"finishReason":""}],"usageMetadata":{}}`,
+			wantLen: 1,
+			checkFn: func(t *testing.T, outLines [][]byte) {
+				t.Helper()
+				chunk := parseChunk(t, outLines[0])
+				if len(chunk.Choices) == 0 {
+					t.Fatal("choices empty")
+				}
+				if len(chunk.Choices[0].Delta.ToolCalls) == 0 {
+					t.Error("tool_calls missing in functionCall-only chunk")
+				}
+				if chunk.Choices[0].Delta.Content != "" {
+					t.Errorf("content = %q, want empty for functionCall-only chunk", chunk.Choices[0].Delta.Content)
+				}
+				tc := chunk.Choices[0].Delta.ToolCalls[0]
+				if tc.Function.Name != "fn" {
+					t.Errorf("function.name = %q, want fn", tc.Function.Name)
+				}
+				// id must be synthesised and satisfy charset regex.
+				if !anthropicToolIDRe.MatchString(tc.ID) {
+					t.Errorf("tool_calls[0].id = %q does not satisfy charset regex", tc.ID)
+				}
+			},
+		},
+		{
+			name:    "text-only chunk emits one content line",
+			line:    `data: {"candidates":[{"content":{"role":"model","parts":[{"text":"hello there"}]},"finishReason":""}],"usageMetadata":{}}`,
+			wantLen: 1,
+			checkFn: func(t *testing.T, outLines [][]byte) {
+				t.Helper()
+				chunk := parseChunk(t, outLines[0])
+				if len(chunk.Choices) == 0 {
+					t.Fatal("choices empty")
+				}
+				if chunk.Choices[0].Delta.Content != "hello there" {
+					t.Errorf("content = %q, want %q", chunk.Choices[0].Delta.Content, "hello there")
+				}
+				if len(chunk.Choices[0].Delta.ToolCalls) != 0 {
+					t.Error("tool_calls must be absent for text-only chunk")
+				}
+			},
+		},
+		{
+			name:    "content-free intermediate chunk is dropped",
+			line:    `data: {"candidates":[{"content":{"role":"model","parts":[]},"finishReason":""}],"usageMetadata":{}}`,
+			wantLen: 0,
+		},
+		{
+			name:    "non-data line is dropped",
+			line:    "not-a-data-line",
+			wantLen: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &GeminiAdapter{}
+			outLines, err := a.TransformStreamLine([]byte(tc.line))
+
+			if err != nil {
+				t.Fatalf("TransformStreamLine(%q) error = %v, want nil", tc.line, err)
+			}
+			if len(outLines) != tc.wantLen {
+				t.Fatalf("TransformStreamLine(%q) returned %d lines, want %d", tc.line, len(outLines), tc.wantLen)
+			}
+			if tc.checkFn != nil && len(outLines) > 0 {
+				tc.checkFn(t, outLines)
+			}
+		})
+	}
+}
+
+// ── H-8: PII path — adapter abort → fail-closed error event, no [DONE], breaker failure ──
+
+// abortRegistryAnthropic builds a Registry with a single "abort-anthropic"
+// model. H-8 and H-9 drive the abort via the real Anthropic adapter responding
+// to a deliberately malformed content_block_start with negative index, which
+// causes errStreamTransformAborted.
+func abortRegistryAnthropic(t *testing.T, upstreamURL string) *Registry {
+	t.Helper()
+	m := &Model{
+		Name:     "abort-anthropic",
+		Provider: "anthropic",
+		Type:     "chat",
+		BaseURL:  upstreamURL,
+		APIKey:   "key-abort",
+		// destPrivate=false: PII filter fires.
+	}
+	r := &Registry{
+		models:  map[string]*Model{"abort-anthropic": m},
+		aliases: make(map[string]string),
+	}
+	r.rebuildSorted()
+	return r
+}
+
+// abortRegistryPlain builds a Registry with a model that uses provider "vllm"
+// (no adapter). We test H-9 by using a real Anthropic provider too (Anthropic
+// adapter is the easiest way to get errStreamTransformAborted on demand), but
+// with NO PII engine attached to exercise the plain passthrough scan loop.
+func abortRegistryPlain(t *testing.T, upstreamURL string) *Registry {
+	t.Helper()
+	m := &Model{
+		Name:     "abort-plain",
+		Provider: "anthropic",
+		Type:     "chat",
+		BaseURL:  upstreamURL,
+		APIKey:   "key-abort-plain",
+	}
+	r := &Registry{
+		models:  map[string]*Model{"abort-plain": m},
+		aliases: make(map[string]string),
+	}
+	r.rebuildSorted()
+	return r
+}
+
+// anthropicAbortUpstream returns an httptest.Server that sends a valid
+// message_start event followed by a content_block_start with negative index
+// (which causes errStreamTransformAborted in AnthropicAdapter), then one more
+// valid line that must never reach the client.
+func anthropicAbortUpstream(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("upstream: no Flusher")
+			return
+		}
+		events := []string{
+			// A valid message_start — gets processed fine.
+			`event: message_start`,
+			`data: {"type":"message_start","message":{"id":"msg_abort_e2e","type":"message","role":"assistant","content":[],"model":"claude-test","stop_reason":null,"usage":{"input_tokens":5,"output_tokens":0}}}`,
+			``,
+			// This line triggers errStreamTransformAborted (negative index).
+			`event: content_block_start`,
+			`data: {"type":"content_block_start","index":-1,"content_block":{"type":"tool_use","id":"toolu_bad","name":"fn","input":{}}}`,
+			``,
+			// This line must never reach the client after the abort.
+			`data: {"type":"message_stop"}`,
+			``,
+		}
+		for _, ev := range events {
+			fmt.Fprintln(w, ev)
+		}
+		flusher.Flush()
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestHandle_PII_AdapterAbort_FailClosed is H-8.
+//
+// The PII path (filter.Touched() == true) must:
+//   - emit exactly one "stream_transform_aborted" error event to the client
+//   - NOT emit a [DONE] sentinel
+//   - record RecordFailure on the circuit breaker
+//   - log streamIncomplete → usage with http.StatusBadGateway
+func TestHandle_PII_AdapterAbort_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestPIIEngine(t)
+	upstream := anthropicAbortUpstream(t)
+
+	reg := abortRegistryAnthropic(t, upstream.URL)
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.PIIEngine = engine
+
+	// Wire a circuit breaker with threshold=1 so a single RecordFailure trips it open.
+	h.CircuitBreakers = circuitbreaker.NewRegistry(circuitbreaker.Config{
+		Enabled:     true,
+		Threshold:   1,
+		Timeout:     30 * time.Second,
+		HalfOpenMax: 1,
+	})
+
+	baseURL := startTestServer(t, h)
+
+	// The request body must contain PII so that filter.Touched() == true.
+	streamBody := fmt.Sprintf(
+		`{"model":"abort-anthropic","messages":[{"role":"user","content":"lookup %s"}],"stream":true}`,
+		piiTestEmail,
+	)
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions",
+		strings.NewReader(streamBody))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	fullBody, _ := io.ReadAll(resp.Body)
+	fullStr := string(fullBody)
+
+	// Must contain exactly one "stream_transform_aborted" error event.
+	if !strings.Contains(fullStr, "stream_transform_aborted") {
+		t.Errorf("H-8: error event with stream_transform_aborted absent\noutput: %s", fullStr)
+	}
+	// The error event must be valid JSON with the expected shape.
+	for _, line := range strings.Split(fullStr, "\n") {
+		if !strings.HasPrefix(line, "data: {") {
+			continue
+		}
+		payload := strings.TrimPrefix(line, "data: ")
+		var obj struct {
+			Error struct {
+				Type string `json:"type"`
+				Code string `json:"code"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal([]byte(payload), &obj); err != nil {
+			// Not an error event — skip (may be the role chunk).
+			continue
+		}
+		if obj.Error.Type == "stream_transform_aborted" {
+			// Found the abort event — validate it is content-free.
+			if strings.Contains(payload, piiTestEmail) {
+				t.Errorf("H-8 SECURITY: error event contains PII value %q\npayload: %s", piiTestEmail, payload)
+			}
+			break
+		}
+	}
+
+	// Must NOT contain [DONE].
+	if strings.Contains(fullStr, "[DONE]") {
+		t.Errorf("H-8: [DONE] present after adapter abort, want absent\noutput: %s", fullStr)
+	}
+
+	// Circuit breaker for "abort-anthropic" must be Open (RecordFailure was called).
+	breaker := h.CircuitBreakers.Get("abort-anthropic")
+	if state := breaker.CurrentState(); state != circuitbreaker.Open {
+		t.Errorf("H-8: breaker state = %v, want Open (RecordFailure expected after adapter abort)", state)
+	}
+}
+
+// TestHandle_Plain_AdapterAbort_FailClosed is H-9.
+//
+// The plain passthrough path (no PII engine) must:
+//   - emit exactly one "stream_transform_aborted" error event as its own
+//     self-terminated SSE event (ends with \n\n, distinct from any preceding event)
+//   - NOT emit a [DONE] sentinel
+//   - record RecordFailure on the circuit breaker
+//
+// Wire-format invariants verified by splitting the full body on "\n\n" and
+// asserting event count and separation — not merely string presence.
+func TestHandle_Plain_AdapterAbort_FailClosed(t *testing.T) {
+	t.Parallel()
+
+	upstream := anthropicAbortUpstream(t)
+
+	reg := abortRegistryPlain(t, upstream.URL)
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	// No PII engine: exercises the plain scan loop.
+
+	h.CircuitBreakers = circuitbreaker.NewRegistry(circuitbreaker.Config{
+		Enabled:     true,
+		Threshold:   1,
+		Timeout:     30 * time.Second,
+		HalfOpenMax: 1,
+	})
+
+	baseURL := startTestServer(t, h)
+
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions",
+		strings.NewReader(`{"model":"abort-plain","messages":[{"role":"user","content":"hi"}],"stream":true}`))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	fullBody, _ := io.ReadAll(resp.Body)
+	fullStr := string(fullBody)
+
+	// Must NOT contain [DONE].
+	if strings.Contains(fullStr, "[DONE]") {
+		t.Errorf("H-9: [DONE] present after adapter abort, want absent\noutput: %s", fullStr)
+	}
+
+	// Parse the wire output as a sequence of SSE events split on "\n\n".
+	// Each non-empty segment is one self-terminated event. The abort event
+	// must be a distinct segment (not merged with a preceding event).
+	rawEvents := strings.Split(fullStr, "\n\n")
+	var dataEvents []string
+	for _, seg := range rawEvents {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			continue
+		}
+		dataEvents = append(dataEvents, seg)
+	}
+
+	// Find the abort event among the segments.
+	abortEventCount := 0
+	var abortPayload string
+	for _, ev := range dataEvents {
+		for _, line := range strings.Split(ev, "\n") {
+			if !strings.HasPrefix(line, "data: {") {
+				continue
+			}
+			payload := strings.TrimPrefix(line, "data: ")
+			var obj struct {
+				Error struct {
+					Type string `json:"type"`
+				} `json:"error"`
+			}
+			if err := json.Unmarshal([]byte(payload), &obj); err != nil {
+				continue
+			}
+			if obj.Error.Type == "stream_transform_aborted" {
+				abortEventCount++
+				abortPayload = payload
+			}
+		}
+	}
+
+	if abortEventCount == 0 {
+		t.Fatalf("H-9: stream_transform_aborted event absent\noutput: %s", fullStr)
+	}
+	if abortEventCount > 1 {
+		t.Errorf("H-9: stream_transform_aborted emitted %d times, want exactly 1\noutput: %s", abortEventCount, fullStr)
+	}
+
+	// Validate the abort event payload fields.
+	var full struct {
+		Error struct {
+			Message string `json:"message"`
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal([]byte(abortPayload), &full); err != nil {
+		t.Fatalf("H-9: abort event JSON invalid: %v\npayload: %s", err, abortPayload)
+	}
+	if full.Error.Message == "" {
+		t.Error("H-9: error.message is empty")
+	}
+	if full.Error.Code != "stream_transform_aborted" {
+		t.Errorf("H-9: error.code = %q, want stream_transform_aborted", full.Error.Code)
+	}
+
+	// The abort event must be a distinct SSE segment — assert that at least one
+	// non-abort event exists before it (the role:assistant chunk from the
+	// upstream message_start) and the abort is in its own segment.
+	// We do this by checking that the abort payload appears exactly once in the
+	// full string split on \n\n (i.e. it is not concatenated with another event).
+	abortInOwnSegment := false
+	for _, seg := range rawEvents {
+		seg = strings.TrimSpace(seg)
+		if strings.Contains(seg, "stream_transform_aborted") {
+			// This segment must NOT also contain any non-abort data line.
+			lines := strings.Split(seg, "\n")
+			nonAbortData := false
+			for _, l := range lines {
+				if strings.HasPrefix(l, "data: ") && !strings.Contains(l, "stream_transform_aborted") {
+					nonAbortData = true
+					break
+				}
+			}
+			if !nonAbortData {
+				abortInOwnSegment = true
+			}
+		}
+	}
+	if !abortInOwnSegment {
+		t.Errorf("H-9: abort event is not in its own \\n\\n-delimited segment (merged with another event)\noutput: %s", fullStr)
+	}
+
+	// Breaker must be Open.
+	breaker := h.CircuitBreakers.Get("abort-plain")
+	if state := breaker.CurrentState(); state != circuitbreaker.Open {
+		t.Errorf("H-9: breaker state = %v, want Open (RecordFailure expected)", state)
+	}
+}
+
+// TestHandle_AbortEvent_NotDoubleEmitted is H-10 (unit-level equivalent).
+//
+// writeStreamAbortEvent is only called once on adapter abort (not duplicated by
+// the post-loop error-event block). We verify this at the unit level by checking
+// the two guards: adapterAborted prevents the PII post-loop block, and
+// plainAborted prevents the plain post-loop block from recording success.
+//
+// The end-to-end tests (H-8, H-9) already guarantee the stream has exactly one
+// error event. This test drives writeStreamAbortEvent directly to confirm the
+// output contains exactly one SSE event terminator (\n\n).
+func TestHandle_AbortEvent_SingleEmission(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	w := bufio.NewWriter(&buf)
+	writeStreamAbortEvent(w, "stream_transform_aborted")
+	// writeStreamAbortEvent flushes internally.
+
+	output := buf.String()
+
+	// Count occurrences of double-newline (SSE event terminators).
+	count := strings.Count(output, "\n\n")
+	if count != 1 {
+		t.Errorf("writeStreamAbortEvent emitted %d SSE event terminators, want exactly 1\noutput: %q", count, output)
+	}
+
+	// The single event must be the error object.
+	if !strings.Contains(output, "stream_transform_aborted") {
+		t.Errorf("output does not contain stream_transform_aborted: %q", output)
+	}
+
+	// Must not contain [DONE].
+	if strings.Contains(output, "[DONE]") {
+		t.Errorf("writeStreamAbortEvent output contains [DONE], want absent: %q", output)
+	}
+}
+
+// ── H-11: Multi-line through PII restorer — both lines delivered ──────────────
+
+// TestHandle_Gemini_MixedChunk_PII_BothLinesDelivered is H-11.
+//
+// A Gemini upstream emits a mixed text+functionCall chunk. The adapter produces
+// TWO SSE lines. Both must flow through the PII StreamRestorer and reach the
+// client. The pseudonym in the tool_call arguments must be restored. The stream
+// must end cleanly with [DONE].
+//
+// Design: the text part carries plain (non-PII) content to avoid a content-carry
+// collision at the restorer cross-lane check. The pseudonym is placed exclusively
+// in the functionCall arguments. The Stage 0c StreamRestorer must:
+//  1. Pass the text content chunk through (no pseudonym → emitted immediately).
+//  2. Buffer the tool_calls chunk arguments, restore the pseudonym, and emit.
+//  3. Emit the finish_reason chunk and [DONE] cleanly.
+func TestHandle_Gemini_MixedChunk_PII_BothLinesDelivered(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestPIIEngine(t)
+
+	// Pre-compute the pseudonym for piiTestEmail.
+	sampleFilter := engine.NewFilter("")
+	sampleBody := []byte(chatBody("gemini-test", "lookup "+piiTestEmail))
+	anonBody, err := sampleFilter.AnonymizeJSON(sampleBody)
+	if err != nil {
+		t.Fatalf("pre-compute AnonymizeJSON: %v", err)
+	}
+	pseudo := piiPseudonymPattern.FindString(string(anonBody))
+	if pseudo == "" {
+		t.Fatal("could not derive pseudonym for piiTestEmail")
+	}
+
+	// The upstream emits:
+	//   Chunk 1: mixed text ("Calling tool...") + functionCall with pseudonym in args.
+	//            No finishReason so text gets its own chunk and tool_calls gets its own
+	//            chunk — the adapter splits them into two lines.
+	//   Chunk 2: terminal chunk with finishReason=STOP (sawFunctionCall=true → tool_calls).
+	//   Blank:   triggers [DONE] from the Gemini adapter's doneSent logic.
+	//
+	// The pseudonym is ONLY in args (not in the text part). This avoids the
+	// StreamRestorer cross-lane abort: the content carry drains between chunks
+	// because the text has no pseudonym.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("upstream: no Flusher")
+			return
+		}
+
+		// Chunk 1: plain text + functionCall with pseudonym in args.
+		// finishReason="" so GeminiAdapter emits text-only chunk (line 0) and
+		// tool_calls chunk (line 1) with no finishReason on either.
+		chunk1 := fmt.Sprintf(
+			`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"Calling tool..."},{"functionCall":{"name":"notify","args":{"email":"%s"}}}]},"finishReason":""}],"usageMetadata":{}}`,
+			pseudo,
+		)
+		// Chunk 2: terminal chunk with finishReason=STOP. Parts is empty so no text/tool
+		// is produced, only the finish_reason chunk (sawFunctionCall=true → "tool_calls").
+		chunk2 := `data: {"candidates":[{"content":{"role":"model","parts":[]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":10,"totalTokenCount":15}}`
+
+		for _, chunk := range []string{chunk1, chunk2} {
+			fmt.Fprintln(w, chunk)
+			fmt.Fprintln(w) // blank separator
+			flusher.Flush()
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	reg := piiRegistryGemini(t, upstream.URL)
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.PIIEngine = engine
+
+	baseURL := startTestServer(t, h)
+
+	streamBody := fmt.Sprintf(
+		`{"model":"gemini-test","messages":[{"role":"user","content":"lookup %s"}],"stream":true}`,
+		piiTestEmail,
+	)
+	httpReq, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions",
+		strings.NewReader(streamBody))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	streamResp, err := client.Do(httpReq)
+	if err != nil {
+		t.Fatalf("streaming request: %v", err)
+	}
+	defer streamResp.Body.Close()
+
+	if streamResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(streamResp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", streamResp.StatusCode, body)
+	}
+
+	fullBody, _ := io.ReadAll(streamResp.Body)
+	fullStr := string(fullBody)
+
+	// No abort events must appear.
+	if strings.Contains(fullStr, "stream_transform_aborted") || strings.Contains(fullStr, "pii_restore_aborted") {
+		t.Fatalf("H-11: unexpected abort event in output\noutput: %s", fullStr)
+	}
+
+	// Both SSE kinds must be delivered: the text content chunk and the tool_calls chunk.
+	if !strings.Contains(fullStr, `"content"`) {
+		t.Errorf("H-11: text content chunk missing from output\noutput: %s", fullStr)
+	}
+	if !strings.Contains(fullStr, `"tool_calls"`) {
+		t.Errorf("H-11: tool_calls chunk missing from output\noutput: %s", fullStr)
+	}
+	// The tool name must be present.
+	if !strings.Contains(fullStr, `"notify"`) {
+		t.Errorf("H-11: function name 'notify' missing from output\noutput: %s", fullStr)
+	}
+
+	// The pseudonym must NOT appear in any emitted line (restorer replaced it).
+	if strings.Contains(fullStr, pseudo) {
+		t.Errorf("H-11 SECURITY: raw pseudonym %q visible in output\noutput: %s", pseudo, fullStr)
+	}
+
+	// The restored email must appear in the output (restorer replaced the pseudonym).
+	if !strings.Contains(fullStr, piiTestEmail) {
+		t.Errorf("H-11: restored email %q missing from output\noutput: %s", piiTestEmail, fullStr)
+	}
+
+	// Stream must terminate cleanly with [DONE].
+	if !strings.Contains(fullStr, "[DONE]") {
+		t.Errorf("H-11: [DONE] missing — stream did not terminate cleanly\noutput: %s", fullStr)
+	}
+}
+
+// ── H-12: Raw-byte cap counts raw upstream bytes before the adapter ───────────
+
+// TestHandle_Streaming_ByteCapCountsRawBytes is H-12.
+//
+// The piiTotalInputBytes counter on the PII path is incremented for EVERY raw
+// byte read from the upstream scanner, including lines the adapter drops
+// (e.g. Anthropic "event:" lines). We verify this by checking that the proxy
+// aborts with a PII policy error when the raw byte total exceeds maxRespBody,
+// even if the adapter drops most lines so the client would otherwise receive
+// far fewer bytes.
+//
+// Strategy: set MaxResponseBody very low (e.g. 100 bytes) and send enough raw
+// upstream bytes to exceed the cap. At least one dropped line must push the
+// aggregate over the threshold.
+func TestHandle_Streaming_ByteCapCountsRawBytes(t *testing.T) {
+	t.Parallel()
+
+	engine := newTestPIIEngine(t)
+
+	// The upstream will send a stream where the raw byte total exceeds the cap.
+	// We send Anthropic "event:" lines (dropped by adapter) plus a final data line.
+	// Each "event: content_block_delta" line is 28 bytes; 10 of them = 280 bytes.
+	// We set maxRespBody = 200 so the cap is hit around line 7.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("upstream: no Flusher")
+			return
+		}
+
+		// Start with message_start (required for AnthropicAdapter).
+		fmt.Fprintln(w, `data: {"type":"message_start","message":{"id":"msg_cap","type":"message","role":"assistant","content":[],"model":"claude-test","stop_reason":null,"usage":{"input_tokens":1,"output_tokens":0}}}`)
+		fmt.Fprintln(w) // blank
+		flusher.Flush()
+
+		// Emit 15 "event:" lines (each ~28 bytes + newline = ~29 bytes each).
+		// 15 * 29 = 435 bytes, exceeding our 200-byte cap.
+		for i := 0; i < 15; i++ {
+			fmt.Fprintln(w, "event: content_block_delta")
+			flusher.Flush()
+		}
+		// Send a data line that would normally be forwarded — but the cap fires first.
+		fmt.Fprintln(w, `data: {"type":"message_stop"}`)
+		fmt.Fprintln(w)
+		flusher.Flush()
+	}))
+	t.Cleanup(upstream.Close)
+
+	reg := abortRegistryAnthropic(t, upstream.URL)
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.PIIEngine = engine
+	h.MaxResponseBody = 200 // Low cap: triggers after ~7 "event:" lines.
+
+	baseURL := startTestServer(t, h)
+
+	// The request body must contain PII so filter.Touched() == true (PII path).
+	streamBody := fmt.Sprintf(
+		`{"model":"abort-anthropic","messages":[{"role":"user","content":"lookup %s"}],"stream":true}`,
+		piiTestEmail,
+	)
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions",
+		strings.NewReader(streamBody))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Status must be 200 (streaming response header was already sent).
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	fullBody, _ := io.ReadAll(resp.Body)
+	fullStr := string(fullBody)
+
+	// The byte cap abort must have triggered. The output must contain the PII
+	// policy error event (the cap abort produces a pii_restore_aborted event).
+	// Note: the byte cap abort fires "streamAborted=true" on the PII path, and
+	// !adapterAborted && !clientDisconnected && streamIncomplete triggers the
+	// pii error event (not stream_transform_aborted, since it's a cap abort).
+	if !strings.Contains(fullStr, "pii_restore_aborted") {
+		t.Errorf("H-12: byte cap not triggered — pii_restore_aborted event absent\noutput: %s", fullStr)
+	}
+
+	// [DONE] must be absent (stream was aborted before completion).
+	if strings.Contains(fullStr, "[DONE]") {
+		t.Errorf("H-12: [DONE] present after byte-cap abort, want absent\noutput: %s", fullStr)
+	}
+}
+
+// ── H-13: Plain path — Gemini mixed chunk → two properly-separated SSE events ─
+
+// TestHandle_Gemini_MixedChunk_Plain_TwoSeparatedEvents is H-13.
+//
+// A Gemini upstream emits a single mixed text+functionCall chunk. The Gemini
+// adapter produces TWO SSE lines from it. On the PLAIN (non-PII) path the
+// handler must write each line as its own self-terminated SSE event ending in
+// "\n\n". The client receives exactly the expected number of events and each
+// parses as valid JSON.
+//
+// Expected wire output for the mixed chunk:
+//
+//	data: {"choices":[{"delta":{"role":"assistant","content":"Calling tool..."}}],...}\n\n
+//	data: {"choices":[{"delta":{"tool_calls":[...]}}],...}\n\n
+//
+// Each event is self-terminated with "\n\n" — no reliance on upstream blank lines.
+// The terminal [DONE] likewise ends with "\n\n".
+func TestHandle_Gemini_MixedChunk_Plain_TwoSeparatedEvents(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("upstream: no Flusher")
+			return
+		}
+
+		// Mixed chunk: text + functionCall, no finishReason so the adapter emits
+		// a text-only line (line 0) and a tool_calls line (line 1).
+		chunk1 := `data: {"candidates":[{"content":{"role":"model","parts":[{"text":"Calling tool..."},{"functionCall":{"name":"notify","args":{"email":"user@example.com"}}}]},"finishReason":""}],"usageMetadata":{}}`
+		// Terminal chunk with finishReason=STOP; emits finish_reason chunk.
+		chunk2 := `data: {"candidates":[{"content":{"role":"model","parts":[]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":10,"totalTokenCount":15}}`
+
+		for _, chunk := range []string{chunk1, chunk2} {
+			fmt.Fprintln(w, chunk)
+			fmt.Fprintln(w) // blank SSE event separator
+			flusher.Flush()
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	// Plain Gemini registry — no PIIEngine attached so the plain scan loop runs.
+	reg := piiRegistryGemini(t, upstream.URL)
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	// h.PIIEngine is intentionally nil: forces the plain passthrough path.
+
+	baseURL := startTestServer(t, h)
+
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions",
+		strings.NewReader(`{"model":"gemini-test","messages":[{"role":"user","content":"hi"}],"stream":true}`))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("streaming request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("H-13: status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	fullBody, _ := io.ReadAll(resp.Body)
+	fullStr := string(fullBody)
+
+	// No abort events must appear.
+	if strings.Contains(fullStr, "stream_transform_aborted") {
+		t.Fatalf("H-13: unexpected abort event in output\noutput: %s", fullStr)
+	}
+
+	// Parse the raw wire output into individual SSE events by splitting on "\n\n".
+	// Each non-empty event that starts with "data: " must carry valid JSON after
+	// stripping the prefix (or be the [DONE] sentinel).
+	rawEvents := strings.Split(fullStr, "\n\n")
+	var dataEvents []string
+	for _, ev := range rawEvents {
+		ev = strings.TrimSpace(ev)
+		if ev == "" {
+			continue
+		}
+		if !strings.HasPrefix(ev, "data: ") {
+			continue
+		}
+		dataEvents = append(dataEvents, ev)
+	}
+
+	// We expect exactly: text-chunk, tool_calls-chunk, finish_reason-chunk, [DONE].
+	// That is at least 4 data events. Assert minimum count to catch merging.
+	if len(dataEvents) < 4 {
+		t.Errorf("H-13: got %d data events, want at least 4 (text, tool_calls, finish_reason, [DONE])\nfull output:\n%s",
+			len(dataEvents), fullStr)
+	}
+
+	// Verify every data event carries valid JSON (or is [DONE]).
+	// If the "\n\n" separator were missing, two lines would be joined as one event
+	// and the JSON parse would fail.
+	for _, ev := range dataEvents {
+		payload := strings.TrimPrefix(ev, "data: ")
+		if payload == "[DONE]" {
+			continue
+		}
+		if !json.Valid([]byte(payload)) {
+			t.Errorf("H-13: SSE event carries invalid JSON — \\n\\n terminator likely missing\npayload: %s\nfull output:\n%s", payload, fullStr)
+		}
+	}
+
+	// The text content chunk and the tool_calls chunk must both appear as separate
+	// parseable events.
+	textFound := false
+	toolFound := false
+	doneFound := false
+	for _, ev := range dataEvents {
+		payload := strings.TrimPrefix(ev, "data: ")
+		if payload == "[DONE]" {
+			doneFound = true
+			continue
+		}
+		if strings.Contains(payload, `"content"`) && strings.Contains(payload, "Calling tool") {
+			textFound = true
+		}
+		if strings.Contains(payload, `"tool_calls"`) {
+			toolFound = true
+		}
+	}
+	if !textFound {
+		t.Errorf("H-13: text content chunk missing from plain-path output\noutput: %s", fullStr)
+	}
+	if !toolFound {
+		t.Errorf("H-13: tool_calls chunk missing from plain-path output\noutput: %s", fullStr)
+	}
+
+	// The function name must be present.
+	if !strings.Contains(fullStr, `"notify"`) {
+		t.Errorf("H-13: function name 'notify' missing from plain-path output\noutput: %s", fullStr)
+	}
+
+	// Stream must terminate cleanly with [DONE] as a distinct self-terminated event.
+	if !doneFound {
+		t.Errorf("H-13: [DONE] missing or not a distinct \\n\\n-terminated event\noutput: %s", fullStr)
+	}
+}
+
+// ── H-14: Azure passthrough single-line stream — byte-identical wire output ──
+
+// TestHandle_Azure_Passthrough_WireFormat is H-14.
+//
+// Azure uses AzureAdapter which passes each upstream line through unchanged
+// (including blank lines). On the plain path the handler writes each adapted
+// line with "\n\n" and skips blank adapted lines. For a standard OpenAI/Azure
+// SSE stream (data-line + blank per event) the wire output must be byte-identical
+// to what a naive "\n"-per-line forwarder would produce: each "data:..." line
+// followed by exactly "\n\n".
+//
+// This test is the regression guard: any change to the framing logic must not
+// alter the output for the common Azure single-line stream case.
+func TestHandle_Azure_Passthrough_WireFormat(t *testing.T) {
+	t.Parallel()
+
+	// Build a minimal Azure model registry pointing at the test upstream.
+	buildAzureRegistry := func(t *testing.T, upstreamURL string) *Registry {
+		t.Helper()
+		m := &Model{
+			Name:            "azure-gpt4",
+			Provider:        "azure",
+			Type:            "chat",
+			BaseURL:         upstreamURL,
+			APIKey:          "azure-key",
+			AzureDeployment: "gpt-4o",
+			AzureAPIVersion: "2024-10-21",
+		}
+		r := &Registry{
+			models:  map[string]*Model{"azure-gpt4": m},
+			aliases: make(map[string]string),
+		}
+		r.rebuildSorted()
+		return r
+	}
+
+	// Standard Azure/OpenAI SSE stream: one data line + one blank line per event.
+	// The upstream sends three chunks followed by [DONE].
+	chunk1 := `data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}`
+	chunk2 := `data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":" world"},"finish_reason":null}]}`
+	chunk3 := `data: {"id":"chatcmpl-1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`
+	done := "data: [DONE]"
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("upstream: no Flusher")
+			return
+		}
+		for _, line := range []string{chunk1, chunk2, chunk3, done} {
+			fmt.Fprintln(w, line)
+			fmt.Fprintln(w) // blank line after each SSE event (standard OpenAI wire format)
+			flusher.Flush()
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	reg := buildAzureRegistry(t, upstream.URL)
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	// h.PIIEngine is intentionally nil: plain path.
+
+	baseURL := startTestServer(t, h)
+
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions",
+		strings.NewReader(`{"model":"azure-gpt4","messages":[{"role":"user","content":"hi"}],"stream":true}`))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("streaming request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("H-14: status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	fullBody, _ := io.ReadAll(resp.Body)
+	fullStr := string(fullBody)
+
+	// Split on "\n\n" to get self-terminated events.
+	rawEvents := strings.Split(fullStr, "\n\n")
+	var dataEvents []string
+	for _, seg := range rawEvents {
+		seg = strings.TrimSpace(seg)
+		if seg == "" {
+			continue
+		}
+		if strings.HasPrefix(seg, "data: ") {
+			dataEvents = append(dataEvents, seg)
+		}
+	}
+
+	// Expect exactly 4 events: chunk1, chunk2, chunk3, [DONE].
+	if len(dataEvents) != 4 {
+		t.Errorf("H-14: got %d data events, want 4\nevents: %v\nfull output:\n%s",
+			len(dataEvents), dataEvents, fullStr)
+	}
+
+	// Every non-DONE event must carry valid JSON.
+	for i, ev := range dataEvents {
+		payload := strings.TrimPrefix(ev, "data: ")
+		if payload == "[DONE]" {
+			continue
+		}
+		if !json.Valid([]byte(payload)) {
+			t.Errorf("H-14: event[%d] carries invalid JSON\npayload: %s\nfull output:\n%s", i, payload, fullStr)
+		}
+	}
+
+	// The [DONE] sentinel must be the last data event.
+	if len(dataEvents) > 0 {
+		last := dataEvents[len(dataEvents)-1]
+		if last != "data: [DONE]" {
+			t.Errorf("H-14: last data event = %q, want %q", last, "data: [DONE]")
+		}
+	}
+
+	// Each data event must end with exactly "\n\n" in the raw wire output
+	// (regression guard: self-termination must not add extra newlines).
+	for _, line := range []string{chunk1, chunk2, chunk3, done} {
+		want := line + "\n\n"
+		if !strings.Contains(fullStr, want) {
+			t.Errorf("H-14: wire output does not contain %q (\\n\\n-terminated)\nfull output:\n%s", want, fullStr)
+		}
+	}
+}
+
+// ── H-15: Gemini plain path — [DONE] is \n\n-terminated ─────────────────────
+
+// TestHandle_Gemini_Plain_DoneTermination is H-15.
+//
+// The Gemini adapter converts the blank upstream line (after the terminal chunk)
+// into "data: [DONE]". With self-terminating events this line must be written as
+// "data: [DONE]\n\n" — the terminal event must be dispatched by strict SSE
+// clients. A trailing "\n" only would be silently dropped.
+func TestHandle_Gemini_Plain_DoneTermination(t *testing.T) {
+	t.Parallel()
+
+	// Minimal Gemini stream: one text chunk with finishReason=STOP, then a blank
+	// line which the GeminiAdapter converts to "data: [DONE]".
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("upstream: no Flusher")
+			return
+		}
+		// Terminal chunk: finishReason=STOP → adapter sets doneSent.
+		fmt.Fprintln(w, `data: {"candidates":[{"content":{"role":"model","parts":[{"text":"hello"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":5,"candidatesTokenCount":3,"totalTokenCount":8}}`)
+		fmt.Fprintln(w) // blank → GeminiAdapter returns "data: [DONE]"
+		flusher.Flush()
+	}))
+	t.Cleanup(upstream.Close)
+
+	reg := piiRegistryGemini(t, upstream.URL)
+	h := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	// h.PIIEngine nil: plain path.
+
+	baseURL := startTestServer(t, h)
+
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions",
+		strings.NewReader(`{"model":"gemini-test","messages":[{"role":"user","content":"hi"}],"stream":true}`))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("H-15: streaming request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("H-15: status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	fullBody, _ := io.ReadAll(resp.Body)
+	fullStr := string(fullBody)
+
+	// The [DONE] sentinel must be present.
+	if !strings.Contains(fullStr, "[DONE]") {
+		t.Fatalf("H-15: [DONE] missing from output\noutput: %s", fullStr)
+	}
+
+	// [DONE] must be self-terminated with \n\n — assert the exact byte sequence.
+	if !strings.Contains(fullStr, "data: [DONE]\n\n") {
+		t.Errorf("H-15: 'data: [DONE]' is not \\n\\n-terminated in wire output\noutput: %q", fullStr)
+	}
+
+	// Parse events and verify [DONE] is its own distinct segment.
+	rawEvents := strings.Split(fullStr, "\n\n")
+	doneCount := 0
+	for _, seg := range rawEvents {
+		seg = strings.TrimSpace(seg)
+		if seg == "data: [DONE]" {
+			doneCount++
+		}
+	}
+	if doneCount != 1 {
+		t.Errorf("H-15: [DONE] appears in %d \\n\\n-segments, want exactly 1\noutput: %q", doneCount, fullStr)
+	}
+}

--- a/internal/proxy/stream_test_helpers_test.go
+++ b/internal/proxy/stream_test_helpers_test.go
@@ -1,0 +1,19 @@
+package proxy
+
+// transformLine1 calls TransformStreamLine and returns the first output line,
+// or nil when the result is empty/nil. It ignores errors so that existing tests
+// that exercise the happy path remain unchanged. Tests that specifically verify
+// abort behaviour must call TransformStreamLine directly and inspect the error.
+func transformLine1(a Adapter, line []byte) []byte {
+	lines, _ := a.TransformStreamLine(line)
+	if len(lines) == 0 {
+		return nil
+	}
+	return lines[0]
+}
+
+// transformLineIgnore calls TransformStreamLine and discards all return values.
+// It is used for priming calls where only the adapter side-effects matter.
+func transformLineIgnore(a Adapter, line []byte) {
+	_, _ = a.TransformStreamLine(line)
+}


### PR DESCRIPTION
Closes the L-018 limitation: `Adapter.TransformStreamLine` returned `[]byte` only, so adapters could not signal a hard abort or emit multiple events from one upstream line, forcing silent drops (flagged 3x during the tool-call adapter work).

## Change
`TransformStreamLine(line []byte) ([][]byte, error)`:
- `(lines, nil)` — emit 0+ SSE output lines (drop if empty).
- `(nil, err)` — abort the stream **fail-closed** (`errStreamTransformAborted`, content-free).

- **Anthropic/Gemini**: the previously-silent protocol-violation drops (duplicate content-block index, `input_json_delta` before header, over-cap, invalid name, unparseable event) now **abort** the stream instead of silently losing a tool call.
- **Gemini mixed text+functionCall**: now emits **both** the text event and the tool_calls event (previously the text was discarded).
- **Handler**: a shared content-free abort event (`stream_transform_aborted`, no `[DONE]`, breaker failure, usage incomplete; not after client disconnect). PII path feeds each adapter output line through the stream restorer with an injected SSE separator; plain path writes self-terminating events so `[DONE]`, multi-line output, and the abort event are always well-formed SSE.

## Reviews
Internal code-review + security-audit, then an external round (Codex + Antigravity). The internal pass caught a missing plain-path SSE separator; the external pass (Codex) caught two further plain-path framing issues (terminal `[DONE]` and the abort event not blank-terminated/separated for strict SSE clients) — fixed by writing self-terminating events on the plain path. Confirmed: the PII multi-line path is leak-safe (the injected separator only resets SSE event state, never drops a carry; cross-lane stays fail-closed), and adapter-abort never flushes unrestored content.

`go build ./...`, `go vet ./...`, full `go test ./...` and `go test -race ./internal/proxy/ ./internal/pii/` green. Targets `0.0.22-beta.2` alongside Stage 1.