### PR TITLE
fix(ui): derive default selections during render instead of in effects

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,7 +18,7 @@
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.39.4",
+        "@eslint/js": "^10.0.1",
         "@tailwindcss/vite": "^4.2.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -27,14 +27,14 @@
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.3",
-        "eslint": "^9.39.4",
-        "eslint-plugin-react-hooks": "^7.0.1",
-        "eslint-plugin-react-refresh": "^0.5.2",
+        "eslint": "^10.7.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.4.0",
         "jsdom": "^29.0.0",
         "tailwindcss": "^4.2.4",
         "typescript": "~5.9.3",
-        "typescript-eslint": "^8.59.2",
+        "typescript-eslint": "^8.65.0",
         "vite": "^8.1.5",
         "vitest": "^4.1.2"
       }
@@ -1055,118 +1055,89 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@exodus/bytes": {
@@ -2205,6 +2176,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2293,17 +2271,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
-      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/type-utils": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2316,15 +2294,15 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.2",
+        "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2332,16 +2310,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
-      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2357,14 +2335,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
-      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.2",
-        "@typescript-eslint/types": "^8.59.2",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2379,14 +2357,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
-      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2397,9 +2375,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
-      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2414,15 +2392,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
-      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2439,9 +2417,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
-      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2453,16 +2431,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
-      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.2",
-        "@typescript-eslint/tsconfig-utils": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/visitor-keys": "8.59.2",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2480,49 +2458,10 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2533,16 +2472,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
-      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.2",
-        "@typescript-eslint/types": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2557,13 +2496,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
-      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -2572,19 +2511,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -2733,9 +2659,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2756,9 +2682,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2782,29 +2708,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -2837,11 +2740,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.0",
@@ -2867,14 +2773,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -2909,16 +2817,6 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2960,23 +2858,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/character-entities": {
@@ -3028,26 +2909,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -3057,13 +2918,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -3471,33 +3325,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.7.0.tgz",
+      "integrity": "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
-        "@eslint/plugin-kit": "^0.4.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -3507,8 +3361,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -3516,7 +3369,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -3531,9 +3384,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3547,13 +3400,13 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.2.tgz",
-      "integrity": "sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.3.tgz",
+      "integrity": "sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -3561,48 +3414,50 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -3844,16 +3699,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -3952,23 +3797,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
-      }
-    },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -4115,29 +3943,6 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/jsdom": {
       "version": "29.0.1",
@@ -4537,13 +4342,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -5459,16 +5257,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -5572,19 +5373,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/parse-entities": {
@@ -6018,16 +5806,6 @@
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/rolldown": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
@@ -6188,19 +5966,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -6217,19 +5982,6 @@
       "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.7"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/symbol-tree": {
@@ -6435,16 +6187,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.2",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
-      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.2",
-        "@typescript-eslint/parser": "8.59.2",
-        "@typescript-eslint/typescript-estree": "8.59.2",
-        "@typescript-eslint/utils": "8.59.2"
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,7 +21,7 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.4",
+    "@eslint/js": "^10.0.1",
     "@tailwindcss/vite": "^4.2.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -30,14 +30,14 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
-    "eslint": "^9.39.4",
-    "eslint-plugin-react-hooks": "^7.0.1",
-    "eslint-plugin-react-refresh": "^0.5.2",
+    "eslint": "^10.7.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.4.0",
     "jsdom": "^29.0.0",
     "tailwindcss": "^4.2.4",
     "typescript": "~5.9.3",
-    "typescript-eslint": "^8.59.2",
+    "typescript-eslint": "^8.65.0",
     "vite": "^8.1.5",
     "vitest": "^4.1.2"
   }

--- a/ui/src/pages/AcceptInvitePage.test.tsx
+++ b/ui/src/pages/AcceptInvitePage.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import AcceptInvitePage from './AcceptInvitePage'
+
+// ---------------------------------------------------------------------------
+// Render helpers
+// ---------------------------------------------------------------------------
+
+function renderAcceptInvitePage(initialPath: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/invite/:token" element={<AcceptInvitePage />} />
+        <Route path="/invite" element={<AcceptInvitePage />} />
+        <Route path="/login" element={<div>Login Page</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function mockFetchOnce(response: { ok: boolean; status: number; body?: unknown }) {
+  return vi.fn(async () => ({
+    ok: response.ok,
+    status: response.status,
+    json: () => Promise.resolve(response.body ?? {}),
+  }))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AcceptInvitePage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders the invalid state and makes no network request when there is no token in the route', () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    renderAcceptInvitePage('/invite')
+
+    expect(
+      screen.getByText(/this invite link is invalid or has already been used/i),
+    ).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('renders the form once the peek request resolves for a valid token', async () => {
+    vi.stubGlobal(
+      'fetch',
+      mockFetchOnce({
+        ok: true,
+        status: 200,
+        body: {
+          email: 'jane@example.com',
+          org_name: 'Acme Corp',
+          role: 'member',
+          expires_at: '2026-08-01T00:00:00Z',
+        },
+      }),
+    )
+
+    renderAcceptInvitePage('/invite/good-token')
+
+    expect(await screen.findByText('Acme Corp')).toBeInTheDocument()
+    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument()
+    expect(screen.getByText('jane@example.com')).toBeInTheDocument()
+  })
+
+  it('renders the expired state for a 410 response', async () => {
+    vi.stubGlobal('fetch', mockFetchOnce({ ok: false, status: 410 }))
+
+    renderAcceptInvitePage('/invite/expired-token')
+
+    expect(await screen.findByText(/this invite link has expired/i)).toBeInTheDocument()
+  })
+
+  it('renders the invalid state for a non-410 error response', async () => {
+    vi.stubGlobal('fetch', mockFetchOnce({ ok: false, status: 404 }))
+
+    renderAcceptInvitePage('/invite/bad-token')
+
+    expect(
+      await screen.findByText(/this invite link is invalid or has already been used/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/ui/src/pages/AcceptInvitePage.tsx
+++ b/ui/src/pages/AcceptInvitePage.tsx
@@ -19,6 +19,8 @@ export default function AcceptInvitePage() {
   const [pageState, setPageState] = useState<PageState>('loading')
   const [invite, setInvite] = useState<InvitePeek | null>(null)
 
+  const effectivePageState: PageState = token ? pageState : 'invalid'
+
   const [displayName, setDisplayName] = useState('')
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
@@ -30,10 +32,7 @@ export default function AcceptInvitePage() {
   const [submitting, setSubmitting] = useState(false)
 
   useEffect(() => {
-    if (!token) {
-      setPageState('invalid')
-      return
-    }
+    if (!token) return
 
     fetch(`/api/v1/invites/peek?token=${encodeURIComponent(token)}`)
       .then((res) => {
@@ -53,12 +52,12 @@ export default function AcceptInvitePage() {
   }, [token])
 
   useEffect(() => {
-    if (pageState !== 'success') return
+    if (effectivePageState !== 'success') return
     const timer = setTimeout(() => {
       void navigate('/login')
     }, 2000)
     return () => clearTimeout(timer)
-  }, [pageState, navigate])
+  }, [effectivePageState, navigate])
 
   function validate(): boolean {
     let valid = true
@@ -128,7 +127,7 @@ export default function AcceptInvitePage() {
           <h1 className="text-3xl font-bold gradient-text">VoidLLM</h1>
         </div>
 
-        {pageState === 'loading' && (
+        {effectivePageState === 'loading' && (
           <div className="space-y-3">
             <div className="h-4 rounded bg-bg-tertiary animate-pulse" />
             <div className="h-4 w-2/3 rounded bg-bg-tertiary animate-pulse" />
@@ -136,11 +135,11 @@ export default function AcceptInvitePage() {
           </div>
         )}
 
-        {(pageState === 'invalid' || pageState === 'expired') && (
+        {(effectivePageState === 'invalid' || effectivePageState === 'expired') && (
           <div className="text-center space-y-4">
             <div className="rounded-lg bg-error/10 border border-error/20 px-4 py-3">
               <p className="text-sm font-medium text-error">
-                {pageState === 'expired'
+                {effectivePageState === 'expired'
                   ? 'This invite link has expired.'
                   : 'This invite link is invalid or has already been used.'}
               </p>
@@ -157,7 +156,7 @@ export default function AcceptInvitePage() {
           </div>
         )}
 
-        {pageState === 'success' && (
+        {effectivePageState === 'success' && (
           <div className="text-center space-y-4">
             <div className="rounded-lg bg-success/10 border border-success/20 px-4 py-3">
               <p className="text-sm font-medium text-success">
@@ -170,7 +169,7 @@ export default function AcceptInvitePage() {
           </div>
         )}
 
-        {pageState === 'form' && invite !== null && (
+        {effectivePageState === 'form' && invite !== null && (
           <>
             <div className="mb-6">
               <p className="text-sm text-text-secondary text-center">

--- a/ui/src/pages/PlaygroundPage.test.tsx
+++ b/ui/src/pages/PlaygroundPage.test.tsx
@@ -1,0 +1,233 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import PlaygroundPage from './PlaygroundPage'
+
+// ---------------------------------------------------------------------------
+// Types used in mocks (mirror the production types)
+// ---------------------------------------------------------------------------
+
+interface MockAvailableModel {
+  name: string
+  type: string
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const CHAT_MODELS: MockAvailableModel[] = [
+  { name: 'chat-alpha', type: 'chat' },
+  { name: 'chat-beta', type: 'chat' },
+]
+
+const CHAT_AND_COMPLETION_MODELS: MockAvailableModel[] = [
+  { name: 'chat-a', type: 'chat' },
+  { name: 'chat-b', type: 'chat' },
+  { name: 'comp-a', type: 'completion' },
+  { name: 'comp-b', type: 'completion' },
+]
+
+const COMPLETION_AND_EMBEDDING_MODELS: MockAvailableModel[] = [
+  { name: 'comp-1', type: 'completion' },
+  { name: 'embed-1', type: 'embedding' },
+]
+
+// ---------------------------------------------------------------------------
+// Render helpers
+// ---------------------------------------------------------------------------
+
+function renderPlaygroundPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+  return render(<PlaygroundPage />, { wrapper: Wrapper })
+}
+
+// ---------------------------------------------------------------------------
+// Fetch mock helpers
+// ---------------------------------------------------------------------------
+
+type FetchMockEntry = {
+  matcher: (url: string) => boolean
+  response: unknown
+  method?: string
+}
+
+function setupFetchMock(entries: FetchMockEntry[], capturedBodies?: Map<string, string>) {
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const method = (init?.method ?? 'GET').toUpperCase()
+
+    const entry = entries.find(
+      (e) => e.matcher(url) && (!e.method || e.method.toUpperCase() === method),
+    )
+
+    if (entry) {
+      if (capturedBodies && init?.body) {
+        capturedBodies.set(`${method}:${url}`, init.body as string)
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(entry.response),
+      }
+    }
+
+    return {
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    }
+  }))
+}
+
+function availableModelsEntry(models: MockAvailableModel[]): FetchMockEntry {
+  return {
+    matcher: (u) => u.includes('/api/v1/me/available-models'),
+    method: 'GET',
+    response: { models },
+  }
+}
+
+function getModelSelect(): HTMLElement {
+  return screen.getByRole('combobox')
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PlaygroundPage — default tab and model selection', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    // jsdom does not implement scrollIntoView; PlaygroundPage calls it on
+    // every chat history update.
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  it('activates the first available tab once models load', async () => {
+    setupFetchMock([availableModelsEntry(COMPLETION_AND_EMBEDDING_MODELS)])
+    renderPlaygroundPage()
+
+    const completionTab = await screen.findByRole('tab', { name: 'Completion' })
+    expect(completionTab).toHaveAttribute('aria-selected', 'true')
+
+    const embeddingTab = screen.getByRole('tab', { name: 'Embedding' })
+    expect(embeddingTab).toHaveAttribute('aria-selected', 'false')
+  })
+
+  it('selects the first model of the active tab without any user interaction', async () => {
+    setupFetchMock([availableModelsEntry(CHAT_MODELS)])
+    renderPlaygroundPage()
+
+    await waitFor(() => expect(getModelSelect()).toHaveTextContent('chat-alpha'))
+  })
+
+  it('selects the first model of a newly active tab, dropping the previous tab\'s selection', async () => {
+    setupFetchMock([availableModelsEntry(CHAT_AND_COMPLETION_MODELS)])
+    renderPlaygroundPage()
+
+    await waitFor(() => expect(getModelSelect()).toHaveTextContent('chat-a'))
+
+    // Explicitly select a different model on the chat tab
+    await userEvent.click(getModelSelect())
+    await userEvent.click(screen.getByRole('option', { name: 'chat-b' }))
+    expect(getModelSelect()).toHaveTextContent('chat-b')
+
+    // Switch to the Completion tab
+    await userEvent.click(screen.getByRole('tab', { name: 'Completion' }))
+
+    // The new tab shows its own first model, not the model from the old tab
+    await waitFor(() => expect(getModelSelect()).toHaveTextContent('comp-a'))
+    expect(getModelSelect()).not.toHaveTextContent('chat-b')
+  })
+
+  it('restores the previously selected model when switching back to its tab', async () => {
+    setupFetchMock([availableModelsEntry(CHAT_AND_COMPLETION_MODELS)])
+    renderPlaygroundPage()
+
+    await waitFor(() => expect(getModelSelect()).toHaveTextContent('chat-a'))
+
+    await userEvent.click(getModelSelect())
+    await userEvent.click(screen.getByRole('option', { name: 'chat-b' }))
+    expect(getModelSelect()).toHaveTextContent('chat-b')
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Completion' }))
+    await waitFor(() => expect(getModelSelect()).toHaveTextContent('comp-a'))
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Chat' }))
+
+    await waitFor(() => expect(getModelSelect()).toHaveTextContent('chat-b'))
+  })
+
+  it('keeps an explicitly selected model that belongs to the active tab across an unrelated re-render', async () => {
+    setupFetchMock([availableModelsEntry(CHAT_MODELS)])
+    renderPlaygroundPage()
+
+    await waitFor(() => expect(getModelSelect()).toHaveTextContent('chat-alpha'))
+
+    await userEvent.click(getModelSelect())
+    await userEvent.click(screen.getByRole('option', { name: 'chat-beta' }))
+    expect(getModelSelect()).toHaveTextContent('chat-beta')
+
+    // Trigger a state update/re-render unrelated to tab or model selection
+    await userEvent.click(screen.getByRole('switch'))
+
+    expect(getModelSelect()).toHaveTextContent('chat-beta')
+  })
+
+  it('sends the selected model in the chat request body', async () => {
+    const capturedBodies = new Map<string, string>()
+    setupFetchMock(
+      [
+        availableModelsEntry(CHAT_MODELS),
+        {
+          matcher: (u) => u.includes('/api/v1/playground/chat/completions'),
+          method: 'POST',
+          response: {
+            choices: [{ message: { content: 'hello there' } }],
+            usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 },
+          },
+        },
+      ],
+      capturedBodies,
+    )
+    renderPlaygroundPage()
+
+    await waitFor(() => expect(getModelSelect()).toHaveTextContent('chat-alpha'))
+
+    await userEvent.click(getModelSelect())
+    await userEvent.click(screen.getByRole('option', { name: 'chat-beta' }))
+
+    // Disable streaming so the mocked response can be a plain JSON body
+    await userEvent.click(screen.getByRole('switch'))
+
+    await userEvent.type(screen.getByPlaceholderText('Type your message...'), 'Hello there')
+    await userEvent.click(screen.getByRole('button', { name: /send message/i }))
+
+    await waitFor(() =>
+      expect(capturedBodies.has('POST:/api/v1/playground/chat/completions')).toBe(true),
+    )
+    const body = JSON.parse(capturedBodies.get('POST:/api/v1/playground/chat/completions') ?? '{}')
+    expect(body.model).toBe('chat-beta')
+  })
+
+  it('renders safely with an empty model list and selects no model', async () => {
+    setupFetchMock([availableModelsEntry([])])
+    renderPlaygroundPage()
+
+    await waitFor(() => expect(getModelSelect()).toHaveTextContent('No models available'))
+    expect(getModelSelect()).toBeDisabled()
+    expect(screen.getByText('No model selected')).toBeInTheDocument()
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument()
+  })
+})

--- a/ui/src/pages/PlaygroundPage.tsx
+++ b/ui/src/pages/PlaygroundPage.tsx
@@ -220,29 +220,16 @@ export default function PlaygroundPage() {
       .map((type) => ({ key: type, label: typeLabels[type] || type }))
   }, [modelsData])
 
-  // Set default tab when tabs first become available
-  useEffect(() => {
-    if (availableTabs.length > 0) {
-      setActiveTab((prev) => (prev === '' ? availableTabs[0].key : prev))
-    }
-  }, [availableTabs])
-
-  // Auto-select the first model of the active tab type
-  useEffect(() => {
-    if (!modelsData?.models || activeTab === '') return
-    const tabModels = modelsData.models.filter((m) => m.type === activeTab)
-    setModel((prev) => {
-      if (tabModels.some((m) => m.name === prev)) return prev
-      return tabModels[0]?.name ?? ''
-    })
-  }, [activeTab, modelsData])
-
   // Scroll to bottom when new messages arrive
   useEffect(() => {
     chatEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [chatHistory, loading])
 
-  const tabModels = (modelsData?.models ?? []).filter((m) => m.type === activeTab)
+  const effectiveTab = activeTab !== '' ? activeTab : (availableTabs[0]?.key ?? '')
+
+  const tabModels = (modelsData?.models ?? []).filter((m) => m.type === effectiveTab)
+
+  const effectiveModel = tabModels.some((m) => m.name === model) ? model : (tabModels[0]?.name ?? '')
 
   const modelOptions: SelectOption[] = tabModels.map((m) => ({
     value: m.name,
@@ -256,7 +243,7 @@ export default function PlaygroundPage() {
 
   function handleClear() {
     setError(null)
-    if (activeTab === 'embedding') {
+    if (effectiveTab === 'embedding') {
       setEmbedResult(null)
       setSimilarity(null)
       setEmbedInput('')
@@ -269,7 +256,7 @@ export default function PlaygroundPage() {
   }
 
   async function handleSend() {
-    if (!model || !message.trim() || loading) return
+    if (!effectiveModel || !message.trim() || loading) return
 
     // Cancel any previous in-flight request
     abortRef.current?.abort()
@@ -310,7 +297,7 @@ export default function PlaygroundPage() {
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
-          model,
+          model: effectiveModel,
           messages,
           stream: streaming,
           temperature,
@@ -458,7 +445,7 @@ export default function PlaygroundPage() {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify({ model, input }),
+      body: JSON.stringify({ model: effectiveModel, input }),
     })
     if (!res.ok) {
       throw new Error(await errorMessageFromResponse(res))
@@ -468,7 +455,7 @@ export default function PlaygroundPage() {
   }
 
   async function handleEmbed() {
-    if (!model || !embedInput.trim() || embedLoading) return
+    if (!effectiveModel || !embedInput.trim() || embedLoading) return
     setEmbedLoading(true)
     setError(null)
     try {
@@ -483,7 +470,7 @@ export default function PlaygroundPage() {
   }
 
   async function handleCompare() {
-    if (!model || !simTextA.trim() || !simTextB.trim() || simLoading) return
+    if (!effectiveModel || !simTextA.trim() || !simTextB.trim() || simLoading) return
     setSimLoading(true)
     setError(null)
     try {
@@ -502,8 +489,8 @@ export default function PlaygroundPage() {
     }
   }
 
-  const canSend = !!model && !!message.trim() && !loading
-  const isEmbedding = activeTab === 'embedding'
+  const canSend = !!effectiveModel && !!message.trim() && !loading
+  const isEmbedding = effectiveTab === 'embedding'
 
   return (
     <div className="flex flex-col overflow-hidden" style={{ height: 'calc(100vh - 4rem)' }}>
@@ -513,7 +500,7 @@ export default function PlaygroundPage() {
           <div className="mt-3">
             <TabSwitcher
               tabs={availableTabs}
-              activeKey={activeTab}
+              activeKey={effectiveTab}
               onChange={handleTabChange}
             />
           </div>
@@ -558,7 +545,7 @@ export default function PlaygroundPage() {
               <ConfigLabel>Model</ConfigLabel>
               <Select
                 options={modelOptions}
-                value={model}
+                value={effectiveModel}
                 onChange={setModel}
                 placeholder={
                   modelsData
@@ -712,9 +699,9 @@ export default function PlaygroundPage() {
           {/* Top bar */}
           <div className="shrink-0 flex items-center justify-between px-5 py-3.5 border-b border-border">
             <div className="flex items-center gap-3">
-              {model ? (
+              {effectiveModel ? (
                 <span className="px-2.5 py-1 rounded-full bg-accent/15 border border-accent/20 text-accent text-xs font-medium truncate max-w-[220px]">
-                  {model}
+                  {effectiveModel}
                 </span>
               ) : (
                 <span className="px-2.5 py-1 rounded-full bg-bg-tertiary border border-border text-text-tertiary text-xs">
@@ -970,7 +957,7 @@ export default function PlaygroundPage() {
                   variant="primary"
                   size="sm"
                   onClick={() => void handleEmbed()}
-                  disabled={!model || !embedInput.trim() || embedLoading}
+                  disabled={!effectiveModel || !embedInput.trim() || embedLoading}
                   loading={embedLoading}
                 >
                   Generate Embedding
@@ -1015,7 +1002,7 @@ export default function PlaygroundPage() {
                   variant="primary"
                   size="sm"
                   onClick={() => void handleCompare()}
-                  disabled={!model || !simTextA.trim() || !simTextB.trim() || simLoading}
+                  disabled={!effectiveModel || !simTextA.trim() || !simTextB.trim() || simLoading}
                   loading={simLoading}
                 >
                   Compare

--- a/ui/src/pages/SystemUsersPage.test.tsx
+++ b/ui/src/pages/SystemUsersPage.test.tsx
@@ -1,0 +1,277 @@
+import React from 'react'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ToastProvider } from '../hooks/useToast'
+import SystemUsersPage from './SystemUsersPage'
+
+// ---------------------------------------------------------------------------
+// Types used in mocks (mirror the production types)
+// ---------------------------------------------------------------------------
+
+interface MockOrg {
+  id: string
+  name: string
+  slug: string
+  timezone: string | null
+  daily_token_limit: number
+  monthly_token_limit: number
+  requests_per_minute: number
+  requests_per_day: number
+  member_count: number
+  team_count: number
+  created_at: string
+  updated_at: string
+}
+
+interface MockUser {
+  id: string
+  email: string
+  display_name: string
+  auth_provider: string
+  is_system_admin: boolean
+  created_at: string
+  updated_at: string
+}
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeOrg(overrides: Partial<MockOrg> = {}): MockOrg {
+  return {
+    id: 'org-1',
+    name: 'Org Alpha',
+    slug: 'org-alpha',
+    timezone: null,
+    daily_token_limit: 0,
+    monthly_token_limit: 0,
+    requests_per_minute: 0,
+    requests_per_day: 0,
+    member_count: 1,
+    team_count: 0,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+const ORG_ALPHA = makeOrg({ id: 'org-1', name: 'Org Alpha', slug: 'org-alpha' })
+const ORG_BETA = makeOrg({ id: 'org-2', name: 'Org Beta', slug: 'org-beta' })
+
+const MOCK_ME = {
+  id: 'user-admin',
+  email: 'admin@example.com',
+  display_name: 'Admin',
+  role: 'system_admin',
+  is_system_admin: true,
+}
+
+// ---------------------------------------------------------------------------
+// Render helpers
+// ---------------------------------------------------------------------------
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  })
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>
+          <MemoryRouter>{children}</MemoryRouter>
+        </ToastProvider>
+      </QueryClientProvider>
+    )
+  }
+  return { queryClient, Wrapper }
+}
+
+function renderSystemUsersPage() {
+  const { queryClient, Wrapper } = makeWrapper()
+  const utils = render(<SystemUsersPage />, { wrapper: Wrapper })
+  return { queryClient, ...utils }
+}
+
+// ---------------------------------------------------------------------------
+// Fetch mock helpers
+// ---------------------------------------------------------------------------
+
+type FetchMockEntry = {
+  matcher: (url: string) => boolean
+  response: unknown
+  method?: string
+}
+
+function setupFetchMock(entries: FetchMockEntry[], capturedBodies?: Map<string, string>) {
+  vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    const method = (init?.method ?? 'GET').toUpperCase()
+
+    const entry = entries.find(
+      (e) => e.matcher(url) && (!e.method || e.method.toUpperCase() === method),
+    )
+
+    if (entry) {
+      if (capturedBodies && init?.body) {
+        capturedBodies.set(`${method}:${url}`, init.body as string)
+      }
+      return {
+        ok: true,
+        status: 200,
+        // Cloning via JSON round-trip guarantees a fresh reference on every
+        // call, the same way a real HTTP response would - this matters for
+        // regression-testing effects/derived-state that key off array
+        // identity rather than content.
+        json: () => Promise.resolve(JSON.parse(JSON.stringify(entry.response))),
+      }
+    }
+
+    return {
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    }
+  }))
+}
+
+function defaultEntries(orgs: MockOrg[], users: MockUser[] = []): FetchMockEntry[] {
+  return [
+    {
+      matcher: (u) => u.includes('/api/v1/me') && !u.includes('/api/v1/models'),
+      method: 'GET',
+      response: MOCK_ME,
+    },
+    {
+      matcher: (u) => u.includes('/api/v1/orgs'),
+      method: 'GET',
+      response: { data: orgs, has_more: false },
+    },
+    {
+      matcher: (u) => u.includes('/api/v1/users'),
+      method: 'GET',
+      response: { data: users, has_more: false },
+    },
+  ]
+}
+
+// ---------------------------------------------------------------------------
+// Dialog helpers
+// ---------------------------------------------------------------------------
+
+function getDialog(): HTMLElement {
+  return screen.getByRole('dialog')
+}
+
+async function openCreateDialog() {
+  await userEvent.click(screen.getByRole('button', { name: 'Create User' }))
+}
+
+function getOrgSelect(): HTMLElement {
+  return screen.getByRole('combobox', { name: /organization/i })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SystemUsersPage — CreateUserDialog default organization', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('selects the first organization when the org list loads and none has been chosen', async () => {
+    setupFetchMock(defaultEntries([ORG_ALPHA, ORG_BETA]))
+    renderSystemUsersPage()
+
+    await openCreateDialog()
+
+    await waitFor(() => {
+      expect(getOrgSelect()).toHaveTextContent('Org Alpha')
+    })
+  })
+
+  it('submits the first organization id when the user creates a user without touching the selector', async () => {
+    const capturedBodies = new Map<string, string>()
+    setupFetchMock(
+      [
+        {
+          matcher: (u) => u.includes('/api/v1/users') && !u.includes('/api/v1/users/'),
+          method: 'POST',
+          response: {
+            id: 'new-user',
+            email: 'newuser@example.com',
+            display_name: 'New User',
+            auth_provider: 'local',
+            is_system_admin: false,
+            created_at: '2024-01-01T00:00:00Z',
+            updated_at: '2024-01-01T00:00:00Z',
+          },
+        },
+        ...defaultEntries([ORG_ALPHA, ORG_BETA]),
+      ],
+      capturedBodies,
+    )
+    renderSystemUsersPage()
+
+    await openCreateDialog()
+
+    await waitFor(() => expect(getOrgSelect()).toHaveTextContent('Org Alpha'))
+
+    const dialog = getDialog()
+    await userEvent.type(within(dialog).getByLabelText(/^email$/i), 'newuser@example.com')
+    await userEvent.type(within(dialog).getByLabelText(/display name/i), 'New User')
+    await userEvent.type(within(dialog).getByLabelText(/^password$/i), 'password123')
+
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Create User' }))
+
+    await waitFor(() => expect(capturedBodies.has('POST:/api/v1/users')).toBe(true))
+    const body = JSON.parse(capturedBodies.get('POST:/api/v1/users') ?? '{}')
+    expect(body.org_id).toBe(ORG_ALPHA.id)
+  })
+
+  it('keeps an explicitly chosen organization selected after the org list is refetched', async () => {
+    setupFetchMock(defaultEntries([ORG_ALPHA, ORG_BETA]))
+    const { queryClient } = renderSystemUsersPage()
+
+    await openCreateDialog()
+
+    await waitFor(() => expect(getOrgSelect()).toHaveTextContent('Org Alpha'))
+
+    await userEvent.click(getOrgSelect())
+    await userEvent.click(screen.getByRole('option', { name: 'Org Beta' }))
+    expect(getOrgSelect()).toHaveTextContent('Org Beta')
+
+    // Force the org list query to refetch. The mock returns a brand-new
+    // array/object reference (but identical content) on every call, which is
+    // exactly the situation that used to trip up an effect keyed on the
+    // `orgs` reference and stomp the user's explicit choice.
+    await queryClient.refetchQueries({ queryKey: ['orgs'] })
+
+    await waitFor(() => expect(getOrgSelect()).toHaveTextContent('Org Beta'))
+  })
+
+  it('resets the selection to the first organization when the dialog is closed and reopened', async () => {
+    setupFetchMock(defaultEntries([ORG_ALPHA, ORG_BETA]))
+    renderSystemUsersPage()
+
+    await openCreateDialog()
+
+    await waitFor(() => expect(getOrgSelect()).toHaveTextContent('Org Alpha'))
+
+    await userEvent.click(getOrgSelect())
+    await userEvent.click(screen.getByRole('option', { name: 'Org Beta' }))
+    expect(getOrgSelect()).toHaveTextContent('Org Beta')
+
+    await userEvent.click(within(getDialog()).getByRole('button', { name: /cancel/i }))
+
+    await openCreateDialog()
+
+    await waitFor(() => expect(getOrgSelect()).toHaveTextContent('Org Alpha'))
+  })
+})

--- a/ui/src/pages/SystemUsersPage.tsx
+++ b/ui/src/pages/SystemUsersPage.tsx
@@ -90,19 +90,14 @@ function CreateUserDialog({ open, onClose }: CreateUserDialogProps) {
     [orgsData?.data],
   )
 
-  // Auto-select first org when list loads and nothing is selected yet
-  React.useEffect(() => {
-    if (orgOptions.length > 0 && orgId === '') {
-      setOrgId(orgOptions[0].value)
-    }
-  }, [orgOptions, orgId])
+  const effectiveOrgId = orgId !== '' ? orgId : (orgOptions[0]?.value ?? '')
 
   function handleClose() {
     setEmail('')
     setDisplayName('')
     setPassword('')
     setIsSystemAdmin(false)
-    setOrgId(orgOptions.length > 0 ? orgOptions[0].value : '')
+    setOrgId('')
     setEmailError(undefined)
     setDisplayNameError(undefined)
     setPasswordError(undefined)
@@ -148,7 +143,7 @@ function CreateUserDialog({ open, onClose }: CreateUserDialogProps) {
       setPasswordError(undefined)
     }
 
-    if (!orgId) {
+    if (!effectiveOrgId) {
       setOrgError('Organization is required')
       valid = false
     } else {
@@ -162,7 +157,7 @@ function CreateUserDialog({ open, onClose }: CreateUserDialogProps) {
       display_name: trimmedName,
       password,
       is_system_admin: isSystemAdmin,
-      org_id: orgId,
+      org_id: effectiveOrgId,
       role: 'member',
     }
 
@@ -220,7 +215,7 @@ function CreateUserDialog({ open, onClose }: CreateUserDialogProps) {
         <Select
           label="Organization"
           options={orgOptions}
-          value={orgId}
+          value={effectiveOrgId}
           onChange={(v) => {
             setOrgId(v)
             if (v) setOrgError(undefined)


### PR DESCRIPTION
Closes #166.

Four `react-hooks/set-state-in-effect` violations, all the same shape: a default selection was applied by calling a setter from inside an effect, which forces a second render pass on every load. Each of them is really a derived value. The user's explicit choice stays in state, and an effective value falls back to the first available option during render.

- `SystemUsersPage` - the organization picker
- `PlaygroundPage` - the active tab and the selected model
- `AcceptInvitePage` - the invalid state when the route carries no token

**One behaviour changes, and it is an improvement.** The old effect overwrote the model *state* on every tab change, so Chat -> Completion -> Chat discarded the model the user had picked on the Chat tab and reset it to the first one. The derived value never touches the state, so returning to a tab restores the earlier selection. This surfaced in review, not from the tests, because none of this was covered.

So the tests came second: 15 new ones across three files, covering the defaults themselves, an explicit choice surviving a refetch with a fresh object identity, the model actually reaching the request body, the empty-model-list case, and the invite page's loading/form/expired/invalid states.

Two checks worth naming, because passing tests alone would not have proved much here:

- Breaking the model derivation on purpose fails 4 of the 7 Playground tests, so they are not vacuous.
- Re-adding the old effect fails the new round-trip test and *only* that one - which is exactly the claim being made: one behaviour changed, the rest did not.

Also bumps eslint 9.39.4 -> 10.7.0 with `eslint-plugin-react-hooks` 7.1.1, `eslint-plugin-react-refresh` 0.5.3 and `typescript-eslint` 8.65.0. That upgrade is what surfaced the rule, and it was blocked until now because react-hooks 7.0.1 capped its peer range at eslint ^9.

`tsc --noEmit`, lint (on eslint 10), 359 tests and the production build are all clean, with 0 npm advisories.