### PR TITLE
docs: document logging configuration and how to enable debug logs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -320,6 +320,20 @@ settings:
     half_open_max: 1         # Probe requests in half-open state
 ```
 
+## Logging
+
+Controls log output level and format.
+
+```yaml
+logging:
+  level: info               # debug, info, warn, error (default: info)
+  format: json              # json (default) or text (local dev)
+```
+
+- `level: debug` additionally records the source file and line of each log call.
+- `${ENV_VAR}` interpolation works here like everywhere in the config, e.g. `level: ${VOIDLLM_LOG_LEVEL:-info}`.
+- No log level, including `debug`, ever logs prompt or response content - VoidLLM never logs request or response bodies by design. Only metadata (token counts, durations, model names) appears in logs.
+
 ---
 
 ## Enterprise Features

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -332,7 +332,7 @@ logging:
 
 - `level: debug` additionally records the source file and line of each log call.
 - `${ENV_VAR}` interpolation works here like everywhere in the config, e.g. `level: ${VOIDLLM_LOG_LEVEL:-info}`.
-- No log level, including `debug`, ever logs prompt or response content - VoidLLM never logs request or response bodies by design. Only metadata (token counts, durations, model names) appears in logs.
+- LLM prompts, responses, and detected PII values never appear in logs at any level, including `debug` - by design, not configuration. Only metadata (token counts, durations, model names) is logged. Error messages returned by configured upstream services (for example an MCP server's error text) can appear in logs.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -112,6 +112,16 @@ VoidLLM does not support the pre-2025-03-26 SSE MCP transport. The upstream serv
 - Check for large request/response bodies (VoidLLM buffers bodies in memory during proxying)
 - If using Code Mode, reduce `pool_size` to limit WASM runtime memory
 
+## Logging
+
+### How do I enable debug logs?
+Set the log level in `voidllm.yaml`:
+```yaml
+logging:
+  level: debug
+```
+Debug also records the source file and line of each log call and is noticeably more verbose - switch back to `info` in production. No log level, including debug, ever includes prompt or response content.
+
 ## Getting Help
 
 - [GitHub Issues](https://github.com/voidmind-io/voidllm/issues) - bug reports and feature requests

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -120,7 +120,7 @@ Set the log level in `voidllm.yaml`:
 logging:
   level: debug
 ```
-Debug also records the source file and line of each log call and is noticeably more verbose - switch back to `info` in production. No log level, including debug, ever includes prompt or response content.
+Debug also records the source file and line of each log call and is noticeably more verbose - switch back to `info` in production. LLM prompts, responses, and detected PII values never appear in logs at any level, including debug - by design, not configuration. Note that error messages returned by configured upstream services (for example an MCP server's error text) can appear in logs.
 
 ## Getting Help
 


### PR DESCRIPTION
The `logging.level` and `logging.format` settings have existed since v0.0.1 but were documented nowhere - the reporter of #172 explicitly could not find how to enable debug logs.

- **docs/configuration.md**: new Logging section (level, format, defaults, debug source positions, env interpolation)
- **docs/troubleshooting.md**: "How do I enable debug logs?" entry

Every documented claim was verified against the code and against a live binary: `level: debug` produces DEBUG records with `source=file:line`, `format: text` switches off JSON, `${VOIDLLM_LOG_LEVEL:-debug}` interpolation and env override behave as described, and `info` suppresses DEBUG records.

Review surfaced one wording issue that got fixed in the second commit: the no-content-logging guarantee is stated precisely - it covers LLM prompts, responses and detected PII values (mechanically verified), while error messages from configured upstream services can appear in logs. The underlying code observation behind that caveat is tracked internally.