### PR TITLE
fix(db): free unique values on soft-delete so names can be reused

### DIFF
--- a/internal/api/admin/deployments.go
+++ b/internal/api/admin/deployments.go
@@ -162,6 +162,9 @@ func (h *Handler) createDeployment(c fiber.Ctx) error {
 	if req.Name == "" {
 		return apierror.BadRequest(c, "name is required")
 	}
+	if db.ContainsTombstoneMarker(req.Name) {
+		return apierror.BadRequest(c, `name must not contain ":deleted:"`)
+	}
 	if req.Provider == "" {
 		return apierror.BadRequest(c, "provider is required")
 	}
@@ -309,6 +312,9 @@ func (h *Handler) updateDeployment(c fiber.Ctx) error {
 	rawBody := append([]byte(nil), c.Body()...)
 	piiPresent, piiIsNull := parsePIIFilterField(rawBody)
 
+	if req.Name != nil && db.ContainsTombstoneMarker(*req.Name) {
+		return apierror.BadRequest(c, `name must not contain ":deleted:"`)
+	}
 	if req.Provider != nil && !provider.ValidProviders[*req.Provider] {
 		return apierror.BadRequest(c, "provider must be one of: "+strings.Join(provider.Names(), ", "))
 	}

--- a/internal/api/admin/deployments.go
+++ b/internal/api/admin/deployments.go
@@ -194,6 +194,9 @@ func (h *Handler) createDeployment(c fiber.Ctx) error {
 		if errors.Is(err, db.ErrConflict) {
 			return apierror.Conflict(c, "a deployment with this name already exists for this model")
 		}
+		if errors.Is(err, db.ErrReservedValue) {
+			return apierror.BadRequest(c, `name must not contain ":deleted:"`)
+		}
 		h.Log.ErrorContext(ctx, "create deployment: db insert", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "failed to create deployment")
 	}
@@ -380,6 +383,9 @@ func (h *Handler) updateDeployment(c fiber.Ctx) error {
 		}
 		if errors.Is(err, db.ErrConflict) {
 			return apierror.Conflict(c, "a deployment with this name already exists for this model")
+		}
+		if errors.Is(err, db.ErrReservedValue) {
+			return apierror.BadRequest(c, `name must not contain ":deleted:"`)
 		}
 		h.Log.ErrorContext(ctx, "update deployment", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "failed to update deployment")

--- a/internal/api/admin/deployments.go
+++ b/internal/api/admin/deployments.go
@@ -446,6 +446,9 @@ func (h *Handler) deleteDeployment(c fiber.Ctx) error {
 		if errors.Is(err, db.ErrNotFound) {
 			return apierror.NotFound(c, "deployment not found")
 		}
+		if errors.Is(err, db.ErrConflict) {
+			return apierror.Conflict(c, "delete blocked: another row occupies the reserved deleted-name for this record; rename it and retry")
+		}
 		h.Log.ErrorContext(ctx, "delete deployment", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "failed to delete deployment")
 	}

--- a/internal/api/admin/invites.go
+++ b/internal/api/admin/invites.go
@@ -447,6 +447,9 @@ func (h *Handler) RedeemInvite(c fiber.Ctx) error {
 		if errors.Is(err, db.ErrConflict) {
 			return apierror.Conflict(c, "email already registered")
 		}
+		if errors.Is(err, db.ErrReservedValue) {
+			return apierror.BadRequest(c, inviteInvalidMsg)
+		}
 		h.Log.ErrorContext(ctx, "redeem invite: create user", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "failed to redeem invite")
 	}

--- a/internal/api/admin/invites.go
+++ b/internal/api/admin/invites.go
@@ -141,6 +141,9 @@ func (h *Handler) CreateInvite(c fiber.Ctx) error {
 	if req.Email == "" || !strings.Contains(req.Email, "@") {
 		return apierror.BadRequest(c, "email is required and must be a valid email address")
 	}
+	if db.ContainsTombstoneMarker(req.Email) {
+		return apierror.BadRequest(c, `email must not contain ":deleted:"`)
+	}
 	if req.Role == "" {
 		req.Role = "member"
 	}

--- a/internal/api/admin/models.go
+++ b/internal/api/admin/models.go
@@ -1010,6 +1010,9 @@ func (h *Handler) DeleteModel(c fiber.Ctx) error {
 		if errors.Is(err, db.ErrNotFound) {
 			return apierror.NotFound(c, "model not found")
 		}
+		if errors.Is(err, db.ErrConflict) {
+			return apierror.Conflict(c, "delete blocked: another row occupies the reserved deleted-name for this record; rename it and retry")
+		}
 		h.Log.ErrorContext(ctx, "delete model", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "failed to delete model")
 	}

--- a/internal/api/admin/models.go
+++ b/internal/api/admin/models.go
@@ -574,6 +574,9 @@ func (h *Handler) CreateModel(c fiber.Ctx) error {
 		if errors.Is(err, db.ErrConflict) {
 			return apierror.Conflict(c, "a model with this name already exists")
 		}
+		if errors.Is(err, db.ErrReservedValue) {
+			return apierror.BadRequest(c, `name must not contain ":deleted:"`)
+		}
 		h.Log.ErrorContext(ctx, "create model: db insert", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "failed to create model")
 	}
@@ -941,6 +944,9 @@ func (h *Handler) UpdateModel(c fiber.Ctx) error {
 		}
 		if errors.Is(err, db.ErrConflict) {
 			return apierror.Conflict(c, "a model with this name already exists")
+		}
+		if errors.Is(err, db.ErrReservedValue) {
+			return apierror.BadRequest(c, `name must not contain ":deleted:"`)
 		}
 		h.Log.ErrorContext(ctx, "update model", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "failed to update model")

--- a/internal/api/admin/models.go
+++ b/internal/api/admin/models.go
@@ -461,6 +461,9 @@ func (h *Handler) CreateModel(c fiber.Ctx) error {
 	if req.Name == "" {
 		return apierror.BadRequest(c, "name is required")
 	}
+	if db.ContainsTombstoneMarker(req.Name) {
+		return apierror.BadRequest(c, `name must not contain ":deleted:"`)
+	}
 	// provider and base_url are required only in single-endpoint mode (no strategy).
 	// When a strategy is set the endpoints live on the model's deployments.
 	if req.Strategy == "" {
@@ -780,6 +783,9 @@ func (h *Handler) UpdateModel(c fiber.Ctx) error {
 		effectiveStrategy = *req.Strategy
 	}
 
+	if req.Name != nil && db.ContainsTombstoneMarker(*req.Name) {
+		return apierror.BadRequest(c, `name must not contain ":deleted:"`)
+	}
 	if req.Provider != nil && *req.Provider != "" && !provider.ValidProviders[*req.Provider] {
 		return apierror.BadRequest(c, "provider must be one of: "+strings.Join(provider.Names(), ", "))
 	}

--- a/internal/api/admin/oidc.go
+++ b/internal/api/admin/oidc.go
@@ -213,6 +213,15 @@ func (h *Handler) OIDCCallback(c fiber.Ctx) error {
 			ExternalID:   &externalID,
 		})
 		if createErr != nil {
+			if errors.Is(createErr, db.ErrReservedValue) {
+				// The IdP-supplied email contains the reserved soft-delete
+				// tombstone marker (see db.ContainsTombstoneMarker). This is an
+				// expected input-validation failure, not an internal error, so
+				// it is logged at warn level and surfaces as a distinct,
+				// non-500 auth failure rather than the generic provisioning error.
+				h.Log.LogAttrs(ctx, slog.LevelWarn, "oidc callback: create user: email rejected")
+				return c.Redirect().To("/login?error=invalid_email")
+			}
 			h.Log.ErrorContext(ctx, "oidc callback: create user", slog.String("error", createErr.Error()))
 			return c.Redirect().To("/login?error=provision_failed")
 		}

--- a/internal/api/admin/orgs.go
+++ b/internal/api/admin/orgs.go
@@ -373,6 +373,9 @@ func (h *Handler) DeleteOrg(c fiber.Ctx) error {
 		if errors.Is(err, db.ErrNotFound) {
 			return apierror.NotFound(c, "organization not found")
 		}
+		if errors.Is(err, db.ErrConflict) {
+			return apierror.Conflict(c, "delete blocked: another row occupies the reserved deleted-name for this record; rename it and retry")
+		}
 		h.Log.ErrorContext(c.Context(), "delete org", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "failed to delete organization")
 	}

--- a/internal/api/admin/orgs.go
+++ b/internal/api/admin/orgs.go
@@ -65,12 +65,19 @@ type paginatedOrgsResponse struct {
 }
 
 // orgToResponse converts a db.OrgWithCounts to its API wire representation,
-// including the computed member_count and team_count fields.
+// including the computed member_count and team_count fields. For
+// soft-deleted organizations the slug is stripped of its tombstone suffix
+// (see db.StripTombstone) so admins viewing include_deleted listings see the
+// original slug rather than the mangled one used to free it for reuse.
 func orgToResponse(o *db.OrgWithCounts) orgResponse {
+	slug := o.Slug
+	if o.DeletedAt != nil {
+		slug = db.StripTombstone(slug, o.ID)
+	}
 	return orgResponse{
 		ID:                o.ID,
 		Name:              o.Name,
-		Slug:              o.Slug,
+		Slug:              slug,
 		Timezone:          o.Timezone,
 		DailyTokenLimit:   o.DailyTokenLimit,
 		MonthlyTokenLimit: o.MonthlyTokenLimit,

--- a/internal/api/admin/orgs.go
+++ b/internal/api/admin/orgs.go
@@ -149,6 +149,9 @@ func (h *Handler) CreateOrg(c fiber.Ctx) error {
 		if errors.Is(err, db.ErrConflict) {
 			return apierror.Conflict(c, "organization slug already exists")
 		}
+		if errors.Is(err, db.ErrReservedValue) {
+			return apierror.BadRequest(c, `slug must not contain ":deleted:"`)
+		}
 		h.Log.ErrorContext(c.Context(), "create org", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "failed to create organization")
 	}
@@ -322,6 +325,9 @@ func (h *Handler) UpdateOrg(c fiber.Ctx) error {
 		}
 		if errors.Is(err, db.ErrConflict) {
 			return apierror.Conflict(c, "organization slug already exists")
+		}
+		if errors.Is(err, db.ErrReservedValue) {
+			return apierror.BadRequest(c, `slug must not contain ":deleted:"`)
 		}
 		h.Log.ErrorContext(c.Context(), "update org", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "failed to update organization")

--- a/internal/api/admin/soft_delete_tombstone_test.go
+++ b/internal/api/admin/soft_delete_tombstone_test.go
@@ -1,0 +1,483 @@
+package admin_test
+
+// Handler-level regression tests for #172's soft-delete tombstone fix:
+//   - include_deleted listings must display the original (untombstoned)
+//     email/slug to admins, even though the underlying DB row is mangled.
+//   - Create/Update endpoints for models, deployments, users, and invites
+//     must reject any name/email containing the ":deleted:" tombstone
+//     marker, so a live row can never be created that collides with, or is
+//     mistaken for, a mangled tombstoned row.
+//   - Ordinary names/emails, including ones that merely contain a colon,
+//     remain unaffected.
+
+import (
+	"context"
+	"io"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/voidmind-io/voidllm/internal/auth"
+	"github.com/voidmind-io/voidllm/internal/db"
+)
+
+// ---- include_deleted listings strip the tombstone for display ---------------
+
+func TestListUsers_IncludeDeleted_StripsTombstoneFromEmail(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestListUsers_IncludeDeleted_Strip?mode=memory&cache=private")
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	u := mustCreateUser(t, database, "strip-me@example.com", "Strip Me")
+	if err := database.DeleteUser(context.Background(), u.ID); err != nil {
+		t.Fatalf("DeleteUser(): %v", err)
+	}
+
+	// The raw DB row must be mangled with a tombstone suffix.
+	dbUsers, err := database.ListUsers(context.Background(), "", 100, true)
+	if err != nil {
+		t.Fatalf("ListUsers(includeDeleted=true) DB call: %v", err)
+	}
+	var rawEmail string
+	for _, du := range dbUsers {
+		if du.ID == u.ID {
+			rawEmail = du.Email
+		}
+	}
+	wantRaw := "strip-me@example.com:deleted:" + u.ID
+	if rawEmail != wantRaw {
+		t.Fatalf("raw DB email = %q, want %q (sanity check that the row is actually mangled)", rawEmail, wantRaw)
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/users?include_deleted=true", nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+	data, ok := got["data"].([]any)
+	if !ok {
+		t.Fatalf("data is not an array: %v", got["data"])
+	}
+
+	found := findByID(t, data, u.ID)
+	if found["email"] != "strip-me@example.com" {
+		t.Errorf("response email = %v, want %q (tombstone suffix must be stripped for display)", found["email"], "strip-me@example.com")
+	}
+}
+
+func TestListOrgs_IncludeDeleted_StripsTombstoneFromSlug(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestListOrgs_IncludeDeleted_Strip?mode=memory&cache=private")
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	org := mustCreateOrg(t, database, "Strip Me Org", "strip-me-org")
+	if err := database.DeleteOrg(context.Background(), org.ID); err != nil {
+		t.Fatalf("DeleteOrg(): %v", err)
+	}
+
+	dbOrgs, err := database.ListOrgs(context.Background(), "", 100, true)
+	if err != nil {
+		t.Fatalf("ListOrgs(includeDeleted=true) DB call: %v", err)
+	}
+	var rawSlug string
+	for _, do := range dbOrgs {
+		if do.ID == org.ID {
+			rawSlug = do.Slug
+		}
+	}
+	wantRaw := "strip-me-org:deleted:" + org.ID
+	if rawSlug != wantRaw {
+		t.Fatalf("raw DB slug = %q, want %q (sanity check that the row is actually mangled)", rawSlug, wantRaw)
+	}
+
+	req := httptest.NewRequest("GET", "/api/v1/orgs?include_deleted=true", nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+	data, ok := got["data"].([]any)
+	if !ok {
+		t.Fatalf("data is not an array: %v", got["data"])
+	}
+
+	found := findByID(t, data, org.ID)
+	if found["slug"] != "strip-me-org" {
+		t.Errorf("response slug = %v, want %q (tombstone suffix must be stripped for display)", found["slug"], "strip-me-org")
+	}
+}
+
+func TestListTeams_IncludeDeleted_StripsTombstoneFromSlug(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestListTeams_IncludeDeleted_Strip?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Strip Team Org", "strip-team-org")
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, org.ID)
+
+	team := mustCreateTeam(t, database, org.ID, "Strip Me Team", "strip-me-team")
+	if err := database.DeleteTeam(context.Background(), team.ID); err != nil {
+		t.Fatalf("DeleteTeam(): %v", err)
+	}
+
+	dbTeams, err := database.ListTeams(context.Background(), org.ID, "", 100, true)
+	if err != nil {
+		t.Fatalf("ListTeams(includeDeleted=true) DB call: %v", err)
+	}
+	var rawSlug string
+	for _, dt := range dbTeams {
+		if dt.ID == team.ID {
+			rawSlug = dt.Slug
+		}
+	}
+	wantRaw := "strip-me-team:deleted:" + team.ID
+	if rawSlug != wantRaw {
+		t.Fatalf("raw DB slug = %q, want %q (sanity check that the row is actually mangled)", rawSlug, wantRaw)
+	}
+
+	req := httptest.NewRequest("GET", teamURL(org.ID)+"?include_deleted=true", nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+	data, ok := got["data"].([]any)
+	if !ok {
+		t.Fatalf("data is not an array: %v", got["data"])
+	}
+
+	found := findByID(t, data, team.ID)
+	if found["slug"] != "strip-me-team" {
+		t.Errorf("response slug = %v, want %q (tombstone suffix must be stripped for display)", found["slug"], "strip-me-team")
+	}
+}
+
+// findByID locates the map entry in data whose "id" field equals id, failing
+// the test if no such entry exists.
+func findByID(t *testing.T, data []any, id string) map[string]any {
+	t.Helper()
+	for _, item := range data {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if m["id"] == id {
+			return m
+		}
+	}
+	t.Fatalf("no entry with id %q found in %d results", id, len(data))
+	return nil
+}
+
+// ---- Create/Update reject names/emails containing the tombstone marker ------
+
+func TestCreateModel_RejectsTombstoneMarkerInName(t *testing.T) {
+	t.Parallel()
+
+	app, _, keyCache := setupModelTestApp(t, "file:TestCreateModel_RejectsTombstone?mode=memory&cache=private")
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("POST", modelURL(), bodyJSON(t, map[string]any{
+		"name":     "gpt-4:deleted:evil",
+		"provider": "openai",
+		"base_url": "https://api.openai.com/v1",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 400; body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestUpdateModel_RejectsTombstoneMarkerInName(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupModelTestApp(t, "file:TestUpdateModel_RejectsTombstone?mode=memory&cache=private")
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	m, err := database.CreateModel(context.Background(), db.CreateModelParams{
+		Name: "update-tombstone-model", Provider: "openai", BaseURL: "https://api.openai.com/v1", Source: "api",
+	})
+	if err != nil {
+		t.Fatalf("CreateModel setup: %v", err)
+	}
+
+	req := httptest.NewRequest("PATCH", modelItemURL(m.ID), bodyJSON(t, map[string]any{
+		"name": "renamed:deleted:evil",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 400; body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestCreateDeployment_RejectsTombstoneMarkerInName(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithEncKey(t, "file:TestCreateDeployment_RejectsTombstone?mode=memory&cache=private")
+	m := mustCreateModelForDeployment(t, database, "deployment-tombstone-model")
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("POST", deploymentURL(m.ID), bodyJSON(t, map[string]any{
+		"name":     "primary:deleted:evil",
+		"provider": "openai",
+		"base_url": "https://api.openai.com/v1",
+		"weight":   1,
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 400; body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestUpdateDeployment_RejectsTombstoneMarkerInName(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestAppWithEncKey(t, "file:TestUpdateDeployment_RejectsTombstone?mode=memory&cache=private")
+	m := mustCreateModelForDeployment(t, database, "deployment-update-tombstone-model")
+	dep := mustCreateDeploymentDB(t, database, m.ID, "update-tombstone-dep")
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("PATCH", deploymentItemURL(m.ID, dep.ID), bodyJSON(t, map[string]any{
+		"name": "renamed:deleted:evil",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 400; body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestCreateUser_RejectsTombstoneMarkerInEmail(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestCreateUser_RejectsTombstone?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Tombstone User Org", "tombstone-user-org")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	req := httptest.NewRequest("POST", "/api/v1/users", bodyJSON(t, map[string]any{
+		"email":        "evil:deleted:123@example.com",
+		"display_name": "Evil",
+		"password":     "securepassword",
+		"org_id":       org.ID,
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 400; body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestUpdateUser_RejectsTombstoneMarkerInEmail(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestUpdateUser_RejectsTombstone?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Tombstone Update Org", "tombstone-update-org")
+	u := mustCreateUser(t, database, "update-tombstone@example.com", "Update Tombstone")
+	mustCreateMembership(t, database, org.ID, u.ID, "member")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	req := httptest.NewRequest("PATCH", "/api/v1/users/"+u.ID, bodyJSON(t, map[string]any{
+		"email": "renamed:deleted:evil@example.com",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 400; body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestCreateInvite_RejectsTombstoneMarkerInEmail(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestCreateInvite_RejectsTombstone?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Tombstone Invite Org", "tombstone-invite-org")
+	creator := mustCreateUser(t, database, "tombstone-invite-creator@example.com", "Creator")
+	testKey := addTestKeyWithUser(t, keyCache, auth.RoleOrgAdmin, org.ID, creator.ID)
+
+	req := httptest.NewRequest("POST", invitesURL(org.ID), bodyJSON(t, map[string]any{
+		"email": "evil:deleted:123@example.com",
+		"role":  "member",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 400; body: %s", resp.StatusCode, body)
+	}
+}
+
+// ---- Happy path: ordinary names/emails are unaffected ------------------------
+
+// TestCreateModel_NameWithColonButNoTombstoneMarker_Succeeds guards against an
+// overly broad validation regression that would reject any colon in a name,
+// rather than specifically the ":deleted:" marker.
+func TestCreateModel_NameWithColonButNoTombstoneMarker_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	app, _, keyCache := setupModelTestApp(t, "file:TestCreateModel_ColonOK?mode=memory&cache=private")
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("POST", modelURL(), bodyJSON(t, map[string]any{
+		"name":     "vertex:gemini-pro",
+		"provider": "openai",
+		"base_url": "https://api.openai.com/v1",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 201; body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestCreateUser_OrdinaryEmail_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestCreateUser_OrdinaryEmailOK?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Ordinary Email Org", "ordinary-email-org")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	req := httptest.NewRequest("POST", "/api/v1/users", bodyJSON(t, map[string]any{
+		"email":        "perfectly.normal@example.com",
+		"display_name": "Perfectly Normal",
+		"password":     "securepassword",
+		"org_id":       org.ID,
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 201; body: %s", resp.StatusCode, body)
+	}
+}
+
+func TestCreateInvite_OrdinaryEmail_Succeeds(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestCreateInvite_OrdinaryEmailOK?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Ordinary Invite Org", "ordinary-invite-org")
+	creator := mustCreateUser(t, database, "ordinary-invite-creator@example.com", "Creator")
+	testKey := addTestKeyWithUser(t, keyCache, auth.RoleOrgAdmin, org.ID, creator.ID)
+
+	req := httptest.NewRequest("POST", invitesURL(org.ID), bodyJSON(t, map[string]any{
+		"email": "perfectly.normal@example.com",
+		"role":  "member",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 201; body: %s", resp.StatusCode, body)
+	}
+}

--- a/internal/api/admin/teams.go
+++ b/internal/api/admin/teams.go
@@ -385,6 +385,9 @@ func (h *Handler) DeleteTeam(c fiber.Ctx) error {
 		if errors.Is(err, db.ErrNotFound) {
 			return apierror.NotFound(c, "team not found")
 		}
+		if errors.Is(err, db.ErrConflict) {
+			return apierror.Conflict(c, "delete blocked: another row occupies the reserved deleted-name for this record; rename it and retry")
+		}
 		h.Log.ErrorContext(c.Context(), "delete team", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "failed to delete team")
 	}

--- a/internal/api/admin/teams.go
+++ b/internal/api/admin/teams.go
@@ -153,6 +153,9 @@ func (h *Handler) CreateTeam(c fiber.Ctx) error {
 		if errors.Is(err, db.ErrConflict) {
 			return apierror.Conflict(c, "team slug already exists in this organization")
 		}
+		if errors.Is(err, db.ErrReservedValue) {
+			return apierror.BadRequest(c, `slug must not contain ":deleted:"`)
+		}
 		h.Log.ErrorContext(c.Context(), "create team", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "failed to create team")
 	}
@@ -338,6 +341,9 @@ func (h *Handler) UpdateTeam(c fiber.Ctx) error {
 		}
 		if errors.Is(err, db.ErrConflict) {
 			return apierror.Conflict(c, "team slug already exists in this organization")
+		}
+		if errors.Is(err, db.ErrReservedValue) {
+			return apierror.BadRequest(c, `slug must not contain ":deleted:"`)
 		}
 		h.Log.ErrorContext(c.Context(), "update team", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "failed to update team")

--- a/internal/api/admin/teams.go
+++ b/internal/api/admin/teams.go
@@ -58,12 +58,19 @@ type paginatedTeamsResponse struct {
 
 // teamToResponse converts a db.Team to its API wire representation.
 // memberCount and keyCount are provided by the caller and included as-is.
+// For soft-deleted teams the slug is stripped of its tombstone suffix (see
+// db.StripTombstone) so admins viewing include_deleted listings see the
+// original slug rather than the mangled one used to free it for reuse.
 func teamToResponse(t *db.Team, memberCount, keyCount int) teamResponse {
+	slug := t.Slug
+	if t.DeletedAt != nil {
+		slug = db.StripTombstone(slug, t.ID)
+	}
 	return teamResponse{
 		ID:                t.ID,
 		OrgID:             t.OrgID,
 		Name:              t.Name,
-		Slug:              t.Slug,
+		Slug:              slug,
 		DailyTokenLimit:   t.DailyTokenLimit,
 		MonthlyTokenLimit: t.MonthlyTokenLimit,
 		RequestsPerMinute: t.RequestsPerMinute,

--- a/internal/api/admin/users.go
+++ b/internal/api/admin/users.go
@@ -187,6 +187,9 @@ func (h *Handler) CreateUser(c fiber.Ctx) error {
 		if errors.Is(err, db.ErrForeignKey) {
 			return apierror.BadRequest(c, "organization not found")
 		}
+		if errors.Is(err, db.ErrReservedValue) {
+			return apierror.BadRequest(c, `email must not contain ":deleted:"`)
+		}
 		h.Log.ErrorContext(c.Context(), "create user", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "failed to create user")
 	}
@@ -426,6 +429,9 @@ func (h *Handler) UpdateUser(c fiber.Ctx) error {
 		}
 		if errors.Is(err, db.ErrConflict) {
 			return apierror.Conflict(c, "email already in use")
+		}
+		if errors.Is(err, db.ErrReservedValue) {
+			return apierror.BadRequest(c, `email must not contain ":deleted:"`)
 		}
 		h.Log.ErrorContext(c.Context(), "update user", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "failed to update user")

--- a/internal/api/admin/users.go
+++ b/internal/api/admin/users.go
@@ -57,11 +57,18 @@ type paginatedUsersResponse struct {
 	Cursor  string         `json:"next_cursor,omitempty"`
 }
 
-// userToResponse converts a db.User to its API wire representation.
+// userToResponse converts a db.User to its API wire representation. For
+// soft-deleted users the email column is stripped of its tombstone suffix
+// (see db.StripTombstone) so admins viewing include_deleted listings see the
+// original email rather than the mangled one used to free it for reuse.
 func userToResponse(u *db.User) userResponse {
+	email := u.Email
+	if u.DeletedAt != nil {
+		email = db.StripTombstone(email, u.ID)
+	}
 	return userResponse{
 		ID:            u.ID,
-		Email:         u.Email,
+		Email:         email,
 		DisplayName:   u.DisplayName,
 		AuthProvider:  u.AuthProvider,
 		IsSystemAdmin: u.IsSystemAdmin,
@@ -110,6 +117,9 @@ func (h *Handler) CreateUser(c fiber.Ctx) error {
 	}
 	if !strings.Contains(req.Email, "@") {
 		return apierror.BadRequest(c, "invalid email format")
+	}
+	if db.ContainsTombstoneMarker(req.Email) {
+		return apierror.BadRequest(c, `email must not contain ":deleted:"`)
 	}
 	if req.DisplayName == "" {
 		return apierror.BadRequest(c, "display_name is required")
@@ -369,6 +379,9 @@ func (h *Handler) UpdateUser(c fiber.Ctx) error {
 		}
 		if !strings.Contains(trimmed, "@") {
 			return apierror.BadRequest(c, "invalid email format")
+		}
+		if db.ContainsTombstoneMarker(trimmed) {
+			return apierror.BadRequest(c, `email must not contain ":deleted:"`)
 		}
 		req.Email = &trimmed
 	}

--- a/internal/api/admin/users.go
+++ b/internal/api/admin/users.go
@@ -463,6 +463,9 @@ func (h *Handler) DeleteUser(c fiber.Ctx) error {
 		if errors.Is(err, db.ErrNotFound) {
 			return apierror.NotFound(c, "user not found")
 		}
+		if errors.Is(err, db.ErrConflict) {
+			return apierror.Conflict(c, "delete blocked: another row occupies the reserved deleted-name for this record; rename it and retry")
+		}
 		h.Log.ErrorContext(c.Context(), "delete user", slog.String("error", err.Error()))
 		return apierror.InternalError(c, "failed to delete user")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -576,6 +576,27 @@ models:
 			errContains: "models[1].name",
 		},
 		{
+			name: "model name containing reserved tombstone marker error",
+			yaml: `
+server:
+  proxy:
+    port: 8080
+database:
+  driver: sqlite
+  dsn: voidllm.db
+settings:
+  encryption_key: key
+  usage:
+    buffer_size: 100
+models:
+  - name: "gpt-4:deleted:0198c9a2-1111-7000-8000-000000000001"
+    provider: openai
+    base_url: https://api.openai.com
+`,
+			wantErr:     true,
+			errContains: "models[0].name",
+		},
+		{
 			name: "duplicate aliases across models error",
 			yaml: `
 server:

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -15,6 +15,14 @@ import (
 // characters and hyphens, starting with an alphanumeric character.
 var mcpAliasRe = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
 
+// reservedTombstoneMarker mirrors db.tombstoneMarker (internal/db/tombstone.go).
+// It cannot be imported directly — internal/db imports internal/config, so the
+// reverse import would create a cycle. Model and deployment names configured
+// in voidllm.yaml are rejected here if they contain this marker so an
+// operator typo fails fast at startup instead of failing later inside
+// SyncYAMLModels, which enforces the same rule at the DB layer. See #172.
+const reservedTombstoneMarker = ":deleted:"
+
 // validMCPAuthTypes is the set of accepted MCP server auth type values.
 var validMCPAuthTypes = map[string]bool{
 	"none":   true,
@@ -136,6 +144,9 @@ func (c *Config) validate() error {
 			if seenNames[m.Name] {
 				errs = append(errs, fmt.Errorf("%s.name: duplicate model name %q", prefix, m.Name))
 			}
+			if strings.Contains(m.Name, reservedTombstoneMarker) {
+				errs = append(errs, fmt.Errorf("%s.name: must not contain %q", prefix, reservedTombstoneMarker))
+			}
 			seenNames[m.Name] = true
 		}
 
@@ -190,6 +201,9 @@ func (c *Config) validate() error {
 				} else {
 					if seenDeploymentNames[d.Name] {
 						errs = append(errs, fmt.Errorf("%s.name: duplicate deployment name %q within model %q", dprefix, d.Name, m.Name))
+					}
+					if strings.Contains(d.Name, reservedTombstoneMarker) {
+						errs = append(errs, fmt.Errorf("%s.name: must not contain %q", dprefix, reservedTombstoneMarker))
 					}
 					seenDeploymentNames[d.Name] = true
 				}

--- a/internal/db/delete_tombstone_conflict_test.go
+++ b/internal/db/delete_tombstone_conflict_test.go
@@ -1,0 +1,61 @@
+package db
+
+// Regression test for the pathological soft-delete/tombstone collision noted
+// in the #172 follow-up review: a legacy ACTIVE row whose unique column value
+// is exactly "<value>:deleted:<victim row's id>" (only possible pre-upgrade,
+// since the Admin API now rejects the ":deleted:" marker in user input) makes
+// the tombstoning UPDATE in Delete* collide with that legacy row's UNIQUE
+// constraint. This must surface as ErrConflict, not a generic/opaque error.
+//
+// Only the models entity is covered here; DeleteUser/DeleteOrg/DeleteTeam/
+// DeleteDeployment share the exact same translateError-based mapping, so one
+// representative case is sufficient to prove the mapping works end to end.
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// TestDeleteModel_LegacyTombstoneCollision_ReturnsErrConflict seeds an active
+// row whose name already occupies the tombstone value that DeleteModel would
+// write for the victim row, then asserts that deleting the victim returns
+// ErrConflict rather than a generic/internal error.
+func TestDeleteModel_LegacyTombstoneCollision_ReturnsErrConflict(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	victim := mustCreateModel(t, d, "tombstone-collision-model")
+	tombstoneValue := "tombstone-collision-model:deleted:" + victim.ID
+
+	// Seed a legacy active row occupying the exact tombstone value the
+	// pending delete will try to write. This shape bypasses the API's guard
+	// against ":deleted:"-suffixed names by inserting directly via raw SQL,
+	// simulating data left over from before that guard existed.
+	legacyID, err := uuid.NewV7()
+	if err != nil {
+		t.Fatalf("uuid.NewV7: %v", err)
+	}
+	if _, err := d.sql.ExecContext(ctx,
+		"INSERT INTO models (id, name, provider, base_url, is_active, source, created_at, updated_at) "+
+			"VALUES (?, ?, 'openai', 'https://api.openai.com/v1', 1, 'api', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+		legacyID.String(), tombstoneValue,
+	); err != nil {
+		t.Fatalf("seed legacy active row occupying tombstone value: %v", err)
+	}
+
+	err = d.DeleteModel(ctx, victim.ID)
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("DeleteModel() with a colliding legacy tombstone row = %v, want ErrConflict", err)
+	}
+
+	// The victim row must remain untouched (still active, original name)
+	// since the UPDATE failed and was not partially applied.
+	got := rawColumnValue(t, d, "models", "name", victim.ID)
+	if got != "tombstone-collision-model" {
+		t.Errorf("victim row name after failed delete = %q, want unchanged %q", got, "tombstone-collision-model")
+	}
+}

--- a/internal/db/deployments.go
+++ b/internal/db/deployments.go
@@ -335,10 +335,13 @@ func (d *DB) UpdateDeployment(ctx context.Context, id string, params UpdateDeplo
 }
 
 // DeleteDeployment soft-deletes an active deployment by setting deleted_at.
+// The name column is mangled with a tombstone suffix so its value is freed
+// for reuse immediately; see StripTombstone and #172.
 // It returns ErrNotFound if the deployment does not exist or is already deleted.
 func (d *DB) DeleteDeployment(ctx context.Context, id string) error {
 	p := d.dialect.Placeholder
-	query := "UPDATE model_deployments SET deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP " +
+	query := "UPDATE model_deployments SET name = name || ':deleted:' || id, " +
+		"deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP " +
 		"WHERE id = " + p(1) + " AND deleted_at IS NULL"
 
 	result, err := d.sql.ExecContext(ctx, query, id)

--- a/internal/db/deployments.go
+++ b/internal/db/deployments.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -338,6 +339,7 @@ func (d *DB) UpdateDeployment(ctx context.Context, id string, params UpdateDeplo
 // The name column is mangled with a tombstone suffix so its value is freed
 // for reuse immediately; see StripTombstone and #172.
 // It returns ErrNotFound if the deployment does not exist or is already deleted.
+// It returns ErrConflict when a legacy row occupies the tombstone value; rename that row to resolve.
 func (d *DB) DeleteDeployment(ctx context.Context, id string) error {
 	p := d.dialect.Placeholder
 	query := "UPDATE model_deployments SET name = name || ':deleted:' || id, " +
@@ -346,7 +348,11 @@ func (d *DB) DeleteDeployment(ctx context.Context, id string) error {
 
 	result, err := d.sql.ExecContext(ctx, query, id)
 	if err != nil {
-		return fmt.Errorf("delete deployment %s: %w", id, translateError(err))
+		translated := translateError(err)
+		if errors.Is(translated, ErrConflict) {
+			return fmt.Errorf("delete deployment %s: legacy row occupies tombstone value: %w", id, ErrConflict)
+		}
+		return fmt.Errorf("delete deployment %s: %w", id, translated)
 	}
 
 	n, err := result.RowsAffected()

--- a/internal/db/deployments.go
+++ b/internal/db/deployments.go
@@ -95,7 +95,13 @@ type UpdateDeploymentParams struct {
 
 // CreateDeployment inserts a new deployment and returns the persisted record.
 // It returns ErrConflict if a deployment with the same (model_id, name) pair already exists.
+// It returns ErrReservedValue if the name contains the reserved soft-delete
+// tombstone marker (see tombstone.go).
 func (d *DB) CreateDeployment(ctx context.Context, params CreateDeploymentParams) (*Deployment, error) {
+	if ContainsTombstoneMarker(params.Name) {
+		return nil, fmt.Errorf("create deployment: %w", ErrReservedValue)
+	}
+
 	id, err := uuid.NewV7()
 	if err != nil {
 		return nil, fmt.Errorf("create deployment: generate id: %w", err)
@@ -231,8 +237,14 @@ func (d *DB) ListActiveDeployments(ctx context.Context, modelID string) ([]Deplo
 // Only non-nil fields in params are written. If all fields are nil the record
 // is returned unchanged without issuing an UPDATE.
 // It returns ErrNotFound if the deployment does not exist or has been soft-deleted,
-// and ErrConflict if the new name collides with an existing deployment on the same model.
+// ErrConflict if the new name collides with an existing deployment on the same
+// model, and ErrReservedValue if the new name contains the reserved
+// soft-delete tombstone marker (see tombstone.go).
 func (d *DB) UpdateDeployment(ctx context.Context, id string, params UpdateDeploymentParams) (*Deployment, error) {
+	if params.Name != nil && ContainsTombstoneMarker(*params.Name) {
+		return nil, fmt.Errorf("update deployment %s: %w", id, ErrReservedValue)
+	}
+
 	p := d.dialect.Placeholder
 	argN := 1
 	var setClauses []string

--- a/internal/db/errors.go
+++ b/internal/db/errors.go
@@ -22,6 +22,13 @@ var ErrNoPassword = errors.New("no password")
 // It indicates that a referenced record (e.g. organization) does not exist.
 var ErrForeignKey = errors.New("foreign key violation")
 
+// ErrReservedValue is returned when a caller-supplied value for a unique
+// column (model/deployment name, user email, organization/team slug) contains
+// the reserved soft-delete tombstone marker. Such values are rejected before
+// any SQL is executed so a live row can never collide with, or be mistaken
+// for, a tombstoned one. See tombstone.go and #172.
+var ErrReservedValue = errors.New("reserved value")
+
 // translateError maps low-level driver errors to domain sentinels.
 // sql.ErrNoRows becomes ErrNotFound, UNIQUE constraint violations become ErrConflict,
 // FOREIGN KEY constraint violations become ErrForeignKey,

--- a/internal/db/migration_0015_legacy_test.go
+++ b/internal/db/migration_0015_legacy_test.go
@@ -1,0 +1,269 @@
+package db
+
+// Migration 0015 pre-seeded data test.
+//
+// The chosen approach, and why: RunMigrations (see migrate.go) always applies
+// every embedded "*.up.sql" file in order and has no "stop at migration N"
+// mode, and openMigratedDB (the shared test harness used across this package,
+// see orgs_test.go) always runs it to completion. So there is no way to open a
+// test database frozen just *before* 0015 runs in order to seed genuine
+// pre-fix rows and then watch 0015 mangle them live during RunMigrations
+// itself -- by the time any test gets a *DB, 0015 has already executed against
+// an empty schema and had nothing to mangle.
+//
+// Rather than fabricate a green test that never actually exercises 0015's SQL
+// (e.g. asserting today's fixed behavior only through the store's Delete*
+// methods, which is already covered by soft_delete_collision_test.go and
+// proves the *ongoing* fix but not the *backfill* for existing installs), the
+// tests below take the honest option available in this harness: they seed
+// rows shaped exactly like a pre-#172 installation would have had -- a
+// soft-deleted row whose unique column still holds its original, unmangled
+// value, and (for the OIDC case) a unique index without the deleted_at
+// predicate -- directly via raw SQL against an already-fully-migrated
+// database, confirm that shape reproduces the original bug, then re-execute
+// migration 0015's own up.sql content (read from disk, not copy-pasted, so
+// this test cannot silently drift from the real migration) against that
+// seeded data and confirm it fixes it. This exercises 0015's actual
+// UPDATE/index-rebuild logic against representative legacy data.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// migration0015UpSQL reads the exact SQL executed by
+// migrations/0015_soft_delete_unique_collision.up.sql from disk.
+func migration0015UpSQL(t *testing.T) string {
+	t.Helper()
+	b, err := os.ReadFile("migrations/0015_soft_delete_unique_collision.up.sql")
+	if err != nil {
+		t.Fatalf("read migration 0015 up.sql: %v", err)
+	}
+	return string(b)
+}
+
+// applyMigration0015SQL re-executes migration 0015's up.sql content against
+// an already-fully-migrated test database, inside a transaction, mirroring
+// how the real migration runner applies it (see applyMigration in migrate.go).
+func applyMigration0015SQL(t *testing.T, d *DB) {
+	t.Helper()
+	ctx := context.Background()
+	err := d.WithTx(ctx, func(q Querier) error {
+		_, execErr := q.ExecContext(ctx, migration0015UpSQL(t))
+		return execErr
+	})
+	if err != nil {
+		t.Fatalf("re-apply migration 0015 SQL: %v", err)
+	}
+}
+
+// TestMigration0015_MangleLegacyDeletedRows_Models seeds a soft-deleted models
+// row with an unmangled name -- exactly the shape left behind by any
+// installation that soft-deleted a model before #172 was fixed -- and
+// verifies that migration 0015's UPDATE statement mangles it and frees the
+// name for reuse.
+func TestMigration0015_MangleLegacyDeletedRows_Models(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	legacyID, err := uuid.NewV7()
+	if err != nil {
+		t.Fatalf("uuid.NewV7: %v", err)
+	}
+	_, err = d.sql.ExecContext(ctx,
+		"INSERT INTO models (id, name, provider, base_url, is_active, source, created_at, updated_at, deleted_at) "+
+			"VALUES (?, ?, 'openai', 'https://api.openai.com/v1', 1, 'api', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+		legacyID.String(), "legacy-conflict-model",
+	)
+	if err != nil {
+		t.Fatalf("seed legacy soft-deleted row: %v", err)
+	}
+
+	// Sanity check: reproduce the pre-0015 bug. models.name is an inline
+	// UNIQUE constraint (not a partial index), so a soft-deleted row with an
+	// unmangled name still blocks creating a new active row with that name.
+	if _, err := d.CreateModel(ctx, CreateModelParams{
+		Name: "legacy-conflict-model", Provider: "openai", BaseURL: "https://api.openai.com/v1", Source: "api",
+	}); !errors.Is(err, ErrConflict) {
+		t.Fatalf("CreateModel() before migration 0015 mangles the legacy row = %v, want ErrConflict (sanity check)", err)
+	}
+
+	applyMigration0015SQL(t, d)
+
+	got := rawColumnValue(t, d, "models", "name", legacyID.String())
+	want := "legacy-conflict-model:deleted:" + legacyID.String()
+	if got != want {
+		t.Errorf("legacy row name after migration 0015 = %q, want %q", got, want)
+	}
+
+	if _, err := d.CreateModel(ctx, CreateModelParams{
+		Name: "legacy-conflict-model", Provider: "openai", BaseURL: "https://api.openai.com/v1", Source: "api",
+	}); err != nil {
+		t.Errorf("CreateModel() after migration 0015 mangled the legacy row = %v, want nil", err)
+	}
+}
+
+// TestMigration0015_MangleLegacyDeletedRows_Users mirrors the models case for
+// users.email.
+func TestMigration0015_MangleLegacyDeletedRows_Users(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	legacyID, err := uuid.NewV7()
+	if err != nil {
+		t.Fatalf("uuid.NewV7: %v", err)
+	}
+	_, err = d.sql.ExecContext(ctx,
+		"INSERT INTO users (id, email, display_name, auth_provider, is_system_admin, created_at, updated_at, deleted_at) "+
+			"VALUES (?, ?, 'Legacy User', 'local', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+		legacyID.String(), "legacy-conflict@example.com",
+	)
+	if err != nil {
+		t.Fatalf("seed legacy soft-deleted row: %v", err)
+	}
+
+	_, err = d.CreateUser(ctx, CreateUserParams{
+		Email:        "legacy-conflict@example.com",
+		DisplayName:  "New User",
+		PasswordHash: testPasswordHash(t),
+	})
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("CreateUser() before migration 0015 mangles the legacy row = %v, want ErrConflict (sanity check)", err)
+	}
+
+	applyMigration0015SQL(t, d)
+
+	got := rawColumnValue(t, d, "users", "email", legacyID.String())
+	want := "legacy-conflict@example.com:deleted:" + legacyID.String()
+	if got != want {
+		t.Errorf("legacy row email after migration 0015 = %q, want %q", got, want)
+	}
+
+	if _, err := d.CreateUser(ctx, CreateUserParams{
+		Email:        "legacy-conflict@example.com",
+		DisplayName:  "New User",
+		PasswordHash: testPasswordHash(t),
+	}); err != nil {
+		t.Errorf("CreateUser() after migration 0015 mangled the legacy row = %v, want nil", err)
+	}
+}
+
+// TestMigration0015_MangleLegacyDeletedRows_Teams mirrors the models case for
+// teams.slug, which is scoped to (org_id, slug) rather than a single global
+// column.
+func TestMigration0015_MangleLegacyDeletedRows_Teams(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	org := mustCreateOrg(t, d, CreateOrgParams{Name: "Legacy Team Org", Slug: "legacy-team-org"})
+
+	legacyID, err := uuid.NewV7()
+	if err != nil {
+		t.Fatalf("uuid.NewV7: %v", err)
+	}
+	_, err = d.sql.ExecContext(ctx,
+		"INSERT INTO teams (id, org_id, name, slug, created_at, updated_at, deleted_at) "+
+			"VALUES (?, ?, 'Legacy Team', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+		legacyID.String(), org.ID, "legacy-conflict-team",
+	)
+	if err != nil {
+		t.Fatalf("seed legacy soft-deleted row: %v", err)
+	}
+
+	_, err = d.CreateTeam(ctx, CreateTeamParams{OrgID: org.ID, Name: "New Team", Slug: "legacy-conflict-team"})
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("CreateTeam() before migration 0015 mangles the legacy row = %v, want ErrConflict (sanity check)", err)
+	}
+
+	applyMigration0015SQL(t, d)
+
+	got := rawColumnValue(t, d, "teams", "slug", legacyID.String())
+	want := "legacy-conflict-team:deleted:" + legacyID.String()
+	if got != want {
+		t.Errorf("legacy row slug after migration 0015 = %q, want %q", got, want)
+	}
+
+	if _, err := d.CreateTeam(ctx, CreateTeamParams{OrgID: org.ID, Name: "New Team", Slug: "legacy-conflict-team"}); err != nil {
+		t.Errorf("CreateTeam() after migration 0015 mangled the legacy row = %v, want nil", err)
+	}
+}
+
+// TestMigration0015_RebuildsUserExternalIndexForLegacyInstalls covers the
+// idx_users_external half of migration 0015. Unlike the mangled-column cases
+// above, idx_users_external is a *named* index rather than an inline
+// constraint, so a legacy install's index (without the "deleted_at IS NULL"
+// predicate added by 0015) is reproduced here by dropping the current,
+// already-correct index and recreating it in its original 0001 shape, then
+// confirming migration 0015's SQL restores the fix.
+func TestMigration0015_RebuildsUserExternalIndexForLegacyInstalls(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	// Roll back idx_users_external to its pre-0015 (0001-original) shape.
+	err := d.WithTx(ctx, func(q Querier) error {
+		_, execErr := q.ExecContext(ctx,
+			"DROP INDEX idx_users_external; "+
+				"CREATE UNIQUE INDEX idx_users_external ON users (auth_provider, external_id) WHERE external_id IS NOT NULL;")
+		return execErr
+	})
+	if err != nil {
+		t.Fatalf("recreate legacy idx_users_external: %v", err)
+	}
+
+	extID := "legacy-oidc-sub-172"
+	first, err := d.CreateUser(ctx, CreateUserParams{
+		Email:        "legacy-oidc-first@example.com",
+		DisplayName:  "Legacy OIDC First",
+		AuthProvider: "oidc",
+		ExternalID:   &extID,
+	})
+	if err != nil {
+		t.Fatalf("CreateUser(first): %v", err)
+	}
+	if err := d.DeleteUser(ctx, first.ID); err != nil {
+		t.Fatalf("DeleteUser(first): %v", err)
+	}
+
+	// Sanity check: reproduce the pre-0015 bug. The legacy full-column
+	// unique index still blocks re-provisioning the same OIDC identity.
+	_, err = d.CreateUser(ctx, CreateUserParams{
+		Email:        "legacy-oidc-second@example.com",
+		DisplayName:  "Legacy OIDC Second",
+		AuthProvider: "oidc",
+		ExternalID:   &extID,
+	})
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("CreateUser() under the legacy index = %v, want ErrConflict (sanity check)", err)
+	}
+
+	applyMigration0015SQL(t, d)
+
+	second, err := d.CreateUser(ctx, CreateUserParams{
+		Email:        "legacy-oidc-second@example.com",
+		DisplayName:  "Legacy OIDC Second",
+		AuthProvider: "oidc",
+		ExternalID:   &extID,
+	})
+	if err != nil {
+		t.Fatalf("CreateUser() after migration 0015 rebuilt idx_users_external = %v, want nil", err)
+	}
+	if second.ID == first.ID {
+		t.Error("second.ID == first.ID, want a newly created, distinct row")
+	}
+
+	got, err := d.GetUserByExternalID(ctx, "oidc", extID)
+	if err != nil {
+		t.Fatalf("GetUserByExternalID(): %v", err)
+	}
+	if got.ID != second.ID {
+		t.Errorf("GetUserByExternalID().ID = %q, want %q (the new row)", got.ID, second.ID)
+	}
+}

--- a/internal/db/migrations/0015_soft_delete_unique_collision.down.sql
+++ b/internal/db/migrations/0015_soft_delete_unique_collision.down.sql
@@ -1,0 +1,45 @@
+-- Migration: 0015_soft_delete_unique_collision.down.sql
+-- Description: Reverses 0015_soft_delete_unique_collision.up.sql.
+--
+-- Restores idx_users_external to its original 0001 definition (no
+-- deleted_at predicate), then strips the ':deleted:' || id tombstone suffix
+-- appended by the up migration. Each UPDATE's WHERE clause only matches
+-- rows whose current value still ends in that row's own ':deleted:' || id
+-- suffix, so it is a safe no-op for any row that was changed independently
+-- since the up migration ran.
+
+DROP INDEX idx_users_external;
+
+CREATE UNIQUE INDEX idx_users_external
+    ON users (auth_provider, external_id)
+    WHERE external_id IS NOT NULL;
+
+UPDATE model_deployments
+SET name = substr(name, 1, length(name) - length(':deleted:' || id))
+WHERE deleted_at IS NOT NULL
+  AND length(name) > length(':deleted:' || id)
+  AND substr(name, length(name) - length(':deleted:' || id) + 1) = ':deleted:' || id;
+
+UPDATE teams
+SET slug = substr(slug, 1, length(slug) - length(':deleted:' || id))
+WHERE deleted_at IS NOT NULL
+  AND length(slug) > length(':deleted:' || id)
+  AND substr(slug, length(slug) - length(':deleted:' || id) + 1) = ':deleted:' || id;
+
+UPDATE organizations
+SET slug = substr(slug, 1, length(slug) - length(':deleted:' || id))
+WHERE deleted_at IS NOT NULL
+  AND length(slug) > length(':deleted:' || id)
+  AND substr(slug, length(slug) - length(':deleted:' || id) + 1) = ':deleted:' || id;
+
+UPDATE users
+SET email = substr(email, 1, length(email) - length(':deleted:' || id))
+WHERE deleted_at IS NOT NULL
+  AND length(email) > length(':deleted:' || id)
+  AND substr(email, length(email) - length(':deleted:' || id) + 1) = ':deleted:' || id;
+
+UPDATE models
+SET name = substr(name, 1, length(name) - length(':deleted:' || id))
+WHERE deleted_at IS NOT NULL
+  AND length(name) > length(':deleted:' || id)
+  AND substr(name, length(name) - length(':deleted:' || id) + 1) = ':deleted:' || id;

--- a/internal/db/migrations/0015_soft_delete_unique_collision.down.sql
+++ b/internal/db/migrations/0015_soft_delete_unique_collision.down.sql
@@ -7,6 +7,26 @@
 -- rows whose current value still ends in that row's own ':deleted:' || id
 -- suffix, so it is a safe no-op for any row that was changed independently
 -- since the up migration ran.
+--
+-- Each strip also carries a correlated NOT EXISTS guard: the whole point of
+-- the up migration was to free a deleted row's original value for reuse, so
+-- by the time this down migration runs, some other row (active, or another
+-- deleted row) may legitimately hold that original value already. Stripping
+-- the suffix unconditionally would then collide with it under the UNIQUE
+-- constraint and abort the migration. The guard skips the strip for that
+-- one row instead -- it keeps its tombstoned value rather than aborting.
+-- There is no way to recover the original value for such a row without
+-- manual intervention, since it is now legitimately in use elsewhere.
+--
+-- idx_users_external cannot be given an equivalent guard: CREATE UNIQUE
+-- INDEX either succeeds or fails outright, there is no per-row skip. If a
+-- deleted and an active user now share (auth_provider, external_id) -- which
+-- the up migration explicitly allowed -- recreating the unfiltered index
+-- will fail by definition, and this migration will abort at that
+-- statement. Rolling back after such an identity has been reused requires
+-- manually resolving (re-mangling or removing) the conflicting row(s)
+-- first. In practice this is not a concern: no VoidLLM code path executes
+-- down migrations automatically; they exist for manual/local use only.
 
 DROP INDEX idx_users_external;
 
@@ -18,28 +38,50 @@ UPDATE model_deployments
 SET name = substr(name, 1, length(name) - length(':deleted:' || id))
 WHERE deleted_at IS NOT NULL
   AND length(name) > length(':deleted:' || id)
-  AND substr(name, length(name) - length(':deleted:' || id) + 1) = ':deleted:' || id;
+  AND substr(name, length(name) - length(':deleted:' || id) + 1) = ':deleted:' || id
+  AND NOT EXISTS (
+    SELECT 1 FROM model_deployments t2
+    WHERE t2.model_id = model_deployments.model_id
+      AND t2.name = substr(model_deployments.name, 1, length(model_deployments.name) - length(':deleted:' || model_deployments.id))
+  );
 
 UPDATE teams
 SET slug = substr(slug, 1, length(slug) - length(':deleted:' || id))
 WHERE deleted_at IS NOT NULL
   AND length(slug) > length(':deleted:' || id)
-  AND substr(slug, length(slug) - length(':deleted:' || id) + 1) = ':deleted:' || id;
+  AND substr(slug, length(slug) - length(':deleted:' || id) + 1) = ':deleted:' || id
+  AND NOT EXISTS (
+    SELECT 1 FROM teams t2
+    WHERE t2.org_id = teams.org_id
+      AND t2.slug = substr(teams.slug, 1, length(teams.slug) - length(':deleted:' || teams.id))
+  );
 
 UPDATE organizations
 SET slug = substr(slug, 1, length(slug) - length(':deleted:' || id))
 WHERE deleted_at IS NOT NULL
   AND length(slug) > length(':deleted:' || id)
-  AND substr(slug, length(slug) - length(':deleted:' || id) + 1) = ':deleted:' || id;
+  AND substr(slug, length(slug) - length(':deleted:' || id) + 1) = ':deleted:' || id
+  AND NOT EXISTS (
+    SELECT 1 FROM organizations t2
+    WHERE t2.slug = substr(organizations.slug, 1, length(organizations.slug) - length(':deleted:' || organizations.id))
+  );
 
 UPDATE users
 SET email = substr(email, 1, length(email) - length(':deleted:' || id))
 WHERE deleted_at IS NOT NULL
   AND length(email) > length(':deleted:' || id)
-  AND substr(email, length(email) - length(':deleted:' || id) + 1) = ':deleted:' || id;
+  AND substr(email, length(email) - length(':deleted:' || id) + 1) = ':deleted:' || id
+  AND NOT EXISTS (
+    SELECT 1 FROM users t2
+    WHERE t2.email = substr(users.email, 1, length(users.email) - length(':deleted:' || users.id))
+  );
 
 UPDATE models
 SET name = substr(name, 1, length(name) - length(':deleted:' || id))
 WHERE deleted_at IS NOT NULL
   AND length(name) > length(':deleted:' || id)
-  AND substr(name, length(name) - length(':deleted:' || id) + 1) = ':deleted:' || id;
+  AND substr(name, length(name) - length(':deleted:' || id) + 1) = ':deleted:' || id
+  AND NOT EXISTS (
+    SELECT 1 FROM models t2
+    WHERE t2.name = substr(models.name, 1, length(models.name) - length(':deleted:' || models.id))
+  );

--- a/internal/db/migrations/0015_soft_delete_unique_collision.up.sql
+++ b/internal/db/migrations/0015_soft_delete_unique_collision.up.sql
@@ -9,24 +9,67 @@
 -- constrained value on every row that is already soft-deleted, freeing the
 -- original value for reuse by new/active rows.
 --
--- These UPDATEs run unconditionally, with no "already mangled" guard,
--- because this migration executes exactly once and no released version has
--- ever produced a ':deleted:'-suffixed value.
+-- Each UPDATE carries a correlated NOT EXISTS guard rather than running
+-- unconditionally. Reason: prior to this patch, values containing the
+-- literal substring ':deleted:' were accepted on ACTIVE rows (nothing
+-- rejected them). If some active row's value already happens to equal
+-- <deleted-row's-value>:deleted:<deleted-row-id>, mangling the deleted row
+-- would collide with that active row's existing value and abort the whole
+-- migration under the UNIQUE constraint -- which would prevent the instance
+-- from starting at all. The guard makes that one pathological row a no-op
+-- instead: it keeps its original (still-blocked) value, and every other
+-- deleted row is mangled normally. That original value stays permanently
+-- blocked for reuse in this one case, which is preferred over a failed
+-- startup. The odds of this are negligible -- it requires an existing
+-- active row whose value exactly matches another specific row's full
+-- tombstone string, including that row's own UUID.
 --
 -- idx_users_external is a *named* index rather than an inline constraint,
 -- so unlike the others it can be dropped and recreated portably -- this
 -- adds the missing deleted_at IS NULL predicate so a deleted OIDC identity
 -- no longer blocks re-provisioning under the same provider + external_id.
 
-UPDATE models SET name = name || ':deleted:' || id WHERE deleted_at IS NOT NULL;
+UPDATE models
+SET name = name || ':deleted:' || id
+WHERE deleted_at IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM models t2
+    WHERE t2.name = models.name || ':deleted:' || models.id
+  );
 
-UPDATE users SET email = email || ':deleted:' || id WHERE deleted_at IS NOT NULL;
+UPDATE users
+SET email = email || ':deleted:' || id
+WHERE deleted_at IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM users t2
+    WHERE t2.email = users.email || ':deleted:' || users.id
+  );
 
-UPDATE organizations SET slug = slug || ':deleted:' || id WHERE deleted_at IS NOT NULL;
+UPDATE organizations
+SET slug = slug || ':deleted:' || id
+WHERE deleted_at IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM organizations t2
+    WHERE t2.slug = organizations.slug || ':deleted:' || organizations.id
+  );
 
-UPDATE teams SET slug = slug || ':deleted:' || id WHERE deleted_at IS NOT NULL;
+UPDATE teams
+SET slug = slug || ':deleted:' || id
+WHERE deleted_at IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM teams t2
+    WHERE t2.org_id = teams.org_id
+      AND t2.slug = teams.slug || ':deleted:' || teams.id
+  );
 
-UPDATE model_deployments SET name = name || ':deleted:' || id WHERE deleted_at IS NOT NULL;
+UPDATE model_deployments
+SET name = name || ':deleted:' || id
+WHERE deleted_at IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM model_deployments t2
+    WHERE t2.model_id = model_deployments.model_id
+      AND t2.name = model_deployments.name || ':deleted:' || model_deployments.id
+  );
 
 DROP INDEX idx_users_external;
 

--- a/internal/db/migrations/0015_soft_delete_unique_collision.up.sql
+++ b/internal/db/migrations/0015_soft_delete_unique_collision.up.sql
@@ -1,0 +1,35 @@
+-- Migration: 0015_soft_delete_unique_collision.up.sql
+-- Description: Soft-deleted rows held their UNIQUE column values hostage,
+-- permanently blocking re-use of that name/email/slug (#172). Affected:
+-- models.name, users.email, organizations.slug, teams(org_id, slug), and
+-- model_deployments(model_id, name) -- all declared as inline UNIQUE
+-- constraints in 0001/0003. SQLite cannot drop an inline UNIQUE constraint
+-- without a full table rebuild, which is not possible inside this
+-- transactional migration runner with foreign_keys=ON. Fix: mangle the
+-- constrained value on every row that is already soft-deleted, freeing the
+-- original value for reuse by new/active rows.
+--
+-- These UPDATEs run unconditionally, with no "already mangled" guard,
+-- because this migration executes exactly once and no released version has
+-- ever produced a ':deleted:'-suffixed value.
+--
+-- idx_users_external is a *named* index rather than an inline constraint,
+-- so unlike the others it can be dropped and recreated portably -- this
+-- adds the missing deleted_at IS NULL predicate so a deleted OIDC identity
+-- no longer blocks re-provisioning under the same provider + external_id.
+
+UPDATE models SET name = name || ':deleted:' || id WHERE deleted_at IS NOT NULL;
+
+UPDATE users SET email = email || ':deleted:' || id WHERE deleted_at IS NOT NULL;
+
+UPDATE organizations SET slug = slug || ':deleted:' || id WHERE deleted_at IS NOT NULL;
+
+UPDATE teams SET slug = slug || ':deleted:' || id WHERE deleted_at IS NOT NULL;
+
+UPDATE model_deployments SET name = name || ':deleted:' || id WHERE deleted_at IS NOT NULL;
+
+DROP INDEX idx_users_external;
+
+CREATE UNIQUE INDEX idx_users_external
+    ON users (auth_provider, external_id)
+    WHERE external_id IS NOT NULL AND deleted_at IS NULL;

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -151,7 +151,13 @@ type UpdateModelParams struct {
 
 // CreateModel inserts a new model and returns the persisted record.
 // It returns ErrConflict if a model with the same name already exists.
+// It returns ErrReservedValue if the name contains the reserved soft-delete
+// tombstone marker (see tombstone.go).
 func (d *DB) CreateModel(ctx context.Context, params CreateModelParams) (*Model, error) {
+	if ContainsTombstoneMarker(params.Name) {
+		return nil, fmt.Errorf("create model: %w", ErrReservedValue)
+	}
+
 	id, err := uuid.NewV7()
 	if err != nil {
 		return nil, fmt.Errorf("create model: generate id: %w", err)
@@ -309,8 +315,14 @@ func (d *DB) ListModels(ctx context.Context, cursor string, limit int, includeIn
 // Only non-nil fields in params are written. If all fields are nil the record
 // is returned unchanged without issuing an UPDATE.
 // It returns ErrNotFound if the model does not exist or has been soft-deleted,
-// and ErrConflict if the new name collides with an existing model name.
+// ErrConflict if the new name collides with an existing model name, and
+// ErrReservedValue if the new name contains the reserved soft-delete
+// tombstone marker (see tombstone.go).
 func (d *DB) UpdateModel(ctx context.Context, id string, params UpdateModelParams) (*Model, error) {
+	if params.Name != nil && ContainsTombstoneMarker(*params.Name) {
+		return nil, fmt.Errorf("update model %s: %w", id, ErrReservedValue)
+	}
+
 	p := d.dialect.Placeholder
 	argN := 1
 	var setClauses []string

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -452,11 +452,14 @@ func (d *DB) UpdateModel(ctx context.Context, id string, params UpdateModelParam
 	return model, nil
 }
 
-// DeleteModel soft-deletes an active model by setting deleted_at.
+// DeleteModel soft-deletes an active model by setting deleted_at. The name
+// column is mangled with a tombstone suffix so its value is freed for reuse
+// immediately; see StripTombstone and #172.
 // It returns ErrNotFound if the model does not exist or is already deleted.
 func (d *DB) DeleteModel(ctx context.Context, id string) error {
 	p := d.dialect.Placeholder
-	query := "UPDATE models SET deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP " +
+	query := "UPDATE models SET name = name || ':deleted:' || id, " +
+		"deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP " +
 		"WHERE id = " + p(1) + " AND deleted_at IS NULL"
 
 	result, err := d.sql.ExecContext(ctx, query, id)

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -456,6 +456,7 @@ func (d *DB) UpdateModel(ctx context.Context, id string, params UpdateModelParam
 // column is mangled with a tombstone suffix so its value is freed for reuse
 // immediately; see StripTombstone and #172.
 // It returns ErrNotFound if the model does not exist or is already deleted.
+// It returns ErrConflict when a legacy row occupies the tombstone value; rename that row to resolve.
 func (d *DB) DeleteModel(ctx context.Context, id string) error {
 	p := d.dialect.Placeholder
 	query := "UPDATE models SET name = name || ':deleted:' || id, " +
@@ -464,7 +465,11 @@ func (d *DB) DeleteModel(ctx context.Context, id string) error {
 
 	result, err := d.sql.ExecContext(ctx, query, id)
 	if err != nil {
-		return fmt.Errorf("delete model %s: %w", id, translateError(err))
+		translated := translateError(err)
+		if errors.Is(translated, ErrConflict) {
+			return fmt.Errorf("delete model %s: legacy row occupies tombstone value: %w", id, ErrConflict)
+		}
+		return fmt.Errorf("delete model %s: %w", id, translated)
 	}
 
 	n, err := result.RowsAffected()

--- a/internal/db/orgs.go
+++ b/internal/db/orgs.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -268,6 +269,7 @@ func (d *DB) UpdateOrg(ctx context.Context, id string, params UpdateOrgParams) (
 // slug column is mangled with a tombstone suffix so its value is freed for
 // reuse immediately; see StripTombstone and #172.
 // It returns ErrNotFound if the organization does not exist or is already deleted.
+// It returns ErrConflict when a legacy row occupies the tombstone value; rename that row to resolve.
 func (d *DB) DeleteOrg(ctx context.Context, id string) error {
 	p := d.dialect.Placeholder
 	query := "UPDATE organizations SET slug = slug || ':deleted:' || id, " +
@@ -276,7 +278,11 @@ func (d *DB) DeleteOrg(ctx context.Context, id string) error {
 
 	result, err := d.sql.ExecContext(ctx, query, id)
 	if err != nil {
-		return fmt.Errorf("DeleteOrg %s: %w", id, translateError(err))
+		translated := translateError(err)
+		if errors.Is(translated, ErrConflict) {
+			return fmt.Errorf("DeleteOrg %s: legacy row occupies tombstone value: %w", id, ErrConflict)
+		}
+		return fmt.Errorf("DeleteOrg %s: %w", id, translated)
 	}
 
 	n, err := result.RowsAffected()

--- a/internal/db/orgs.go
+++ b/internal/db/orgs.go
@@ -55,7 +55,13 @@ type UpdateOrgParams struct {
 
 // CreateOrg inserts a new organization and returns the persisted record.
 // It returns ErrConflict if the slug is already taken.
+// It returns ErrReservedValue if the slug contains the reserved soft-delete
+// tombstone marker (see tombstone.go).
 func (d *DB) CreateOrg(ctx context.Context, params CreateOrgParams) (*Org, error) {
+	if ContainsTombstoneMarker(params.Slug) {
+		return nil, fmt.Errorf("create org: %w", ErrReservedValue)
+	}
+
 	id, err := uuid.NewV7()
 	if err != nil {
 		return nil, fmt.Errorf("create org: generate id: %w", err)
@@ -183,8 +189,14 @@ func (d *DB) ListOrgs(ctx context.Context, cursor string, limit int, includeDele
 // Only non-nil fields in params are written. If all fields are nil the record
 // is returned unchanged without issuing an UPDATE.
 // It returns ErrNotFound if the organization does not exist or has been soft-deleted,
-// and ErrConflict if the new slug collides with an existing one.
+// ErrConflict if the new slug collides with an existing one, and
+// ErrReservedValue if the new slug contains the reserved soft-delete
+// tombstone marker (see tombstone.go).
 func (d *DB) UpdateOrg(ctx context.Context, id string, params UpdateOrgParams) (*Org, error) {
+	if params.Slug != nil && ContainsTombstoneMarker(*params.Slug) {
+		return nil, fmt.Errorf("UpdateOrg %s: %w", id, ErrReservedValue)
+	}
+
 	p := d.dialect.Placeholder
 	argN := 1
 	var setClauses []string

--- a/internal/db/orgs.go
+++ b/internal/db/orgs.go
@@ -264,11 +264,14 @@ func (d *DB) UpdateOrg(ctx context.Context, id string, params UpdateOrgParams) (
 	return org, nil
 }
 
-// DeleteOrg soft-deletes an active organization by setting deleted_at.
+// DeleteOrg soft-deletes an active organization by setting deleted_at. The
+// slug column is mangled with a tombstone suffix so its value is freed for
+// reuse immediately; see StripTombstone and #172.
 // It returns ErrNotFound if the organization does not exist or is already deleted.
 func (d *DB) DeleteOrg(ctx context.Context, id string) error {
 	p := d.dialect.Placeholder
-	query := "UPDATE organizations SET deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP " +
+	query := "UPDATE organizations SET slug = slug || ':deleted:' || id, " +
+		"deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP " +
 		"WHERE id = " + p(1) + " AND deleted_at IS NULL"
 
 	result, err := d.sql.ExecContext(ctx, query, id)

--- a/internal/db/reserved_value_test.go
+++ b/internal/db/reserved_value_test.go
@@ -1,0 +1,115 @@
+package db
+
+// Regression test for the #172 follow-up: the ":deleted:" tombstone marker
+// must be rejected by the DB layer itself — the single choke point — rather
+// than relying solely on Admin API handler validation. SyncYAMLModels and
+// OIDC auto-provisioning call CreateModel/UpdateModel/CreateUser directly,
+// bypassing the handler-level checks, so the store functions themselves must
+// reject the marker before executing any SQL. See tombstone.go and errors.go.
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// markerName is a value containing the reserved soft-delete tombstone marker.
+// It is shared read-only across the table-driven subtests below.
+const markerName = "gpt-4:deleted:someid"
+
+// TestCreateAndUpdate_RejectTombstoneMarker is a table-driven test proving
+// that every Create* function for the five entities with a tombstone-eligible
+// unique column (models.name, users.email, organizations.slug, teams.slug,
+// model_deployments.name), plus a representative Update* function, return
+// ErrReservedValue when the relevant field contains the marker — without
+// going through any Admin API handler.
+func TestCreateAndUpdate_RejectTombstoneMarker(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func(t *testing.T, d *DB) error
+	}{
+		{
+			name: "CreateModel rejects a name containing the marker",
+			run: func(t *testing.T, d *DB) error {
+				_, err := d.CreateModel(context.Background(), CreateModelParams{
+					Name:     markerName,
+					Provider: "openai",
+					BaseURL:  "https://api.openai.com/v1",
+					Source:   "api",
+				})
+				return err
+			},
+		},
+		{
+			name: "CreateUser rejects an email containing the marker",
+			run: func(t *testing.T, d *DB) error {
+				_, err := d.CreateUser(context.Background(), CreateUserParams{
+					Email:        markerName + "@example.com",
+					DisplayName:  "Marker User",
+					PasswordHash: testPasswordHash(t),
+				})
+				return err
+			},
+		},
+		{
+			name: "CreateOrg rejects a slug containing the marker",
+			run: func(t *testing.T, d *DB) error {
+				_, err := d.CreateOrg(context.Background(), CreateOrgParams{
+					Name: "Marker Org",
+					Slug: markerName,
+				})
+				return err
+			},
+		},
+		{
+			name: "CreateTeam rejects a slug containing the marker",
+			run: func(t *testing.T, d *DB) error {
+				org := mustCreateOrg(t, d, CreateOrgParams{Name: "Team Marker Org", Slug: "team-marker-org"})
+				_, err := d.CreateTeam(context.Background(), CreateTeamParams{
+					OrgID: org.ID,
+					Name:  "Marker Team",
+					Slug:  markerName,
+				})
+				return err
+			},
+		},
+		{
+			name: "CreateDeployment rejects a name containing the marker",
+			run: func(t *testing.T, d *DB) error {
+				m := mustCreateModel(t, d, "deployment-marker-model")
+				_, err := d.CreateDeployment(context.Background(), CreateDeploymentParams{
+					ModelID:  m.ID,
+					Name:     markerName,
+					Provider: "openai",
+					BaseURL:  "https://api.openai.com/v1",
+					Weight:   1,
+				})
+				return err
+			},
+		},
+		{
+			name: "UpdateModel rejects a new name containing the marker",
+			run: func(t *testing.T, d *DB) error {
+				m := mustCreateModel(t, d, "update-marker-model")
+				_, err := d.UpdateModel(context.Background(), m.ID, UpdateModelParams{
+					Name: ptr(markerName),
+				})
+				return err
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := openMigratedDB(t)
+
+			err := tc.run(t, d)
+			if !errors.Is(err, ErrReservedValue) {
+				t.Fatalf("error = %v, want ErrReservedValue", err)
+			}
+		})
+	}
+}

--- a/internal/db/soft_delete_collision_test.go
+++ b/internal/db/soft_delete_collision_test.go
@@ -1,0 +1,670 @@
+package db
+
+// Regression suite for #172: soft-deleted rows previously held their UNIQUE
+// column value hostage forever, because the column mangling that frees the
+// value for reuse (DeleteModel/DeleteUser/DeleteOrg/DeleteTeam/DeleteDeployment)
+// and migration 0015 (which mangles any already soft-deleted legacy rows) had
+// not shipped yet. Each entity below is exercised through the same four
+// assertions:
+//
+//  1. create -> soft-delete -> create again with the same unique value succeeds.
+//  2. the deleted row's unique column is stored as value + ":deleted:" + id.
+//  3. the active lookup by the original value finds the new row, not the old one.
+//  4. deleting the second (new) row also succeeds -- two deleted rows sharing
+//     the same original value, but different ids, must not collide with
+//     each other either.
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// rawColumnValue reads a single column's current stored value for the row
+// identified by id, bypassing all "deleted_at IS NULL" filtering that the
+// store's normal getters apply. It is used to assert on the raw, possibly
+// tombstone-mangled, value written by a soft-delete.
+func rawColumnValue(t *testing.T, d *DB, table, column, id string) string {
+	t.Helper()
+	var got string
+	query := "SELECT " + column + " FROM " + table + " WHERE id = ?"
+	if err := d.sql.QueryRowContext(context.Background(), query, id).Scan(&got); err != nil {
+		t.Fatalf("rawColumnValue(%s.%s, id=%s): %v", table, column, id, err)
+	}
+	return got
+}
+
+// ---- models.name -----------------------------------------------------------
+
+func TestDeleteModel_FreesNameForReuse(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	first := mustCreateModel(t, d, "reuse-model")
+	if err := d.DeleteModel(ctx, first.ID); err != nil {
+		t.Fatalf("DeleteModel(first): %v", err)
+	}
+
+	second, err := d.CreateModel(ctx, CreateModelParams{
+		Name:     "reuse-model",
+		Provider: "openai",
+		BaseURL:  "https://api.openai.com/v1",
+		Source:   "api",
+	})
+	if err != nil {
+		t.Fatalf("CreateModel() reusing name after delete = %v, want nil (#172)", err)
+	}
+	if second.ID == first.ID {
+		t.Error("second.ID == first.ID, want a newly created, distinct row")
+	}
+	if second.Name != "reuse-model" {
+		t.Errorf("second.Name = %q, want %q", second.Name, "reuse-model")
+	}
+}
+
+func TestDeleteModel_MangledNameHasTombstoneSuffix(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	m := mustCreateModel(t, d, "mangle-model")
+	if err := d.DeleteModel(ctx, m.ID); err != nil {
+		t.Fatalf("DeleteModel(): %v", err)
+	}
+
+	got := rawColumnValue(t, d, "models", "name", m.ID)
+	want := "mangle-model:deleted:" + m.ID
+	if got != want {
+		t.Errorf("stored name after delete = %q, want %q", got, want)
+	}
+	if stripped := StripTombstone(got, m.ID); stripped != "mangle-model" {
+		t.Errorf("StripTombstone(%q, %q) = %q, want %q", got, m.ID, stripped, "mangle-model")
+	}
+}
+
+func TestGetModelByName_AfterDeleteAndRecreate_FindsNewRow(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	old := mustCreateModel(t, d, "lookup-reuse-model")
+	if err := d.DeleteModel(ctx, old.ID); err != nil {
+		t.Fatalf("DeleteModel(old): %v", err)
+	}
+	fresh := mustCreateModel(t, d, "lookup-reuse-model")
+
+	got, err := d.GetModelByName(ctx, "lookup-reuse-model")
+	if err != nil {
+		t.Fatalf("GetModelByName(): %v", err)
+	}
+	if got.ID != fresh.ID {
+		t.Errorf("GetModelByName().ID = %q, want %q (the new row)", got.ID, fresh.ID)
+	}
+	if got.ID == old.ID {
+		t.Error("GetModelByName() returned the soft-deleted row")
+	}
+}
+
+func TestDeleteModel_TwoDeletedRowsSameOriginalName_DoNotCollide(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	first := mustCreateModel(t, d, "double-delete-model")
+	if err := d.DeleteModel(ctx, first.ID); err != nil {
+		t.Fatalf("first DeleteModel(): %v", err)
+	}
+
+	second := mustCreateModel(t, d, "double-delete-model")
+	if err := d.DeleteModel(ctx, second.ID); err != nil {
+		t.Fatalf("second DeleteModel() = %v, want nil (#172: deleting a second row with the same original name must not collide with the first tombstoned row)", err)
+	}
+
+	firstName := rawColumnValue(t, d, "models", "name", first.ID)
+	secondName := rawColumnValue(t, d, "models", "name", second.ID)
+	if firstName == secondName {
+		t.Fatalf("both deleted rows share identical mangled name %q, want distinct tombstone suffixes", firstName)
+	}
+	if want := "double-delete-model:deleted:" + first.ID; firstName != want {
+		t.Errorf("first mangled name = %q, want %q", firstName, want)
+	}
+	if want := "double-delete-model:deleted:" + second.ID; secondName != want {
+		t.Errorf("second mangled name = %q, want %q", secondName, want)
+	}
+}
+
+// ---- users.email ------------------------------------------------------------
+
+func TestDeleteUser_FreesEmailForReuse(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	first := mustCreateUser(t, d, CreateUserParams{
+		Email:        "reuse@example.com",
+		DisplayName:  "First",
+		PasswordHash: testPasswordHash(t),
+	})
+	if err := d.DeleteUser(ctx, first.ID); err != nil {
+		t.Fatalf("DeleteUser(first): %v", err)
+	}
+
+	second, err := d.CreateUser(ctx, CreateUserParams{
+		Email:        "reuse@example.com",
+		DisplayName:  "Second",
+		PasswordHash: testPasswordHash(t),
+	})
+	if err != nil {
+		t.Fatalf("CreateUser() reusing email after delete = %v, want nil (#172)", err)
+	}
+	if second.ID == first.ID {
+		t.Error("second.ID == first.ID, want a newly created, distinct row")
+	}
+	if second.Email != "reuse@example.com" {
+		t.Errorf("second.Email = %q, want %q", second.Email, "reuse@example.com")
+	}
+}
+
+func TestDeleteUser_MangledEmailHasTombstoneSuffix(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	u := mustCreateUser(t, d, CreateUserParams{
+		Email:        "mangle@example.com",
+		DisplayName:  "Mangle Me",
+		PasswordHash: testPasswordHash(t),
+	})
+	if err := d.DeleteUser(ctx, u.ID); err != nil {
+		t.Fatalf("DeleteUser(): %v", err)
+	}
+
+	got := rawColumnValue(t, d, "users", "email", u.ID)
+	want := "mangle@example.com:deleted:" + u.ID
+	if got != want {
+		t.Errorf("stored email after delete = %q, want %q", got, want)
+	}
+	if stripped := StripTombstone(got, u.ID); stripped != "mangle@example.com" {
+		t.Errorf("StripTombstone(%q, %q) = %q, want %q", got, u.ID, stripped, "mangle@example.com")
+	}
+}
+
+func TestGetUserByEmail_AfterDeleteAndRecreate_FindsNewRow(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	old := mustCreateUser(t, d, CreateUserParams{
+		Email:        "lookup-reuse@example.com",
+		DisplayName:  "Old",
+		PasswordHash: testPasswordHash(t),
+	})
+	if err := d.DeleteUser(ctx, old.ID); err != nil {
+		t.Fatalf("DeleteUser(old): %v", err)
+	}
+	fresh := mustCreateUser(t, d, CreateUserParams{
+		Email:        "lookup-reuse@example.com",
+		DisplayName:  "Fresh",
+		PasswordHash: testPasswordHash(t),
+	})
+
+	got, err := d.GetUserByEmail(ctx, "lookup-reuse@example.com")
+	if err != nil {
+		t.Fatalf("GetUserByEmail(): %v", err)
+	}
+	if got.ID != fresh.ID {
+		t.Errorf("GetUserByEmail().ID = %q, want %q (the new row)", got.ID, fresh.ID)
+	}
+	if got.ID == old.ID {
+		t.Error("GetUserByEmail() returned the soft-deleted row")
+	}
+}
+
+func TestDeleteUser_TwoDeletedRowsSameOriginalEmail_DoNotCollide(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	first := mustCreateUser(t, d, CreateUserParams{
+		Email:        "double-delete@example.com",
+		DisplayName:  "First",
+		PasswordHash: testPasswordHash(t),
+	})
+	if err := d.DeleteUser(ctx, first.ID); err != nil {
+		t.Fatalf("first DeleteUser(): %v", err)
+	}
+
+	second := mustCreateUser(t, d, CreateUserParams{
+		Email:        "double-delete@example.com",
+		DisplayName:  "Second",
+		PasswordHash: testPasswordHash(t),
+	})
+	if err := d.DeleteUser(ctx, second.ID); err != nil {
+		t.Fatalf("second DeleteUser() = %v, want nil (#172: deleting a second row with the same original email must not collide)", err)
+	}
+
+	firstEmail := rawColumnValue(t, d, "users", "email", first.ID)
+	secondEmail := rawColumnValue(t, d, "users", "email", second.ID)
+	if firstEmail == secondEmail {
+		t.Fatalf("both deleted rows share identical mangled email %q, want distinct tombstone suffixes", firstEmail)
+	}
+	if want := "double-delete@example.com:deleted:" + first.ID; firstEmail != want {
+		t.Errorf("first mangled email = %q, want %q", firstEmail, want)
+	}
+	if want := "double-delete@example.com:deleted:" + second.ID; secondEmail != want {
+		t.Errorf("second mangled email = %q, want %q", secondEmail, want)
+	}
+}
+
+// ---- OIDC identity: (auth_provider, external_id) -----------------------------
+
+// TestDeleteUser_OIDCIdentityReusableAfterDelete covers the idx_users_external
+// half of #172: before migration 0015 added a "deleted_at IS NULL" predicate to
+// that index, a soft-deleted OIDC identity permanently blocked re-provisioning
+// the same (auth_provider, external_id) pair for a new user.
+func TestDeleteUser_OIDCIdentityReusableAfterDelete(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	extID := "oidc-sub-reuse-172"
+	first, err := d.CreateUser(ctx, CreateUserParams{
+		Email:        "oidc-first@example.com",
+		DisplayName:  "OIDC First",
+		AuthProvider: "oidc",
+		ExternalID:   &extID,
+	})
+	if err != nil {
+		t.Fatalf("CreateUser(first): %v", err)
+	}
+	if err := d.DeleteUser(ctx, first.ID); err != nil {
+		t.Fatalf("DeleteUser(first): %v", err)
+	}
+
+	second, err := d.CreateUser(ctx, CreateUserParams{
+		Email:        "oidc-second@example.com",
+		DisplayName:  "OIDC Second",
+		AuthProvider: "oidc",
+		ExternalID:   &extID,
+	})
+	if err != nil {
+		t.Fatalf("CreateUser(second) with the same auth_provider+external_id after delete = %v, want nil (#172)", err)
+	}
+	if second.ID == first.ID {
+		t.Error("second.ID == first.ID, want a newly created, distinct row")
+	}
+
+	got, err := d.GetUserByExternalID(ctx, "oidc", extID)
+	if err != nil {
+		t.Fatalf("GetUserByExternalID(): %v", err)
+	}
+	if got.ID != second.ID {
+		t.Errorf("GetUserByExternalID().ID = %q, want %q (the new row)", got.ID, second.ID)
+	}
+}
+
+// ---- organizations.slug -------------------------------------------------------
+
+func TestDeleteOrg_FreesSlugForReuse(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	first := mustCreateOrg(t, d, CreateOrgParams{Name: "First Org", Slug: "reuse-org"})
+	if err := d.DeleteOrg(ctx, first.ID); err != nil {
+		t.Fatalf("DeleteOrg(first): %v", err)
+	}
+
+	second, err := d.CreateOrg(ctx, CreateOrgParams{Name: "Second Org", Slug: "reuse-org"})
+	if err != nil {
+		t.Fatalf("CreateOrg() reusing slug after delete = %v, want nil (#172)", err)
+	}
+	if second.ID == first.ID {
+		t.Error("second.ID == first.ID, want a newly created, distinct row")
+	}
+	if second.Slug != "reuse-org" {
+		t.Errorf("second.Slug = %q, want %q", second.Slug, "reuse-org")
+	}
+}
+
+func TestDeleteOrg_MangledSlugHasTombstoneSuffix(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	org := mustCreateOrg(t, d, CreateOrgParams{Name: "Mangle Org", Slug: "mangle-org"})
+	if err := d.DeleteOrg(ctx, org.ID); err != nil {
+		t.Fatalf("DeleteOrg(): %v", err)
+	}
+
+	got := rawColumnValue(t, d, "organizations", "slug", org.ID)
+	want := "mangle-org:deleted:" + org.ID
+	if got != want {
+		t.Errorf("stored slug after delete = %q, want %q", got, want)
+	}
+	if stripped := StripTombstone(got, org.ID); stripped != "mangle-org" {
+		t.Errorf("StripTombstone(%q, %q) = %q, want %q", got, org.ID, stripped, "mangle-org")
+	}
+}
+
+func TestGetOrgBySlug_AfterDeleteAndRecreate_FindsNewRow(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	old := mustCreateOrg(t, d, CreateOrgParams{Name: "Old Org", Slug: "lookup-reuse-org"})
+	if err := d.DeleteOrg(ctx, old.ID); err != nil {
+		t.Fatalf("DeleteOrg(old): %v", err)
+	}
+	fresh := mustCreateOrg(t, d, CreateOrgParams{Name: "Fresh Org", Slug: "lookup-reuse-org"})
+
+	got, err := d.GetOrgBySlug(ctx, "lookup-reuse-org")
+	if err != nil {
+		t.Fatalf("GetOrgBySlug(): %v", err)
+	}
+	if got.ID != fresh.ID {
+		t.Errorf("GetOrgBySlug().ID = %q, want %q (the new row)", got.ID, fresh.ID)
+	}
+	if got.ID == old.ID {
+		t.Error("GetOrgBySlug() returned the soft-deleted row")
+	}
+}
+
+func TestDeleteOrg_TwoDeletedRowsSameOriginalSlug_DoNotCollide(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	first := mustCreateOrg(t, d, CreateOrgParams{Name: "First", Slug: "double-delete-org"})
+	if err := d.DeleteOrg(ctx, first.ID); err != nil {
+		t.Fatalf("first DeleteOrg(): %v", err)
+	}
+
+	second := mustCreateOrg(t, d, CreateOrgParams{Name: "Second", Slug: "double-delete-org"})
+	if err := d.DeleteOrg(ctx, second.ID); err != nil {
+		t.Fatalf("second DeleteOrg() = %v, want nil (#172: deleting a second row with the same original slug must not collide)", err)
+	}
+
+	firstSlug := rawColumnValue(t, d, "organizations", "slug", first.ID)
+	secondSlug := rawColumnValue(t, d, "organizations", "slug", second.ID)
+	if firstSlug == secondSlug {
+		t.Fatalf("both deleted rows share identical mangled slug %q, want distinct tombstone suffixes", firstSlug)
+	}
+	if want := "double-delete-org:deleted:" + first.ID; firstSlug != want {
+		t.Errorf("first mangled slug = %q, want %q", firstSlug, want)
+	}
+	if want := "double-delete-org:deleted:" + second.ID; secondSlug != want {
+		t.Errorf("second mangled slug = %q, want %q", secondSlug, want)
+	}
+}
+
+// ---- teams.slug (scoped to org_id) --------------------------------------------
+
+func TestDeleteTeam_FreesSlugForReuse(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	org := mustCreateOrg(t, d, CreateOrgParams{Name: "Team Reuse Org", Slug: "team-reuse-org"})
+
+	first := mustCreateTeam(t, d, CreateTeamParams{OrgID: org.ID, Name: "First Team", Slug: "reuse-team"})
+	if err := d.DeleteTeam(ctx, first.ID); err != nil {
+		t.Fatalf("DeleteTeam(first): %v", err)
+	}
+
+	second, err := d.CreateTeam(ctx, CreateTeamParams{OrgID: org.ID, Name: "Second Team", Slug: "reuse-team"})
+	if err != nil {
+		t.Fatalf("CreateTeam() reusing slug after delete = %v, want nil (#172)", err)
+	}
+	if second.ID == first.ID {
+		t.Error("second.ID == first.ID, want a newly created, distinct row")
+	}
+	if second.Slug != "reuse-team" {
+		t.Errorf("second.Slug = %q, want %q", second.Slug, "reuse-team")
+	}
+}
+
+func TestDeleteTeam_MangledSlugHasTombstoneSuffix(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	org := mustCreateOrg(t, d, CreateOrgParams{Name: "Mangle Team Org", Slug: "mangle-team-org"})
+	team := mustCreateTeam(t, d, CreateTeamParams{OrgID: org.ID, Name: "Mangle Team", Slug: "mangle-team"})
+	if err := d.DeleteTeam(ctx, team.ID); err != nil {
+		t.Fatalf("DeleteTeam(): %v", err)
+	}
+
+	got := rawColumnValue(t, d, "teams", "slug", team.ID)
+	want := "mangle-team:deleted:" + team.ID
+	if got != want {
+		t.Errorf("stored slug after delete = %q, want %q", got, want)
+	}
+	if stripped := StripTombstone(got, team.ID); stripped != "mangle-team" {
+		t.Errorf("StripTombstone(%q, %q) = %q, want %q", got, team.ID, stripped, "mangle-team")
+	}
+}
+
+func TestGetTeamByName_AfterDeleteAndRecreateWithSameSlug_FindsNewRow(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	org := mustCreateOrg(t, d, CreateOrgParams{Name: "Lookup Reuse Team Org", Slug: "lookup-reuse-team-org"})
+
+	old := mustCreateTeam(t, d, CreateTeamParams{OrgID: org.ID, Name: "Old Team", Slug: "lookup-reuse-team"})
+	if err := d.DeleteTeam(ctx, old.ID); err != nil {
+		t.Fatalf("DeleteTeam(old): %v", err)
+	}
+	fresh, err := d.CreateTeam(ctx, CreateTeamParams{OrgID: org.ID, Name: "Old Team", Slug: "lookup-reuse-team"})
+	if err != nil {
+		t.Fatalf("CreateTeam(fresh) reusing slug: %v", err)
+	}
+
+	// GetTeamByName looks up by (org_id, name), which is not the mangled
+	// column, but the row's continued reachability by its active lookup
+	// confirms the delete/recreate cycle left a healthy, findable new row.
+	got, err := d.GetTeamByName(ctx, org.ID, "Old Team")
+	if err != nil {
+		t.Fatalf("GetTeamByName(): %v", err)
+	}
+	if got.ID != fresh.ID {
+		t.Errorf("GetTeamByName().ID = %q, want %q (the new row)", got.ID, fresh.ID)
+	}
+	if got.ID == old.ID {
+		t.Error("GetTeamByName() returned the soft-deleted row")
+	}
+	if got.Slug != "lookup-reuse-team" {
+		t.Errorf("GetTeamByName().Slug = %q, want %q", got.Slug, "lookup-reuse-team")
+	}
+}
+
+func TestDeleteTeam_TwoDeletedRowsSameOriginalSlug_DoNotCollide(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	org := mustCreateOrg(t, d, CreateOrgParams{Name: "Double Delete Team Org", Slug: "double-delete-team-org"})
+
+	first := mustCreateTeam(t, d, CreateTeamParams{OrgID: org.ID, Name: "First", Slug: "double-delete-team"})
+	if err := d.DeleteTeam(ctx, first.ID); err != nil {
+		t.Fatalf("first DeleteTeam(): %v", err)
+	}
+
+	second := mustCreateTeam(t, d, CreateTeamParams{OrgID: org.ID, Name: "Second", Slug: "double-delete-team"})
+	if err := d.DeleteTeam(ctx, second.ID); err != nil {
+		t.Fatalf("second DeleteTeam() = %v, want nil (#172: deleting a second row with the same original slug must not collide)", err)
+	}
+
+	firstSlug := rawColumnValue(t, d, "teams", "slug", first.ID)
+	secondSlug := rawColumnValue(t, d, "teams", "slug", second.ID)
+	if firstSlug == secondSlug {
+		t.Fatalf("both deleted rows share identical mangled slug %q, want distinct tombstone suffixes", firstSlug)
+	}
+	if want := "double-delete-team:deleted:" + first.ID; firstSlug != want {
+		t.Errorf("first mangled slug = %q, want %q", firstSlug, want)
+	}
+	if want := "double-delete-team:deleted:" + second.ID; secondSlug != want {
+		t.Errorf("second mangled slug = %q, want %q", secondSlug, want)
+	}
+}
+
+// ---- model_deployments.name (scoped to model_id) -------------------------------
+
+func TestDeleteDeployment_FreesNameForReuse(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	m := mustCreateModel(t, d, "deployment-reuse-model")
+
+	first := mustCreateDeployment(t, d, CreateDeploymentParams{
+		ModelID: m.ID, Name: "reuse-dep", Provider: "openai", BaseURL: "https://api.openai.com/v1", Weight: 1,
+	})
+	if err := d.DeleteDeployment(ctx, first.ID); err != nil {
+		t.Fatalf("DeleteDeployment(first): %v", err)
+	}
+
+	second, err := d.CreateDeployment(ctx, CreateDeploymentParams{
+		ModelID: m.ID, Name: "reuse-dep", Provider: "openai", BaseURL: "https://api.openai.com/v1", Weight: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateDeployment() reusing name after delete = %v, want nil (#172)", err)
+	}
+	if second.ID == first.ID {
+		t.Error("second.ID == first.ID, want a newly created, distinct row")
+	}
+	if second.Name != "reuse-dep" {
+		t.Errorf("second.Name = %q, want %q", second.Name, "reuse-dep")
+	}
+}
+
+func TestDeleteDeployment_MangledNameHasTombstoneSuffix(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	m := mustCreateModel(t, d, "deployment-mangle-model")
+	dep := mustCreateDeployment(t, d, CreateDeploymentParams{
+		ModelID: m.ID, Name: "mangle-dep", Provider: "openai", BaseURL: "https://api.openai.com/v1", Weight: 1,
+	})
+	if err := d.DeleteDeployment(ctx, dep.ID); err != nil {
+		t.Fatalf("DeleteDeployment(): %v", err)
+	}
+
+	got := rawColumnValue(t, d, "model_deployments", "name", dep.ID)
+	want := "mangle-dep:deleted:" + dep.ID
+	if got != want {
+		t.Errorf("stored name after delete = %q, want %q", got, want)
+	}
+	if stripped := StripTombstone(got, dep.ID); stripped != "mangle-dep" {
+		t.Errorf("StripTombstone(%q, %q) = %q, want %q", got, dep.ID, stripped, "mangle-dep")
+	}
+}
+
+func TestListDeployments_AfterDeleteAndRecreateWithSameName_FindsNewRow(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	m := mustCreateModel(t, d, "deployment-lookup-reuse-model")
+
+	old := mustCreateDeployment(t, d, CreateDeploymentParams{
+		ModelID: m.ID, Name: "lookup-reuse-dep", Provider: "openai", BaseURL: "https://api.openai.com/v1", Weight: 1,
+	})
+	if err := d.DeleteDeployment(ctx, old.ID); err != nil {
+		t.Fatalf("DeleteDeployment(old): %v", err)
+	}
+	fresh := mustCreateDeployment(t, d, CreateDeploymentParams{
+		ModelID: m.ID, Name: "lookup-reuse-dep", Provider: "openai", BaseURL: "https://api.openai.com/v1", Weight: 1,
+	})
+
+	deps, err := d.ListDeployments(ctx, m.ID)
+	if err != nil {
+		t.Fatalf("ListDeployments(): %v", err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("ListDeployments() len = %d, want 1 (only the active, renamed-back row)", len(deps))
+	}
+	if deps[0].ID != fresh.ID {
+		t.Errorf("ListDeployments()[0].ID = %q, want %q (the new row)", deps[0].ID, fresh.ID)
+	}
+	if deps[0].ID == old.ID {
+		t.Error("ListDeployments() returned the soft-deleted row")
+	}
+	if deps[0].Name != "lookup-reuse-dep" {
+		t.Errorf("ListDeployments()[0].Name = %q, want %q", deps[0].Name, "lookup-reuse-dep")
+	}
+
+	got, err := d.GetDeployment(ctx, fresh.ID)
+	if err != nil {
+		t.Fatalf("GetDeployment(fresh): %v", err)
+	}
+	if got.Name != "lookup-reuse-dep" {
+		t.Errorf("GetDeployment(fresh).Name = %q, want %q", got.Name, "lookup-reuse-dep")
+	}
+}
+
+func TestDeleteDeployment_TwoDeletedRowsSameOriginalName_DoNotCollide(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	m := mustCreateModel(t, d, "deployment-double-delete-model")
+
+	first := mustCreateDeployment(t, d, CreateDeploymentParams{
+		ModelID: m.ID, Name: "double-delete-dep", Provider: "openai", BaseURL: "https://api.openai.com/v1", Weight: 1,
+	})
+	if err := d.DeleteDeployment(ctx, first.ID); err != nil {
+		t.Fatalf("first DeleteDeployment(): %v", err)
+	}
+
+	second := mustCreateDeployment(t, d, CreateDeploymentParams{
+		ModelID: m.ID, Name: "double-delete-dep", Provider: "openai", BaseURL: "https://api.openai.com/v1", Weight: 1,
+	})
+	if err := d.DeleteDeployment(ctx, second.ID); err != nil {
+		t.Fatalf("second DeleteDeployment() = %v, want nil (#172: deleting a second row with the same original name must not collide)", err)
+	}
+
+	firstName := rawColumnValue(t, d, "model_deployments", "name", first.ID)
+	secondName := rawColumnValue(t, d, "model_deployments", "name", second.ID)
+	if firstName == secondName {
+		t.Fatalf("both deleted rows share identical mangled name %q, want distinct tombstone suffixes", firstName)
+	}
+	if want := "double-delete-dep:deleted:" + first.ID; firstName != want {
+		t.Errorf("first mangled name = %q, want %q", firstName, want)
+	}
+	if want := "double-delete-dep:deleted:" + second.ID; secondName != want {
+		t.Errorf("second mangled name = %q, want %q", secondName, want)
+	}
+}
+
+// ---- sanity: not-yet-deleted errors are unaffected ----------------------------
+
+// TestDeleteModel_AlreadyDeleted_StillReturnsErrNotFound guards against a
+// regression where the mangling UPDATE's "WHERE deleted_at IS NULL" clause
+// might accidentally be dropped, which would let a double-delete silently
+// re-mangle an already-tombstoned name a second time instead of returning
+// ErrNotFound.
+func TestDeleteModel_AlreadyDeleted_StillReturnsErrNotFound(t *testing.T) {
+	t.Parallel()
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	m := mustCreateModel(t, d, "already-deleted-model")
+	if err := d.DeleteModel(ctx, m.ID); err != nil {
+		t.Fatalf("first DeleteModel(): %v", err)
+	}
+	nameAfterFirstDelete := rawColumnValue(t, d, "models", "name", m.ID)
+
+	err := d.DeleteModel(ctx, m.ID)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("second DeleteModel() error = %v, want ErrNotFound", err)
+	}
+
+	nameAfterSecondAttempt := rawColumnValue(t, d, "models", "name", m.ID)
+	if nameAfterSecondAttempt != nameAfterFirstDelete {
+		t.Errorf("name changed after a no-op double delete: %q -> %q, want unchanged", nameAfterFirstDelete, nameAfterSecondAttempt)
+	}
+}

--- a/internal/db/teams.go
+++ b/internal/db/teams.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -269,6 +270,7 @@ func (d *DB) UpdateTeam(ctx context.Context, id string, params UpdateTeamParams)
 // column is mangled with a tombstone suffix so its value is freed for reuse
 // immediately; see StripTombstone and #172.
 // It returns ErrNotFound if the team does not exist or is already deleted.
+// It returns ErrConflict when a legacy row occupies the tombstone value; rename that row to resolve.
 func (d *DB) DeleteTeam(ctx context.Context, id string) error {
 	p := d.dialect.Placeholder
 	query := "UPDATE teams SET slug = slug || ':deleted:' || id, " +
@@ -277,7 +279,11 @@ func (d *DB) DeleteTeam(ctx context.Context, id string) error {
 
 	result, err := d.sql.ExecContext(ctx, query, id)
 	if err != nil {
-		return fmt.Errorf("DeleteTeam %s: %w", id, translateError(err))
+		translated := translateError(err)
+		if errors.Is(translated, ErrConflict) {
+			return fmt.Errorf("DeleteTeam %s: legacy row occupies tombstone value: %w", id, ErrConflict)
+		}
+		return fmt.Errorf("DeleteTeam %s: %w", id, translated)
 	}
 
 	n, err := result.RowsAffected()

--- a/internal/db/teams.go
+++ b/internal/db/teams.go
@@ -55,7 +55,13 @@ type UpdateTeamParams struct {
 
 // CreateTeam inserts a new team and returns the persisted record.
 // It returns ErrConflict if the (org_id, slug) pair is already taken.
+// It returns ErrReservedValue if the slug contains the reserved soft-delete
+// tombstone marker (see tombstone.go).
 func (d *DB) CreateTeam(ctx context.Context, params CreateTeamParams) (*Team, error) {
+	if ContainsTombstoneMarker(params.Slug) {
+		return nil, fmt.Errorf("create team: %w", ErrReservedValue)
+	}
+
 	id, err := uuid.NewV7()
 	if err != nil {
 		return nil, fmt.Errorf("create team: generate id: %w", err)
@@ -189,8 +195,14 @@ func (d *DB) ListTeams(ctx context.Context, orgID string, cursor string, limit i
 // Only non-nil fields in params are written. If all fields are nil the record
 // is returned unchanged without issuing an UPDATE.
 // It returns ErrNotFound if the team does not exist or has been soft-deleted,
-// and ErrConflict if the new slug collides with an existing one in the same org.
+// ErrConflict if the new slug collides with an existing one in the same org,
+// and ErrReservedValue if the new slug contains the reserved soft-delete
+// tombstone marker (see tombstone.go).
 func (d *DB) UpdateTeam(ctx context.Context, id string, params UpdateTeamParams) (*Team, error) {
+	if params.Slug != nil && ContainsTombstoneMarker(*params.Slug) {
+		return nil, fmt.Errorf("UpdateTeam %s: %w", id, ErrReservedValue)
+	}
+
 	p := d.dialect.Placeholder
 	argN := 1
 	var setClauses []string

--- a/internal/db/teams.go
+++ b/internal/db/teams.go
@@ -265,11 +265,14 @@ func (d *DB) UpdateTeam(ctx context.Context, id string, params UpdateTeamParams)
 	return team, nil
 }
 
-// DeleteTeam soft-deletes an active team by setting deleted_at.
+// DeleteTeam soft-deletes an active team by setting deleted_at. The slug
+// column is mangled with a tombstone suffix so its value is freed for reuse
+// immediately; see StripTombstone and #172.
 // It returns ErrNotFound if the team does not exist or is already deleted.
 func (d *DB) DeleteTeam(ctx context.Context, id string) error {
 	p := d.dialect.Placeholder
-	query := "UPDATE teams SET deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP " +
+	query := "UPDATE teams SET slug = slug || ':deleted:' || id, " +
+		"deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP " +
 		"WHERE id = " + p(1) + " AND deleted_at IS NULL"
 
 	result, err := d.sql.ExecContext(ctx, query, id)

--- a/internal/db/tombstone.go
+++ b/internal/db/tombstone.go
@@ -1,0 +1,32 @@
+package db
+
+import "strings"
+
+// tombstoneMarker is appended to a unique column's value at soft-delete time,
+// suffixed with the row's own id, so the original value becomes immediately
+// available for re-use while the deleted row still occupies its unique
+// constraint slot. See #172.
+const tombstoneMarker = ":deleted:"
+
+// StripTombstone removes a tombstone suffix previously applied at soft-delete
+// time, returning the original value. It is display-only: callers that render
+// soft-deleted rows to admins (e.g. include_deleted listings) should run the
+// stored value through StripTombstone before returning it, so the response
+// shows the value the row had before deletion rather than the mangled one. If
+// value does not end with exactly tombstoneMarker+id, value is returned
+// unchanged.
+func StripTombstone(value, id string) string {
+	suffix := tombstoneMarker + id
+	if strings.HasSuffix(value, suffix) {
+		return strings.TrimSuffix(value, suffix)
+	}
+	return value
+}
+
+// ContainsTombstoneMarker reports whether s contains the tombstone marker
+// anywhere. Input validation on unique columns (model/deployment names, user
+// emails) must reject values containing the marker so a live row can never
+// collide with, or be mistaken for, a tombstoned one.
+func ContainsTombstoneMarker(s string) bool {
+	return strings.Contains(s, tombstoneMarker)
+}

--- a/internal/db/tombstone_test.go
+++ b/internal/db/tombstone_test.go
@@ -1,0 +1,152 @@
+package db
+
+import "testing"
+
+// ---- StripTombstone -----------------------------------------------------
+
+func TestStripTombstone(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		id    string
+		want  string
+	}{
+		{
+			name:  "value with matching tombstone suffix is stripped",
+			value: "gpt-4:deleted:0198c9a2-1111-7000-8000-000000000001",
+			id:    "0198c9a2-1111-7000-8000-000000000001",
+			want:  "gpt-4",
+		},
+		{
+			name:  "value ending in a different id's tombstone is left unchanged",
+			value: "gpt-4:deleted:0198c9a2-1111-7000-8000-000000000001",
+			id:    "0198c9a2-2222-7000-8000-000000000002",
+			want:  "gpt-4:deleted:0198c9a2-1111-7000-8000-000000000001",
+		},
+		{
+			name:  "value containing the marker mid-string but not as a suffix for this id is unchanged",
+			value: "gpt-4:deleted:not-the-id:extra",
+			id:    "not-the-id",
+			want:  "gpt-4:deleted:not-the-id:extra",
+		},
+		{
+			name:  "value with no tombstone marker at all is unchanged",
+			value: "gpt-4",
+			id:    "0198c9a2-1111-7000-8000-000000000001",
+			want:  "gpt-4",
+		},
+		{
+			name:  "value equal to just the suffix strips to empty string",
+			value: ":deleted:0198c9a2-1111-7000-8000-000000000001",
+			id:    "0198c9a2-1111-7000-8000-000000000001",
+			want:  "",
+		},
+		{
+			name:  "empty value with non-empty id is unchanged",
+			value: "",
+			id:    "0198c9a2-1111-7000-8000-000000000001",
+			want:  "",
+		},
+		{
+			name:  "empty value with empty id: suffix is just the marker, still no match against empty value",
+			value: "",
+			id:    "",
+			want:  "",
+		},
+		{
+			name:  "value equal to the marker+empty-id suffix strips to empty string",
+			value: ":deleted:",
+			id:    "",
+			want:  "",
+		},
+		{
+			name:  "original value happens to contain a colon but not the marker is unchanged",
+			value: "team:engineering",
+			id:    "0198c9a2-1111-7000-8000-000000000001",
+			want:  "team:engineering",
+		},
+		{
+			name:  "email-shaped value with matching tombstone suffix is stripped",
+			value: "alice@example.com:deleted:0198c9a2-3333-7000-8000-000000000003",
+			id:    "0198c9a2-3333-7000-8000-000000000003",
+			want:  "alice@example.com",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := StripTombstone(tc.value, tc.id)
+			if got != tc.want {
+				t.Errorf("StripTombstone(%q, %q) = %q, want %q", tc.value, tc.id, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---- ContainsTombstoneMarker ---------------------------------------------
+
+func TestContainsTombstoneMarker(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{
+			name:  "value with the marker in a delete-shaped suffix",
+			value: "gpt-4:deleted:0198c9a2-1111-7000-8000-000000000001",
+			want:  true,
+		},
+		{
+			name:  "value with the marker anywhere in the middle",
+			value: "prefix:deleted:suffix",
+			want:  true,
+		},
+		{
+			name:  "value with just the marker itself",
+			value: ":deleted:",
+			want:  true,
+		},
+		{
+			name:  "value with no marker at all",
+			value: "gpt-4",
+			want:  false,
+		},
+		{
+			name:  "value containing a colon but not the full marker",
+			value: "team:engineering",
+			want:  false,
+		},
+		{
+			name:  "empty value",
+			value: "",
+			want:  false,
+		},
+		{
+			name:  "value containing 'deleted' without surrounding colons",
+			value: "deleted-model",
+			want:  false,
+		},
+		{
+			name:  "email containing the marker",
+			value: "alice:deleted:123@example.com",
+			want:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := ContainsTombstoneMarker(tc.value)
+			if got != tc.want {
+				t.Errorf("ContainsTombstoneMarker(%q) = %v, want %v", tc.value, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -55,8 +55,14 @@ type UpdateUserParams struct {
 
 // CreateUser inserts a new user and returns the persisted record.
 // It returns ErrConflict if the email is already taken.
+// It returns ErrReservedValue if the email contains the reserved soft-delete
+// tombstone marker (see tombstone.go).
 // If params.AuthProvider is empty, "local" is used.
 func (d *DB) CreateUser(ctx context.Context, params CreateUserParams) (*User, error) {
+	if ContainsTombstoneMarker(params.Email) {
+		return nil, fmt.Errorf("create user: %w", ErrReservedValue)
+	}
+
 	id, err := uuid.NewV7()
 	if err != nil {
 		return nil, fmt.Errorf("create user: generate id: %w", err)
@@ -118,7 +124,13 @@ func (d *DB) CreateUser(ctx context.Context, params CreateUserParams) (*User, er
 // Returns ErrForeignKey if orgID does not reference an existing organization,
 // allowing callers to map this to a 400 "organization not found" response
 // without an additional pre-flight SELECT.
+// Returns ErrReservedValue if the email contains the reserved soft-delete
+// tombstone marker (see tombstone.go).
 func (d *DB) CreateUserWithMembership(ctx context.Context, userParams CreateUserParams, orgID, role string) (*User, error) {
+	if ContainsTombstoneMarker(userParams.Email) {
+		return nil, fmt.Errorf("create user with membership: %w", ErrReservedValue)
+	}
+
 	userID, err := uuid.NewV7()
 	if err != nil {
 		return nil, fmt.Errorf("create user with membership: generate user id: %w", err)
@@ -293,8 +305,14 @@ func (d *DB) ListUsers(ctx context.Context, cursor string, limit int, includeDel
 // Only non-nil fields in params are written. If all fields are nil the record
 // is returned unchanged without issuing an UPDATE.
 // It returns ErrNotFound if the user does not exist or has been soft-deleted,
-// and ErrConflict if the new email collides with an existing one.
+// ErrConflict if the new email collides with an existing one, and
+// ErrReservedValue if the new email contains the reserved soft-delete
+// tombstone marker (see tombstone.go).
 func (d *DB) UpdateUser(ctx context.Context, id string, params UpdateUserParams) (*User, error) {
+	if params.Email != nil && ContainsTombstoneMarker(*params.Email) {
+		return nil, fmt.Errorf("UpdateUser %s: %w", id, ErrReservedValue)
+	}
+
 	p := d.dialect.Placeholder
 	argN := 1
 	var setClauses []string

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -364,11 +364,14 @@ func (d *DB) UpdateUser(ctx context.Context, id string, params UpdateUserParams)
 	return user, nil
 }
 
-// DeleteUser soft-deletes an active user by setting deleted_at.
+// DeleteUser soft-deletes an active user by setting deleted_at. The email
+// column is mangled with a tombstone suffix so its value is freed for reuse
+// immediately; see StripTombstone and #172.
 // It returns ErrNotFound if the user does not exist or is already deleted.
 func (d *DB) DeleteUser(ctx context.Context, id string) error {
 	p := d.dialect.Placeholder
-	query := "UPDATE users SET deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP " +
+	query := "UPDATE users SET email = email || ':deleted:' || id, " +
+		"deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP " +
 		"WHERE id = " + p(1) + " AND deleted_at IS NULL"
 
 	result, err := d.sql.ExecContext(ctx, query, id)

--- a/internal/db/users.go
+++ b/internal/db/users.go
@@ -368,6 +368,7 @@ func (d *DB) UpdateUser(ctx context.Context, id string, params UpdateUserParams)
 // column is mangled with a tombstone suffix so its value is freed for reuse
 // immediately; see StripTombstone and #172.
 // It returns ErrNotFound if the user does not exist or is already deleted.
+// It returns ErrConflict when a legacy row occupies the tombstone value; rename that row to resolve.
 func (d *DB) DeleteUser(ctx context.Context, id string) error {
 	p := d.dialect.Placeholder
 	query := "UPDATE users SET email = email || ':deleted:' || id, " +
@@ -376,7 +377,11 @@ func (d *DB) DeleteUser(ctx context.Context, id string) error {
 
 	result, err := d.sql.ExecContext(ctx, query, id)
 	if err != nil {
-		return fmt.Errorf("DeleteUser %s: %w", id, translateError(err))
+		translated := translateError(err)
+		if errors.Is(translated, ErrConflict) {
+			return fmt.Errorf("DeleteUser %s: legacy row occupies tombstone value: %w", id, ErrConflict)
+		}
+		return fmt.Errorf("DeleteUser %s: %w", id, translated)
 	}
 
 	n, err := result.RowsAffected()


### PR DESCRIPTION
Closes #172.

Soft-deleted rows kept their UNIQUE column values, so re-creating a model with a previously used name failed with 409. The reporter's diagnosis was exactly right. The same trap existed for user emails, org slugs, team slugs, deployment names, and the OIDC identity index - deleting a user and re-inviting the same email, or deleting an SSO user and having them log in again, failed the same way.

## Fix
Soft-deleting now appends `:deleted:<row-id>` to the constrained column in the same UPDATE, freeing the original value immediately. The row id makes the tombstone unique by construction, and the original value is recoverable by stripping the exact suffix. A schema-level fix (partial unique indexes) is not portably possible here: the constraints are inline, and SQLite cannot drop those without a table rebuild that our transactional, dual-dialect migration runner cannot perform safely with `foreign_keys=ON`. The one place where the constraint is a *named* index (`idx_users_external` for OIDC identities) gets the proper fix: rebuilt with `AND deleted_at IS NULL`.

- **Migration 0015** applies the same tombstone to rows deleted before the fix, so existing installations are unblocked too. Collision-guarded so a pathological legacy value can never abort the migration (and with it, startup).
- **Runtime**: the five `Delete*` functions mangle atomically; a legacy collision maps to `ErrConflict`/409 with an actionable message instead of a 500.
- **The marker is reserved** at the store layer (single choke point, covers YAML sync and OIDC provisioning, not just the admin API), in yaml config validation at startup, and in the admin handlers for friendlier 400s.
- **Admin `include_deleted` listings** strip the suffix for display, so system admins see the original value; the DB row keeps the honest mangled state.
- `model_aliases` reference models by *name*, so an alias now follows a same-named re-created model. That is the intended semantic of name-based aliases and is left unchanged.

## Proof
The exact repro from #172, run against a locally built binary on a fresh SQLite DB:

```
1. POST /api/v1/models {"name":"antony-test",...}  -> 201
2. DELETE /api/v1/models/<id>                      -> 204
3. GET /api/v1/models: name no longer listed       -> ok
5. POST same name again                            -> 201  (was: 409)
   Guard: name containing ":deleted:"              -> 400

DB afterwards:
  'antony-test:deleted:019f9051-b9fd-...'  deleted=True
  'antony-test'                            deleted=False
```

43 new tests: the repro as a regression test for all five entities, OIDC identity reuse, double-delete, tombstone helper semantics, migration 0015 against seeded legacy rows (executing the real up.sql read from disk, so the test cannot drift from the migration), include_deleted stripping, marker rejection on every write path, and the legacy-collision 409. Full suite and `-race` on internal/db green. Four external review rounds; the last found nothing.