### PR TITLE
chore: release 0.0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to VoidLLM are documented in this file.
 
+## [0.0.24] - 2026-07-24
+
+### Fixes
+- Deleting a model, user, organization, team, or deployment frees its name, email, or slug for immediate re-use. Previously the soft-deleted row kept the unique value, so re-creating a model with a previously used name failed with 409 - and re-inviting a deleted user's email or re-provisioning a deleted SSO identity failed the same way. The migration also unblocks values held by rows deleted before the fix, so existing installations need no manual cleanup (#173)
+
+### Security
+- Dependency updates addressing security advisories in the Go standard library extensions, the gRPC client, and the frontend router (#174, #175, #176)
+
+### Documentation
+- The logging configuration (level and format) is now documented, including how to enable debug logs and what the debug level adds. The no-content-logging guarantee is stated precisely: LLM prompts, responses, and detected PII values never appear in logs at any level (#177)
+
+---
+
 ## [0.0.23] - 2026-07-21
 
 ### Fixes

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 COPY --from=ui-builder /app/ui/dist ./ui/dist
-ARG VERSION=0.0.23
+ARG VERSION=0.0.24
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -ldflags="-s -w -X 'github.com/voidmind-io/voidllm/internal/api/health.Version=${VERSION}'" \
     -o /voidllm ./cmd/voidllm

--- a/chart/voidllm/Chart.yaml
+++ b/chart/voidllm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: voidllm
 description: Privacy-first LLM proxy and AI gateway with load balancing, RBAC, MCP gateway, and built-in admin UI. Self-hosted, single binary, sub-500us overhead.
 type: application
-version: 0.0.23
-appVersion: "0.0.23"
+version: 0.0.24
+appVersion: "0.0.24"
 home: https://voidllm.ai
 icon: https://voidllm.ai/logo.svg
 sources:

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -89,5 +89,5 @@ The Docker image sets `VOIDLLM_DATABASE_DSN=/data/voidllm.db` by default. Overri
 
 ```bash
 curl http://localhost:8080/healthz
-# {"status":"ok","uptime_seconds":42,"version":"0.0.23"}
+# {"status":"ok","uptime_seconds":42,"version":"0.0.24"}
 ```


### PR DESCRIPTION
Version bump for 0.0.24: CHANGELOG, Dockerfile `ARG VERSION`, Helm chart `version`/`appVersion`, and the `/healthz` example in the Docker deployment guide.

The release story is #172: a user-reported bug (soft-deleted rows blocking their unique names forever), diagnosed by the reporter, fixed with a migration that also unblocks existing installations. Plus dependency updates addressing security advisories and the previously undocumented logging configuration.