### PR TITLE
chore(deps): bump base images to alpine 3.24 and node 24 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Build UI (required for Go embed)
         working-directory: ui
@@ -55,7 +55,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20"
+          node-version: "24"
 
       - name: Install
         working-directory: ui

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
       - if: matrix.language == 'go'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "20"
+          node-version: "24"
 
       - if: matrix.language == 'go'
         run: cd ui && npm ci && npm run build && cd ..

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Build UI
         run: cd ui && npm ci && npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build UI (arch-independent, runs on build platform)
-FROM --platform=$BUILDPLATFORM node:20-alpine@sha256:fb4cd12c85ee03686f6af5362a0b0d56d50c58a04632e6c0fb8363f609372293 AS ui-builder
+FROM --platform=$BUILDPLATFORM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS ui-builder
 WORKDIR /app/ui
 COPY ui/package.json ui/package-lock.json ./
 RUN npm ci
@@ -7,7 +7,7 @@ COPY ui/ ./
 RUN npm run build
 
 # Stage 2: Build Go binary (cross-compiles on build platform)
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:3ad57304ad93bbec8548a0437ad9e06a455660655d9af011d58b993f6f615648 AS go-builder
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS go-builder
 ARG TARGETOS
 ARG TARGETARCH
 RUN apk add --no-cache git
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -o /voidllm ./cmd/voidllm
 
 # Stage 3: Runtime
-FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 RUN apk upgrade --no-cache \
     && apk add --no-cache ca-certificates tzdata \
     && addgroup -S voidllm && adduser -S -G voidllm voidllm \


### PR DESCRIPTION
- `alpine` 3.21 -> 3.24 (runtime image)
- `node` 20 -> **24**, not the 26 Dependabot proposed
- `golang:1.26-alpine` digest refresh

Node 20 is end of life, so it had to move. Dependabot offered node 26, but 26 is *Current*, not LTS - node 24 "Krypton" is the active LTS as of today, so that is what the build image uses.

The same bump applies to `actions/setup-node` in ci.yml, codeql.yml and release.yml, which were all still on node 20. Leaving those behind would mean the UI is built on one runtime in CI and another in the release image, which is exactly the kind of drift that produces a bug nobody can reproduce.

All three digests were resolved from the registry independently; the alpine and golang digests match Dependabot's byte for byte.

Verified locally rather than trusting the build alone: image builds, container starts, `/healthz` returns `{"status":"ok",...,"version":"0.0.22"}`, `/readyz` reports the database ok, `/etc/alpine-release` is 3.24.1, and the embedded SPA plus its JS bundle are served correctly - the last one being what a node major bump would realistically break.

Closes #128, #129, #152.