### PR TITLE
chore(ci): drop redundant top-level workflow permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   analyze:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   docker:


### PR DESCRIPTION
Two OpenSSF Scorecard `TokenPermissions` findings, both scoring 0:

- `codeql.yml` granted `security-events: write` at the workflow level
- `release.yml` granted `packages: write` at the workflow level

In both cases every job already declares the permissions it needs. Job-level `permissions` replace the top-level set outright rather than adding to it, so these top-level grants were never actually in effect for any job - they only widened the default for a job that forgot to declare its own, and there is no such job.

Checked before changing: `release.yml` (docker, binaries, provenance), `codeql.yml` (analyze), `helm-release.yml`, `ci.yml` and `scorecard.yml` all declare per-job permissions.

`release.yml` cannot be exercised without cutting a release, so this rests on that reasoning rather than on a test run. The change is inert by construction: it removes a grant that no job reads.

The remaining `contents: write` findings in the release jobs are not fixable - that is the permission required to upload release assets and push the chart - and the SLSA generator is referenced by tag because the generator rejects SHA pins by design. Those are dismissed separately.