### PR TITLE
fix(proxy): fail over on upstream 429 instead of counting it as success

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -31,6 +31,7 @@ import (
 	"github.com/voidmind-io/voidllm/internal/cache"
 	"github.com/voidmind-io/voidllm/internal/circuitbreaker"
 	"github.com/voidmind-io/voidllm/internal/config"
+	"github.com/voidmind-io/voidllm/internal/cooldown"
 	"github.com/voidmind-io/voidllm/internal/db"
 	"github.com/voidmind-io/voidllm/internal/docs"
 	"github.com/voidmind-io/voidllm/internal/health"
@@ -609,6 +610,13 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 		)
 	}
 
+	// cdRegistry tracks deployments that returned HTTP 429 so the router can
+	// deprioritize them for a short window. Unlike cbRegistry it has no
+	// enable/disable setting — it is always created; a 429 must never be
+	// treated as a circuit-breaker failure regardless of whether circuit
+	// breaking itself is enabled.
+	cdRegistry := cooldown.NewRegistry()
+
 	// OTel tracing: initialise only when the feature is licensed and enabled.
 	var otelShutdownFn func(context.Context) error
 	var tracer trace.Tracer
@@ -662,15 +670,16 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 		)
 	}
 
-	// Create the deployment router for load balancing. Both dependencies are
-	// optional: healthChecker may be nil when health probes are disabled, and
-	// cbRegistry may be nil when circuit breaking is disabled.
-	modelRouter := router.NewRouter(healthChecker, cbRegistry)
+	// Create the deployment router for load balancing. healthChecker and
+	// cbRegistry are optional and may be nil when the corresponding feature is
+	// disabled; cdRegistry is always non-nil (see above).
+	modelRouter := router.NewRouter(healthChecker, cbRegistry, cdRegistry)
 
 	proxyHandler := proxy.NewProxyHandler(registry, log)
 	proxyHandler.AccessCache = accessCache
 	proxyHandler.AliasCache = aliasCache
 	proxyHandler.CircuitBreakers = cbRegistry
+	proxyHandler.Cooldowns = cdRegistry
 	proxyHandler.Router = modelRouter
 	proxyHandler.UsageLogger = usageLogger
 	proxyHandler.RateLimiter = rateLimiter

--- a/internal/circuitbreaker/breaker.go
+++ b/internal/circuitbreaker/breaker.go
@@ -172,6 +172,33 @@ func (b *Breaker) RecordFailure() {
 	}
 }
 
+// RecordNeutral records an outcome that is neither a success nor a failure —
+// for example an upstream HTTP 429 (rate limit), which means the deployment
+// is healthy but temporarily throttled and must not be treated as evidence
+// of either recovery or breakage. Recording it as a success would erase real
+// accumulated failures via RecordSuccess's counter reset; recording it as a
+// failure would mis-trip the breaker for an upstream that isn't actually
+// broken. Callers use this instead of RecordSuccess/RecordFailure whenever
+// they decide an outcome is circuit-breaker-neutral.
+//
+//   - HalfOpen: Allow already reserved one of the halfOpenMax probe slots for
+//     this request (see Allow). Since this call reports no verdict, that
+//     reservation must still be released so a future request can probe again
+//     — otherwise halfOpenActive would stay elevated forever and the breaker
+//     would lock itself out of ever leaving HalfOpen. The state, failure
+//     counter, and lastFailure timestamp are left untouched: the breaker
+//     stays HalfOpen awaiting a real success or failure.
+//   - Closed and Open: no-op. Closed has no probe reservation to release, and
+//     Open rejects requests before Allow ever admits one.
+func (b *Breaker) RecordNeutral() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.state == HalfOpen && b.halfOpenActive > 0 {
+		b.halfOpenActive--
+	}
+}
+
 // CurrentState returns the current circuit state. It is safe to call from
 // multiple goroutines.
 func (b *Breaker) CurrentState() State {

--- a/internal/circuitbreaker/breaker.go
+++ b/internal/circuitbreaker/breaker.go
@@ -83,6 +83,18 @@ func NewBreaker(cfg Config) *Breaker {
 
 // Allow reports whether a request should be allowed to proceed to the upstream.
 //
+// Allow is not a pure predicate: a true return always reserves something — a
+// HalfOpen probe slot, or (from Open) the transition into HalfOpen plus its
+// first probe slot — that only RecordSuccess, RecordFailure, or RecordNeutral
+// releases. Every call to Allow that returns true MUST be balanced by exactly
+// one call to one of those three methods, even if the caller ends up not
+// using the request for any reason (e.g. it fails to build, or the caller
+// decides not to send it). Failing to balance a reservation leaves it stuck
+// forever, which permanently starves the breaker of probes once
+// halfOpenActive reaches halfOpenMax — the circuit can then never leave
+// HalfOpen. Callers that only need to inspect whether Allow would currently
+// admit a request, without reserving anything, must use Permits instead.
+//
 //   - Closed: always returns true.
 //   - Open: checks if the recovery timeout has elapsed; if so, transitions to
 //     HalfOpen and counts this request against halfOpenMax, returning true.
@@ -114,6 +126,36 @@ func (b *Breaker) Allow() bool {
 		b.halfOpenActive++
 		return true
 
+	default:
+		return true
+	}
+}
+
+// Permits reports whether Allow would currently admit a request, WITHOUT
+// transitioning state or reserving a probe slot. It exists for candidate
+// *selection* — for example a router inspecting many deployments to decide
+// which ones are worth ordering into the retry list, when most of those
+// candidates will never actually be attempted. Because it reserves nothing,
+// Permits must never be used as the gate for actually issuing a request:
+// only Allow may do that (see Allow's godoc for the reservation-balance
+// contract that gate carries).
+//
+//   - Closed: always returns true.
+//   - Open: returns true only if the recovery timeout has elapsed — i.e. the
+//     same condition under which Allow would transition to HalfOpen.
+//   - HalfOpen: returns true only if fewer than halfOpenMax probes are
+//     currently active.
+func (b *Breaker) Permits() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	switch b.state {
+	case Closed:
+		return true
+	case Open:
+		return time.Since(b.lastFailure) >= b.timeout
+	case HalfOpen:
+		return b.halfOpenActive < b.halfOpenMax
 	default:
 		return true
 	}

--- a/internal/circuitbreaker/breaker_test.go
+++ b/internal/circuitbreaker/breaker_test.go
@@ -1,0 +1,376 @@
+package circuitbreaker_test
+
+// breaker_test.go is the first test file for internal/circuitbreaker. It
+// covers the classic Closed -> Open -> HalfOpen -> Closed state machine and,
+// in particular, RecordNeutral: an outcome (e.g. an upstream HTTP 429) that
+// must neither trip nor heal the breaker but, while HalfOpen, must still
+// release the probe-slot reservation Allow() took for the request so a
+// future request can probe again. Without that release, halfOpenActive stays
+// elevated forever and the breaker locks itself out of ever leaving
+// HalfOpen — Allow() returns false permanently.
+//
+// Only the exported API (plus CurrentState, which is exported for exactly
+// this purpose) is used, so this file lives in the black-box
+// circuitbreaker_test package rather than reaching into unexported fields.
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/voidmind-io/voidllm/internal/circuitbreaker"
+)
+
+// ── Basic state machine (context for the RecordNeutral fix) ─────────────────
+
+// TestAllow_Closed_AlwaysTrue verifies that a freshly constructed breaker
+// starts Closed and admits every request.
+func TestAllow_Closed_AlwaysTrue(t *testing.T) {
+	t.Parallel()
+
+	b := circuitbreaker.NewBreaker(circuitbreaker.Config{
+		Threshold:   3,
+		Timeout:     time.Minute,
+		HalfOpenMax: 1,
+	})
+
+	for i := 0; i < 5; i++ {
+		if !b.Allow() {
+			t.Fatalf("Allow() call %d = false, want true (Closed state)", i)
+		}
+	}
+	if state := b.CurrentState(); state != circuitbreaker.Closed {
+		t.Errorf("CurrentState() = %v, want Closed", state)
+	}
+}
+
+// TestRecordFailure_Closed_TripsAtExactThreshold verifies that the breaker
+// opens exactly when the consecutive-failure count reaches Threshold, not
+// before and not after.
+func TestRecordFailure_Closed_TripsAtExactThreshold(t *testing.T) {
+	t.Parallel()
+
+	const threshold = 3
+	b := circuitbreaker.NewBreaker(circuitbreaker.Config{
+		Threshold:   threshold,
+		Timeout:     time.Minute,
+		HalfOpenMax: 1,
+	})
+
+	for i := 1; i < threshold; i++ {
+		b.RecordFailure()
+		if state := b.CurrentState(); state != circuitbreaker.Closed {
+			t.Fatalf("CurrentState() after %d/%d failures = %v, want Closed", i, threshold, state)
+		}
+	}
+	b.RecordFailure() // the threshold-th failure
+	if state := b.CurrentState(); state != circuitbreaker.Open {
+		t.Fatalf("CurrentState() after %d/%d failures = %v, want Open", threshold, threshold, state)
+	}
+}
+
+// TestAllow_Open_BlocksUntilTimeout verifies that Allow() rejects requests
+// while Open and admits exactly one probe once Timeout has elapsed,
+// transitioning to HalfOpen.
+func TestAllow_Open_BlocksUntilTimeout(t *testing.T) {
+	t.Parallel()
+
+	const timeout = 20 * time.Millisecond
+	b := circuitbreaker.NewBreaker(circuitbreaker.Config{
+		Threshold:   1,
+		Timeout:     timeout,
+		HalfOpenMax: 1,
+	})
+
+	b.RecordFailure() // trips at threshold 1
+	if state := b.CurrentState(); state != circuitbreaker.Open {
+		t.Fatalf("setup: CurrentState() = %v, want Open", state)
+	}
+	if b.Allow() {
+		t.Error("Allow() immediately after trip = true, want false (still within Timeout)")
+	}
+
+	time.Sleep(timeout + 15*time.Millisecond)
+
+	if !b.Allow() {
+		t.Fatal("Allow() after Timeout elapsed = false, want true (transition to HalfOpen)")
+	}
+	if state := b.CurrentState(); state != circuitbreaker.HalfOpen {
+		t.Errorf("CurrentState() after post-timeout Allow() = %v, want HalfOpen", state)
+	}
+}
+
+// TestRecordSuccess_HalfOpen_ClosesAndResetsFailures verifies that a success
+// while HalfOpen closes the circuit.
+func TestRecordSuccess_HalfOpen_ClosesAndResetsFailures(t *testing.T) {
+	t.Parallel()
+
+	b := circuitbreaker.NewBreaker(circuitbreaker.Config{
+		Threshold:   1,
+		Timeout:     10 * time.Millisecond,
+		HalfOpenMax: 1,
+	})
+
+	b.RecordFailure()
+	time.Sleep(25 * time.Millisecond)
+	if !b.Allow() {
+		t.Fatal("setup: Allow() did not admit the HalfOpen probe")
+	}
+
+	b.RecordSuccess()
+	if state := b.CurrentState(); state != circuitbreaker.Closed {
+		t.Errorf("CurrentState() after HalfOpen success = %v, want Closed", state)
+	}
+}
+
+// TestRecordFailure_HalfOpen_ReopensImmediately verifies that a failed probe
+// while HalfOpen reopens the circuit regardless of Threshold.
+func TestRecordFailure_HalfOpen_ReopensImmediately(t *testing.T) {
+	t.Parallel()
+
+	b := circuitbreaker.NewBreaker(circuitbreaker.Config{
+		Threshold:   5, // large threshold — a single HalfOpen failure must still reopen
+		Timeout:     10 * time.Millisecond,
+		HalfOpenMax: 1,
+	})
+
+	b.RecordFailure()
+	b.RecordFailure()
+	b.RecordFailure()
+	b.RecordFailure()
+	b.RecordFailure() // reaches threshold 5, trips Open
+	if state := b.CurrentState(); state != circuitbreaker.Open {
+		t.Fatalf("setup: CurrentState() = %v, want Open", state)
+	}
+
+	time.Sleep(25 * time.Millisecond)
+	if !b.Allow() {
+		t.Fatal("setup: Allow() did not admit the HalfOpen probe")
+	}
+
+	b.RecordFailure()
+	if state := b.CurrentState(); state != circuitbreaker.Open {
+		t.Errorf("CurrentState() after HalfOpen failure = %v, want Open (immediate reopen, ignoring Threshold)", state)
+	}
+}
+
+// ── RecordNeutral ─────────────────────────────────────────────────────────
+
+// TestRecordNeutral_Closed_IsNoOp verifies that RecordNeutral in Closed
+// state neither changes state nor touches the failure counter: a subsequent
+// threshold-worth of RecordFailure calls still trips the breaker at exactly
+// Threshold, proving the counter was untouched by the intervening neutral
+// calls.
+func TestRecordNeutral_Closed_IsNoOp(t *testing.T) {
+	t.Parallel()
+
+	const threshold = 3
+	b := circuitbreaker.NewBreaker(circuitbreaker.Config{
+		Threshold:   threshold,
+		Timeout:     time.Minute,
+		HalfOpenMax: 1,
+	})
+
+	// Interleave neutral calls with failures below the threshold: if
+	// RecordNeutral incremented or reset the counter, this loop would trip
+	// the breaker early or never.
+	for i := 1; i < threshold; i++ {
+		b.RecordNeutral()
+		b.RecordFailure()
+		b.RecordNeutral()
+		if state := b.CurrentState(); state != circuitbreaker.Closed {
+			t.Fatalf("CurrentState() after %d/%d failures (with interleaved neutrals) = %v, want Closed", i, threshold, state)
+		}
+	}
+
+	b.RecordNeutral()
+	b.RecordFailure() // the threshold-th failure
+	if state := b.CurrentState(); state != circuitbreaker.Open {
+		t.Errorf("CurrentState() after reaching threshold = %v, want Open (RecordNeutral must not have touched the failure counter)", state)
+	}
+}
+
+// TestRecordNeutral_Open_StaysOpenAndBlocked verifies that RecordNeutral in
+// Open state is a no-op: the circuit stays Open and Allow() keeps returning
+// false until Timeout elapses, exactly as if RecordNeutral had never been
+// called.
+func TestRecordNeutral_Open_StaysOpenAndBlocked(t *testing.T) {
+	t.Parallel()
+
+	const timeout = 200 * time.Millisecond
+	b := circuitbreaker.NewBreaker(circuitbreaker.Config{
+		Threshold:   1,
+		Timeout:     timeout,
+		HalfOpenMax: 1,
+	})
+
+	b.RecordFailure() // trips at threshold 1
+	if state := b.CurrentState(); state != circuitbreaker.Open {
+		t.Fatalf("setup: CurrentState() = %v, want Open", state)
+	}
+
+	for i := 0; i < 5; i++ {
+		b.RecordNeutral()
+	}
+
+	if state := b.CurrentState(); state != circuitbreaker.Open {
+		t.Errorf("CurrentState() after RecordNeutral x5 in Open = %v, want Open", state)
+	}
+	if b.Allow() {
+		t.Error("Allow() before Timeout elapsed (after RecordNeutral calls) = true, want false")
+	}
+}
+
+// TestRecordNeutral_HalfOpen_ReleasesProbeReservation is the regression case
+// for the fix: without RecordNeutral releasing the probe slot Allow() took,
+// a HalfOpen breaker with HalfOpenMax=1 would lock itself out of ever
+// probing again once a single neutral (e.g. 429) outcome was recorded —
+// Allow() would return false forever. With the fix, RecordNeutral releases
+// the reservation and a subsequent Allow() succeeds.
+func TestRecordNeutral_HalfOpen_ReleasesProbeReservation(t *testing.T) {
+	t.Parallel()
+
+	const timeout = 10 * time.Millisecond
+	b := circuitbreaker.NewBreaker(circuitbreaker.Config{
+		Threshold:   1,
+		Timeout:     timeout,
+		HalfOpenMax: 1,
+	})
+
+	// Trip the breaker.
+	b.RecordFailure()
+	if state := b.CurrentState(); state != circuitbreaker.Open {
+		t.Fatalf("setup: CurrentState() = %v, want Open", state)
+	}
+
+	// Wait past Timeout so the circuit is eligible to transition to
+	// HalfOpen. A real sleep is used deliberately: this package has no
+	// injectable clock.
+	time.Sleep(timeout + 15*time.Millisecond)
+
+	// Allow() transitions Open -> HalfOpen and consumes the single probe
+	// slot (HalfOpenMax=1).
+	if !b.Allow() {
+		t.Fatal("first Allow() after Timeout = false, want true (enters HalfOpen and admits the probe)")
+	}
+	if state := b.CurrentState(); state != circuitbreaker.HalfOpen {
+		t.Fatalf("CurrentState() after first Allow() = %v, want HalfOpen", state)
+	}
+
+	// With the single probe slot already consumed, a second Allow() must be
+	// rejected — there is no free slot until the in-flight probe resolves.
+	if b.Allow() {
+		t.Fatal("second Allow() while the only probe slot is in flight = true, want false")
+	}
+
+	// The in-flight probe's outcome is neutral (e.g. the upstream returned
+	// 429). RecordNeutral must release the reservation without changing
+	// state.
+	b.RecordNeutral()
+	if state := b.CurrentState(); state != circuitbreaker.HalfOpen {
+		t.Errorf("CurrentState() after RecordNeutral = %v, want HalfOpen (unchanged)", state)
+	}
+
+	// This is the bug the fix addresses: without RecordNeutral releasing the
+	// reservation, this Allow() call returns false forever (halfOpenActive
+	// stays at 1, permanently >= HalfOpenMax). With the fix it must return
+	// true.
+	if !b.Allow() {
+		t.Fatal("Allow() after RecordNeutral released the probe slot = false, want true — " +
+			"this is the exact regression RecordNeutral fixes: without it, a neutral outcome " +
+			"(e.g. HTTP 429) during the HalfOpen probe permanently locks the breaker out of probing again")
+	}
+}
+
+// TestRecordNeutral_HalfOpen_NeverGoesNegative verifies that calling
+// RecordNeutral repeatedly while HalfOpen (more times than there are
+// reserved probe slots to release) never drives halfOpenActive below zero.
+// If it did, a subsequent Allow() would incorrectly permit unbounded
+// concurrent probes instead of respecting HalfOpenMax.
+func TestRecordNeutral_HalfOpen_NeverGoesNegative(t *testing.T) {
+	t.Parallel()
+
+	const timeout = 10 * time.Millisecond
+	b := circuitbreaker.NewBreaker(circuitbreaker.Config{
+		Threshold:   1,
+		Timeout:     timeout,
+		HalfOpenMax: 1,
+	})
+
+	b.RecordFailure()
+	time.Sleep(timeout + 15*time.Millisecond)
+
+	if !b.Allow() {
+		t.Fatal("setup: Allow() did not admit the HalfOpen probe")
+	}
+	if state := b.CurrentState(); state != circuitbreaker.HalfOpen {
+		t.Fatalf("setup: CurrentState() = %v, want HalfOpen", state)
+	}
+
+	// Call RecordNeutral far more times than there are outstanding
+	// reservations (only one was ever taken). If halfOpenActive were
+	// allowed to underflow below zero, the next two Allow() calls below
+	// would both incorrectly return true (a negative count always compares
+	// less than HalfOpenMax).
+	for i := 0; i < 10; i++ {
+		b.RecordNeutral()
+	}
+
+	if !b.Allow() {
+		t.Fatal("Allow() after over-calling RecordNeutral = false, want true (one free slot)")
+	}
+	if b.Allow() {
+		t.Error("second consecutive Allow() after over-calling RecordNeutral = true, want false " +
+			"(halfOpenActive must be floored at zero, not negative, so HalfOpenMax=1 is still enforced)")
+	}
+}
+
+// ── Concurrency ───────────────────────────────────────────────────────────
+
+// TestBreaker_ConcurrentAccess fires Allow, RecordSuccess, RecordFailure,
+// and RecordNeutral concurrently from many goroutines. It makes no
+// assertions about the resulting state (which is inherently
+// nondeterministic under concurrent, mixed outcomes) — its only purpose is
+// to be race-free under `go test -race` and to never panic or deadlock.
+func TestBreaker_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	b := circuitbreaker.NewBreaker(circuitbreaker.Config{
+		Threshold:   4,
+		Timeout:     5 * time.Millisecond,
+		HalfOpenMax: 2,
+	})
+
+	const goroutines = 50
+	const opsEach = 200
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for i := 0; i < opsEach; i++ {
+				if b.Allow() {
+					switch (seed + i) % 3 {
+					case 0:
+						b.RecordSuccess()
+					case 1:
+						b.RecordFailure()
+					default:
+						b.RecordNeutral()
+					}
+				}
+				_ = b.CurrentState()
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	// The breaker must still be in one of the three valid states — mostly a
+	// sanity check that nothing corrupted the state field under race.
+	switch b.CurrentState() {
+	case circuitbreaker.Closed, circuitbreaker.Open, circuitbreaker.HalfOpen:
+	default:
+		t.Errorf("CurrentState() = %v after concurrent access, want a valid State", b.CurrentState())
+	}
+}

--- a/internal/circuitbreaker/breaker_test.go
+++ b/internal/circuitbreaker/breaker_test.go
@@ -325,6 +325,206 @@ func TestRecordNeutral_HalfOpen_NeverGoesNegative(t *testing.T) {
 	}
 }
 
+// ── Permits ───────────────────────────────────────────────────────────────
+
+// TestPermits_HalfOpen_DoesNotMutate is the regression case for the fix: a
+// candidate-selection caller (e.g. router.filterAvailable) must be able to
+// call Permits any number of times on a HalfOpen breaker with a free slot
+// without consuming it — a subsequent Allow() must still see that slot and
+// return true. Before Permits existed, the only way to peek was Allow()
+// itself, which reserved the slot as a side effect and starved the real
+// attempt.
+func TestPermits_HalfOpen_DoesNotMutate(t *testing.T) {
+	t.Parallel()
+
+	const timeout = 10 * time.Millisecond
+	b := circuitbreaker.NewBreaker(circuitbreaker.Config{
+		Threshold:   1,
+		Timeout:     timeout,
+		HalfOpenMax: 1,
+	})
+
+	b.RecordFailure()
+	time.Sleep(timeout + 15*time.Millisecond)
+
+	// Enter HalfOpen via the sole Allow() call that reserves the one slot,
+	// then immediately release it so the breaker is HalfOpen with one free
+	// slot for the rest of the test.
+	if !b.Allow() {
+		t.Fatal("setup: Allow() did not admit the HalfOpen probe")
+	}
+	b.RecordNeutral()
+	if state := b.CurrentState(); state != circuitbreaker.HalfOpen {
+		t.Fatalf("setup: CurrentState() = %v, want HalfOpen", state)
+	}
+
+	// Repeated Permits() calls on a HalfOpen breaker with a free slot must
+	// all report true and must never consume the slot.
+	for i := 0; i < 10; i++ {
+		if !b.Permits() {
+			t.Fatalf("Permits() call %d = false, want true (HalfOpen with a free slot)", i)
+		}
+	}
+	if state := b.CurrentState(); state != circuitbreaker.HalfOpen {
+		t.Errorf("CurrentState() after repeated Permits() = %v, want HalfOpen (unchanged)", state)
+	}
+
+	// The slot must still be available: Allow() must succeed exactly as if
+	// Permits() had never been called.
+	if !b.Allow() {
+		t.Fatal("Allow() after repeated Permits() calls = false, want true — " +
+			"Permits() must never reserve a probe slot")
+	}
+}
+
+// TestPermits_Open_BeforeTimeout_DoesNotTransition verifies that Permits on
+// an Open breaker before the recovery timeout has elapsed returns false and,
+// critically, does not transition the breaker to HalfOpen — unlike Allow,
+// which would perform that transition and reserve the first probe slot.
+// Repeated calls must leave the breaker Open and still blocked.
+func TestPermits_Open_BeforeTimeout_DoesNotTransition(t *testing.T) {
+	t.Parallel()
+
+	const timeout = time.Hour // never elapses during this test
+	b := circuitbreaker.NewBreaker(circuitbreaker.Config{
+		Threshold:   1,
+		Timeout:     timeout,
+		HalfOpenMax: 1,
+	})
+
+	b.RecordFailure() // trips at threshold 1
+	if state := b.CurrentState(); state != circuitbreaker.Open {
+		t.Fatalf("setup: CurrentState() = %v, want Open", state)
+	}
+
+	for i := 0; i < 5; i++ {
+		if b.Permits() {
+			t.Errorf("Permits() call %d = true, want false (Open, timeout not elapsed)", i)
+		}
+	}
+	if state := b.CurrentState(); state != circuitbreaker.Open {
+		t.Errorf("CurrentState() after repeated Permits() = %v, want Open (must not transition to HalfOpen)", state)
+	}
+
+	// Allow() must still behave exactly as if Permits() were never called:
+	// blocked, because the timeout genuinely has not elapsed.
+	if b.Allow() {
+		t.Error("Allow() after repeated Permits() calls = true, want false (timeout still not elapsed)")
+	}
+}
+
+// TestPermits_AgreesWithAllow exercises all three states and asserts that
+// Permits reports exactly what Allow would then do, for a breaker whose
+// prior state Permits itself is guaranteed not to have disturbed (each
+// subtest builds its own breaker to keep the two calls independent).
+func TestPermits_AgreesWithAllow(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Closed", func(t *testing.T) {
+		t.Parallel()
+		b := circuitbreaker.NewBreaker(circuitbreaker.Config{
+			Threshold:   3,
+			Timeout:     time.Minute,
+			HalfOpenMax: 1,
+		})
+		permits := b.Permits()
+		allow := b.Allow()
+		if permits != allow {
+			t.Errorf("Permits() = %v, Allow() = %v; want equal (Closed)", permits, allow)
+		}
+		if !permits {
+			t.Error("Closed breaker: Permits() = false, want true")
+		}
+	})
+
+	t.Run("Open before timeout", func(t *testing.T) {
+		t.Parallel()
+		b := circuitbreaker.NewBreaker(circuitbreaker.Config{
+			Threshold:   1,
+			Timeout:     time.Hour,
+			HalfOpenMax: 1,
+		})
+		b.RecordFailure()
+		permits := b.Permits()
+		allow := b.Allow()
+		if permits != allow {
+			t.Errorf("Permits() = %v, Allow() = %v; want equal (Open, before timeout)", permits, allow)
+		}
+		if permits {
+			t.Error("Open breaker before timeout: Permits() = true, want false")
+		}
+	})
+
+	t.Run("Open after timeout", func(t *testing.T) {
+		t.Parallel()
+		const timeout = 10 * time.Millisecond
+		b := circuitbreaker.NewBreaker(circuitbreaker.Config{
+			Threshold:   1,
+			Timeout:     timeout,
+			HalfOpenMax: 1,
+		})
+		b.RecordFailure()
+		time.Sleep(timeout + 15*time.Millisecond)
+
+		permits := b.Permits()
+		allow := b.Allow()
+		if permits != allow {
+			t.Errorf("Permits() = %v, Allow() = %v; want equal (Open, after timeout)", permits, allow)
+		}
+		if !permits {
+			t.Error("Open breaker after timeout: Permits() = false, want true")
+		}
+	})
+
+	t.Run("HalfOpen with free slot", func(t *testing.T) {
+		t.Parallel()
+		const timeout = 10 * time.Millisecond
+		b := circuitbreaker.NewBreaker(circuitbreaker.Config{
+			Threshold:   1,
+			Timeout:     timeout,
+			HalfOpenMax: 2,
+		})
+		b.RecordFailure()
+		time.Sleep(timeout + 15*time.Millisecond)
+		if !b.Allow() { // consumes 1 of 2 slots, enters HalfOpen
+			t.Fatal("setup: Allow() did not admit the HalfOpen probe")
+		}
+
+		permits := b.Permits()
+		allow := b.Allow()
+		if permits != allow {
+			t.Errorf("Permits() = %v, Allow() = %v; want equal (HalfOpen, free slot)", permits, allow)
+		}
+		if !permits {
+			t.Error("HalfOpen breaker with a free slot: Permits() = false, want true")
+		}
+	})
+
+	t.Run("HalfOpen with no free slot", func(t *testing.T) {
+		t.Parallel()
+		const timeout = 10 * time.Millisecond
+		b := circuitbreaker.NewBreaker(circuitbreaker.Config{
+			Threshold:   1,
+			Timeout:     timeout,
+			HalfOpenMax: 1,
+		})
+		b.RecordFailure()
+		time.Sleep(timeout + 15*time.Millisecond)
+		if !b.Allow() { // consumes the only slot, enters HalfOpen
+			t.Fatal("setup: Allow() did not admit the HalfOpen probe")
+		}
+
+		permits := b.Permits()
+		allow := b.Allow()
+		if permits != allow {
+			t.Errorf("Permits() = %v, Allow() = %v; want equal (HalfOpen, no free slot)", permits, allow)
+		}
+		if permits {
+			t.Error("HalfOpen breaker with no free slot: Permits() = true, want false")
+		}
+	})
+}
+
 // ── Concurrency ───────────────────────────────────────────────────────────
 
 // TestBreaker_ConcurrentAccess fires Allow, RecordSuccess, RecordFailure,

--- a/internal/cooldown/registry.go
+++ b/internal/cooldown/registry.go
@@ -16,6 +16,11 @@ import (
 // Registry instance is shared across all proxy handler and router goroutines.
 // All methods are nil-receiver safe so callers never need to nil-check a
 // *Registry before use.
+//
+// Entries do not stay forever: Mark opportunistically evicts keys whose
+// cooldown has already expired (see Mark's godoc), so a long-running process
+// that adds and removes deployments over time does not grow this map without
+// bound.
 type Registry struct {
 	mu    sync.RWMutex
 	until map[string]time.Time
@@ -36,15 +41,31 @@ func NewRegistry() *Registry {
 // non-positive d is a no-op — it never shortens or clears an existing
 // cooldown. Mark is safe for concurrent use and safe to call on a nil
 // Registry (no-op).
+//
+// While it holds the write lock, Mark also opportunistically evicts every
+// entry whose deadline has already passed. This is deliberately piggybacked
+// on Mark (rather than a background goroutine or timer) so cleanup only
+// costs anything on the already-infrequent 429 path, is bounded by the
+// number of currently-tracked keys (expected to stay small — one per
+// deployment), and never touches the read-only, allocation-free Cooling hot
+// path.
 func (r *Registry) Mark(key string, d time.Duration) {
 	if r == nil || d <= 0 {
 		return
 	}
-	until := r.now().Add(d)
+	now := r.now()
+	until := now.Add(d)
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.until[key] = until
+	// now is strictly before the deadline we just set (d > 0), so this loop
+	// can never evict the entry for key on this call.
+	for k, deadline := range r.until {
+		if !now.Before(deadline) {
+			delete(r.until, k)
+		}
+	}
 }
 
 // Cooling reports whether the deployment identified by key is currently

--- a/internal/cooldown/registry.go
+++ b/internal/cooldown/registry.go
@@ -1,0 +1,66 @@
+// Package cooldown tracks upstream deployments that are temporarily
+// rate-limited (HTTP 429) so that the router can prefer other deployments for
+// a short window without treating the rate limit as a circuit-breaker
+// failure. It intentionally imports neither internal/proxy nor
+// internal/router so it can be used by both — the same constraint that
+// shapes internal/circuitbreaker.
+package cooldown
+
+import (
+	"sync"
+	"time"
+)
+
+// Registry tracks, per deployment key, the time until which a deployment is
+// considered "cooling" (temporarily rate-limited by its upstream). A single
+// Registry instance is shared across all proxy handler and router goroutines.
+// All methods are nil-receiver safe so callers never need to nil-check a
+// *Registry before use.
+type Registry struct {
+	mu    sync.RWMutex
+	until map[string]time.Time
+	// now returns the current time. Defaults to time.Now; overridden in tests.
+	now func() time.Time
+}
+
+// NewRegistry creates an empty Registry ready for use.
+func NewRegistry() *Registry {
+	return &Registry{
+		until: make(map[string]time.Time),
+		now:   time.Now,
+	}
+}
+
+// Mark records that the deployment identified by key is cooling down for the
+// duration d, i.e. Cooling(key) reports true until d has elapsed. A
+// non-positive d is a no-op — it never shortens or clears an existing
+// cooldown. Mark is safe for concurrent use and safe to call on a nil
+// Registry (no-op).
+func (r *Registry) Mark(key string, d time.Duration) {
+	if r == nil || d <= 0 {
+		return
+	}
+	until := r.now().Add(d)
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.until[key] = until
+}
+
+// Cooling reports whether the deployment identified by key is currently
+// within its cooldown window. It performs a pure time comparison under a
+// read lock and never allocates, so it is safe to call on the hot path once
+// per candidate per request. Cooling returns false on a nil Registry and for
+// any key that was never marked or whose cooldown has expired.
+func (r *Registry) Cooling(key string) bool {
+	if r == nil {
+		return false
+	}
+	r.mu.RLock()
+	until, ok := r.until[key]
+	r.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	return r.now().Before(until)
+}

--- a/internal/cooldown/registry_test.go
+++ b/internal/cooldown/registry_test.go
@@ -1,0 +1,150 @@
+package cooldown
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// newRegistryWithClock returns a Registry whose clock is controlled by the
+// supplied pointer, following the pattern established by
+// internal/auth/login_throttle_test.go's newThrottleWithClock. Tests advance
+// *cur to simulate the passage of time without real sleeps.
+func newRegistryWithClock(cur *time.Time) *Registry {
+	return &Registry{
+		until: make(map[string]time.Time),
+		now:   func() time.Time { return *cur },
+	}
+}
+
+// TestMark_Cooling_ReflectsDeadline verifies that Cooling reports true
+// immediately after Mark, remains true right up to the deadline, and becomes
+// false once the clock advances past it.
+func TestMark_Cooling_ReflectsDeadline(t *testing.T) {
+	t.Parallel()
+
+	cur := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	r := newRegistryWithClock(&cur)
+
+	r.Mark("dep-a", 10*time.Second)
+
+	if !r.Cooling("dep-a") {
+		t.Fatal("Cooling immediately after Mark = false, want true")
+	}
+
+	// Just before the deadline: still cooling.
+	cur = cur.Add(9999 * time.Millisecond)
+	if !r.Cooling("dep-a") {
+		t.Error("Cooling 1ms before deadline = false, want true")
+	}
+
+	// Exactly at (and past) the deadline: no longer cooling.
+	cur = cur.Add(2 * time.Millisecond)
+	if r.Cooling("dep-a") {
+		t.Error("Cooling after deadline = true, want false")
+	}
+}
+
+// TestMark_NonPositiveDuration_IsNoOp verifies that Mark with d <= 0 never
+// creates a cooldown, and — critically — never shortens or clears an
+// existing one.
+func TestMark_NonPositiveDuration_IsNoOp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		d    time.Duration
+	}{
+		{name: "zero duration", d: 0},
+		{name: "negative duration", d: -5 * time.Second},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cur := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+			r := newRegistryWithClock(&cur)
+
+			// A non-positive Mark on a never-seen key must not create a
+			// cooldown.
+			r.Mark("fresh-key", tc.d)
+			if r.Cooling("fresh-key") {
+				t.Error("Cooling after non-positive Mark on fresh key = true, want false")
+			}
+
+			// A non-positive Mark must not shorten or clear an existing
+			// cooldown established by a prior valid Mark.
+			r.Mark("existing-key", time.Minute)
+			if !r.Cooling("existing-key") {
+				t.Fatal("setup: existing cooldown not active")
+			}
+			r.Mark("existing-key", tc.d)
+			if !r.Cooling("existing-key") {
+				t.Error("non-positive Mark cleared an existing cooldown; want it preserved")
+			}
+		})
+	}
+}
+
+// TestCooling_UnknownKey_ReturnsFalse verifies that a key which was never
+// marked reports as not cooling.
+func TestCooling_UnknownKey_ReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	if r.Cooling("never-marked") {
+		t.Error("Cooling for an unknown key = true, want false")
+	}
+}
+
+// TestNilRegistry_MethodsAreSafe verifies that both Mark and Cooling are safe
+// to call on a nil *Registry — the nil-receiver-safe contract documented on
+// both methods — and that Cooling always reports false in that case.
+func TestNilRegistry_MethodsAreSafe(t *testing.T) {
+	t.Parallel()
+
+	var r *Registry
+
+	// Must not panic.
+	r.Mark("any-key", time.Minute)
+
+	if r.Cooling("any-key") {
+		t.Error("Cooling on nil Registry = true, want false")
+	}
+}
+
+// TestRegistry_ConcurrentAccess fires many concurrent Mark and Cooling calls
+// against both shared and per-goroutine keys and must be free of data races
+// (run with -race).
+func TestRegistry_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+
+	const goroutines = 50
+	const opsEach = 200
+	const sharedKey = "shared-key"
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		g := g
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ownKey := "own-key-" + string(rune('A'+g%26))
+			for i := 0; i < opsEach; i++ {
+				r.Mark(sharedKey, time.Minute)
+				r.Mark(ownKey, time.Minute)
+				_ = r.Cooling(sharedKey)
+				_ = r.Cooling(ownKey)
+				_ = r.Cooling("never-marked-key")
+			}
+		}()
+	}
+	wg.Wait()
+
+	if !r.Cooling(sharedKey) {
+		t.Error("shared key should be cooling after concurrent Mark calls")
+	}
+}

--- a/internal/cooldown/registry_test.go
+++ b/internal/cooldown/registry_test.go
@@ -114,6 +114,88 @@ func TestNilRegistry_MethodsAreSafe(t *testing.T) {
 	}
 }
 
+// TestMark_EvictsExpiredEntries verifies that Mark opportunistically sweeps
+// out every entry whose deadline has already passed, keeping the map from
+// growing without bound in a long-running process. Cooling cannot observe
+// this directly (it only reports true/false for a single key, and an
+// expired-but-not-yet-evicted entry already reports false), so this test
+// reaches into the unexported until map directly — safe and intended here
+// since this file is already in-package (package cooldown, white-box).
+func TestMark_EvictsExpiredEntries(t *testing.T) {
+	t.Parallel()
+
+	cur := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	r := newRegistryWithClock(&cur)
+
+	r.Mark("dep-a", 5*time.Second)
+	r.Mark("dep-b", 5*time.Second)
+	r.Mark("dep-c", 5*time.Second)
+
+	if got := len(r.until); got != 3 {
+		t.Fatalf("setup: len(until) = %d, want 3", got)
+	}
+
+	// Advance the clock past all three deadlines.
+	cur = cur.Add(10 * time.Second)
+
+	// Marking a new key triggers Mark's opportunistic sweep of every expired
+	// entry, not just a lookup of "dep-d".
+	r.Mark("dep-d", 5*time.Second)
+
+	if _, ok := r.until["dep-a"]; ok {
+		t.Error("dep-a still present in the map after its deadline passed; want evicted")
+	}
+	if _, ok := r.until["dep-b"]; ok {
+		t.Error("dep-b still present in the map after its deadline passed; want evicted")
+	}
+	if _, ok := r.until["dep-c"]; ok {
+		t.Error("dep-c still present in the map after its deadline passed; want evicted")
+	}
+	if _, ok := r.until["dep-d"]; !ok {
+		t.Error("dep-d missing from the map; the entry just set by this very Mark call must never evict itself")
+	}
+	if got := len(r.until); got != 1 {
+		t.Errorf("len(until) = %d, want 1 (only the just-marked dep-d should remain)", got)
+	}
+
+	// Behavioral cross-check: Cooling agrees with the map contents.
+	if r.Cooling("dep-a") {
+		t.Error("Cooling(\"dep-a\") = true after eviction, want false")
+	}
+	if !r.Cooling("dep-d") {
+		t.Error("Cooling(\"dep-d\") = false right after Mark, want true")
+	}
+}
+
+// TestMark_NonExpiredEntry_SurvivesSweep verifies that Mark's opportunistic
+// eviction only removes entries whose deadline has actually passed, never a
+// still-cooling one — the sweep must not be overzealous.
+func TestMark_NonExpiredEntry_SurvivesSweep(t *testing.T) {
+	t.Parallel()
+
+	cur := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	r := newRegistryWithClock(&cur)
+
+	// dep-long is marked with a cooldown that outlives dep-short.
+	r.Mark("dep-long", time.Minute)
+	r.Mark("dep-short", time.Second)
+
+	// Advance the clock past dep-short's deadline but not dep-long's.
+	cur = cur.Add(5 * time.Second)
+
+	r.Mark("dep-new", time.Second)
+
+	if _, ok := r.until["dep-short"]; ok {
+		t.Error("dep-short still present after its deadline passed; want evicted")
+	}
+	if _, ok := r.until["dep-long"]; !ok {
+		t.Error("dep-long evicted even though its deadline has not passed; want it preserved")
+	}
+	if !r.Cooling("dep-long") {
+		t.Error("Cooling(\"dep-long\") = false, want true (its cooldown has not expired)")
+	}
+}
+
 // TestRegistry_ConcurrentAccess fires many concurrent Mark and Cooling calls
 // against both shared and per-goroutine keys and must be free of data races
 // (run with -race).

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -119,6 +119,19 @@ var RoutingRetriesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Help:      "Number of upstream retry attempts during load-balanced routing.",
 }, []string{"model", "strategy"})
 
+// RateLimitFailoversTotal counts requests that failed over to the next
+// deployment candidate because the current one returned HTTP 429, partitioned
+// by model name and deployment key. Unlike RoutingRetriesTotal (which also
+// fires for 5xx retries), this metric isolates rate-limit-induced failover so
+// operators can distinguish "upstream is broken" from "upstream is
+// throttling us" without inspecting request content — only the model and
+// deployment identifiers are recorded.
+var RateLimitFailoversTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "voidllm",
+	Name:      "rate_limit_failovers_total",
+	Help:      "Number of requests that failed over to another deployment due to HTTP 429.",
+}, []string{"model", "deployment"})
+
 // RegisterDBCollectors registers database connection pool metrics against the
 // default Prometheus registry. The gauges are implemented as GaugeFuncs that
 // read live values from sql.DB.Stats() on each scrape, so they always reflect

--- a/internal/proxy/breaker_reservation_test.go
+++ b/internal/proxy/breaker_reservation_test.go
@@ -1,0 +1,195 @@
+package proxy
+
+// breaker_reservation_test.go pins the Allow()/Record* balance invariant
+// documented on circuitbreaker.Breaker.Allow: every Allow() call that
+// returns true reserves a HalfOpen probe slot that only RecordSuccess,
+// RecordFailure, or RecordNeutral releases. tryModel must therefore call
+// Allow() exactly once per candidate it actually attempts — never for
+// candidates it only considers and never twice for one it does attempt — and
+// the streaming client-disconnect path must release the reservation via
+// RecordNeutral() rather than leaving it dangling. Violating either half of
+// this permanently locks a HalfOpenMax=1 deployment out of ever probing
+// again.
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/voidmind-io/voidllm/internal/circuitbreaker"
+	"github.com/voidmind-io/voidllm/internal/cooldown"
+)
+
+// halfOpenBreakerWithFreeSlot returns a circuitbreaker.Registry (HalfOpenMax=1)
+// whose breaker for key is already in HalfOpen state with its single probe
+// slot free (halfOpenActive=0): tripped via one RecordFailure (Threshold=1),
+// advanced past a short Timeout, admitted through Allow() once to perform the
+// Open->HalfOpen transition and reserve the slot, then immediately released
+// via RecordNeutral() so the slot is free again for the test to observe being
+// consumed (or not) by the code path under test. This is the same
+// construction internal/circuitbreaker's TestPermits_HalfOpen_DoesNotMutate
+// uses to reach a HalfOpen-with-free-slot state.
+func halfOpenBreakerWithFreeSlot(t *testing.T, key string) *circuitbreaker.Registry {
+	t.Helper()
+	const timeout = 10 * time.Millisecond
+	reg := circuitbreaker.NewRegistry(circuitbreaker.Config{
+		Enabled:     true,
+		Threshold:   1,
+		Timeout:     timeout,
+		HalfOpenMax: 1,
+	})
+	b := reg.Get(key)
+	b.RecordFailure()
+	time.Sleep(timeout + 15*time.Millisecond)
+	if !b.Allow() {
+		t.Fatalf("setup: Allow() for %q did not admit the HalfOpen probe", key)
+	}
+	b.RecordNeutral()
+	if state := b.CurrentState(); state != circuitbreaker.HalfOpen {
+		t.Fatalf("setup: breaker for %q state = %v, want HalfOpen", key, state)
+	}
+	return reg
+}
+
+// ── Reserved but never attempted ─────────────────────────────────────────
+
+// TestHandle_HalfOpenBreaker_UnattemptedCandidate_SlotNotConsumed verifies
+// that a candidate which the router lists but tryModel never actually tries
+// — because an earlier candidate already succeeded — leaves that candidate's
+// breaker reservation completely untouched. dep-2's breaker starts HalfOpen
+// with its one free slot; dep-1 succeeds first, so dep-2 must never be
+// attempted (and never call Allow()), and the slot must still be available
+// afterward.
+func TestHandle_HalfOpenBreaker_UnattemptedCandidate_SlotNotConsumed(t *testing.T) {
+	t.Parallel()
+
+	var dep1Calls, dep2Calls int32
+	srv1 := okServer(t, &dep1Calls)
+	srv2 := okServer(t, &dep2Calls) // must never actually be hit
+
+	dep1 := Deployment{Name: "dep-1", Provider: "openai", BaseURL: srv1.URL, APIKey: "k1", Priority: 1}
+	dep2 := Deployment{Name: "dep-2", Provider: "openai", BaseURL: srv2.URL, APIKey: "k2", Priority: 2}
+
+	const modelName = "unattempted-candidate-model"
+	reg := twoDeploymentRegistry(modelName, dep1, dep2)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.Router = &staticDeploymentPicker{deps: []Deployment{dep1, dep2}}
+
+	dep2Key := deploymentKey(modelName, "dep-2")
+	handler.CircuitBreakers = halfOpenBreakerWithFreeSlot(t, dep2Key)
+	handler.Cooldowns = cooldown.NewRegistry()
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"`+modelName+`","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+	if atomic.LoadInt32(&dep1Calls) == 0 {
+		t.Fatal("dep-1 was never called")
+	}
+	if atomic.LoadInt32(&dep2Calls) != 0 {
+		t.Fatal("dep-2 was called — it should never have been attempted since dep-1 succeeded first")
+	}
+
+	dep2Breaker := handler.CircuitBreakers.Get(dep2Key)
+	if !dep2Breaker.Allow() {
+		t.Error("dep-2's HalfOpen probe slot was consumed even though dep-2 was never attempted — " +
+			"a reservation may only be taken at the moment a candidate is actually tried, " +
+			"never merely because it was considered")
+	}
+}
+
+// ── Streaming client disconnect releases the reservation ────────────────
+
+// TestHandle_StreamingClientDisconnect_ReleasesHalfOpenReservation mirrors
+// TestStreamTermination_ClientDisconnect_NoScannerError_IsDisconnect
+// (stream_termination_matrix_test.go) but starts the deployment's breaker
+// HalfOpen with its single slot already reserved-then-released (i.e. free),
+// and asserts that after the client disconnects mid-stream, the slot Allow()
+// takes for the request is released via RecordNeutral() — not left
+// dangling. Before the fix, the clientDisconnected case in
+// handleStreamingResponse recorded nothing, so this reservation would stay
+// consumed forever and a HalfOpenMax=1 deployment would never be probed
+// again.
+func TestHandle_StreamingClientDisconnect_ReleasesHalfOpenReservation(t *testing.T) {
+	t.Parallel()
+
+	upstreamCanceled := make(chan struct{})
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Error("upstream: no Flusher")
+			return
+		}
+		fmt.Fprintln(w, `data: {"choices":[{"delta":{"content":"a"}}]}`)
+		fmt.Fprintln(w)
+		flusher.Flush()
+
+		ticker := time.NewTicker(20 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-r.Context().Done():
+				close(upstreamCanceled)
+				return
+			case <-ticker.C:
+				fmt.Fprintln(w, `data: {"choices":[{"delta":{"content":"b"}}]}`)
+				fmt.Fprintln(w)
+				flusher.Flush()
+			}
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	const modelName = "half-open-disconnect-model"
+	reg := terminationRegistry(t, modelName, upstream.URL)
+	h, _, d := newTerminationTestHandler(t, reg)
+
+	// Override the Threshold=1/Timeout=30s registry newTerminationTestHandler
+	// wires by default with one whose breaker is already HalfOpen with its
+	// single slot free, so the request under test is the one that reserves
+	// (via Allow()) and must release (via RecordNeutral()) that exact slot.
+	depKey := deploymentKey(modelName, modelName)
+	h.CircuitBreakers = halfOpenBreakerWithFreeSlot(t, depKey)
+
+	baseURL, rawKey := startAuthedTestServer(t, h, terminationKeyInfo("org-half-open-disconnect"))
+	streamRequestThenAbruptlyDisconnect(t, baseURL, rawKey, modelName)
+
+	select {
+	case <-upstreamCanceled:
+	case <-time.After(3 * time.Second):
+		t.Fatal("upstream never observed request cancellation")
+	}
+
+	// waitForLoggedStatusCode's DB poll happens-after handleStreamingResponse's
+	// SendStreamWriter goroutine finishes (see its own doc comment for why
+	// that ordering is safe to rely on here), so by the time it returns, any
+	// breaker recording from the disconnect path has already completed.
+	if status := waitForLoggedStatusCode(t, d); status != http.StatusOK {
+		t.Errorf("usage status_code = %d, want 200 (disconnect keeps the upstream status, not 502)", status)
+	}
+
+	if !h.CircuitBreakers.Get(depKey).Allow() {
+		t.Error("dep breaker's HalfOpen probe slot was not released after a client disconnect — " +
+			"the streaming client-disconnect path must call RecordNeutral() to balance the Allow() reservation")
+	}
+}

--- a/internal/proxy/cooldown_failover_test.go
+++ b/internal/proxy/cooldown_failover_test.go
@@ -391,16 +391,6 @@ func TestRetryAfterOrDefault(t *testing.T) {
 			want:    5 * time.Second,
 		},
 		{
-			name:    "Retry-After HTTP-date far in the future clamps to max",
-			headers: map[string]string{"Retry-After": time.Now().Add(24 * time.Hour).UTC().Format(http.TimeFormat)},
-			want:    maxRateLimitCooldown,
-		},
-		{
-			name:    "Retry-After HTTP-date in the past clamps to zero",
-			headers: map[string]string{"Retry-After": time.Now().Add(-24 * time.Hour).UTC().Format(http.TimeFormat)},
-			want:    0,
-		},
-		{
 			name:    "Retry-After unparseable garbage uses default",
 			headers: map[string]string{"Retry-After": "not-a-valid-value"},
 			want:    defaultRateLimitCooldown,
@@ -425,6 +415,56 @@ func TestRetryAfterOrDefault(t *testing.T) {
 			headers: map[string]string{"Retry-After": "-5"},
 			want:    defaultRateLimitCooldown,
 		},
+		{
+			// Regression guard for the int64-overflow bug the bounds check in
+			// retryAfterOrDefault exists to prevent: 9999999999 seconds,
+			// multiplied by time.Second, overflows int64 and wraps to a
+			// negative duration, which clampCooldown would then turn into 0 —
+			// no cooldown at all, the exact opposite of the intent of a large
+			// Retry-After value. The pre-multiplication bounds check against
+			// maxRateLimitCooldownSecs must catch this before the overflow
+			// happens.
+			name:    "Retry-After large enough to overflow int64 seconds clamps to max",
+			headers: map[string]string{"Retry-After": "9999999999"},
+			want:    maxRateLimitCooldown,
+		},
+		{
+			// The extreme case of the same overflow: math.MaxInt64 itself.
+			name:    "Retry-After math.MaxInt64 clamps to max",
+			headers: map[string]string{"Retry-After": "9223372036854775807"},
+			want:    maxRateLimitCooldown,
+		},
+		{
+			// Same overflow regression, but for the retry-after-ms branch:
+			// multiplying by time.Millisecond instead of time.Second.
+			name:    "retry-after-ms large enough to overflow int64 ms clamps to max",
+			headers: map[string]string{"retry-after-ms": "9999999999999999"},
+			want:    maxRateLimitCooldown,
+		},
+		{
+			// Pins the ordinary clamp boundary (a value just above the cap,
+			// far from the overflow range) as distinct from the overflow
+			// guard above: deleting the bounds check would not overflow here,
+			// so this case alone would not catch that mutation, but it
+			// verifies the "> max clamps" behavior holds independent of
+			// overflow.
+			name:    "Retry-After just above cap in seconds clamps to max",
+			headers: map[string]string{"Retry-After": fmt.Sprintf("%d", maxRateLimitCooldownSecs+1)},
+			want:    maxRateLimitCooldown,
+		},
+		{
+			// Exactly at the cap in seconds: secs > maxRateLimitCooldownSecs
+			// is false, so this falls through to clampCooldown(secs *
+			// time.Second), which multiplies out to exactly
+			// maxRateLimitCooldown and clampCooldown's d > maxRateLimitCooldown
+			// check leaves it unchanged. The boundary is inclusive on the
+			// non-clamping side of the pre-multiplication check, but the
+			// numeric result is the same maxRateLimitCooldown value either
+			// way.
+			name:    "Retry-After exactly at cap in seconds is honored",
+			headers: map[string]string{"Retry-After": fmt.Sprintf("%d", maxRateLimitCooldownSecs)},
+			want:    maxRateLimitCooldown,
+		},
 	}
 
 	for _, tc := range tests {
@@ -446,6 +486,71 @@ func TestRetryAfterOrDefault(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRetryAfterOrDefault_HTTPDate covers the RFC 7231 HTTP-date form of the
+// Retry-After header specifically: past date, near-future date (not
+// clamped), and far-future date (must clamp to maxRateLimitCooldown).
+//
+// Unlike the table-driven cases above, these deliberately do not assert
+// exact equality against a duration precomputed from time.Now(): parsing an
+// HTTP-date internally calls time.Until, which reads the wall clock again at
+// call time, so any expected value baked in at header-construction time
+// would be racing the clock. The past- and far-future cases stay exact
+// because their expected results are the two saturating clamp bounds (0 and
+// maxRateLimitCooldown) — values wide enough that ordinary test-execution
+// jitter can never cross the clamp boundary. The near-future case is the one
+// that actually carries an unclamped, clock-derived value, so it asserts a
+// bound instead of exact equality.
+func TestRetryAfterOrDefault_HTTPDate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("past date clamps to zero", func(t *testing.T) {
+		t.Parallel()
+
+		h := make(http.Header)
+		h.Set("Retry-After", time.Now().Add(-24*time.Hour).UTC().Format(http.TimeFormat))
+		resp := &http.Response{Header: h}
+
+		got := retryAfterOrDefault(resp)
+		if got != 0 {
+			t.Errorf("retryAfterOrDefault() = %v, want 0 (date is in the past)", got)
+		}
+	})
+
+	t.Run("near-future date within cap is honored", func(t *testing.T) {
+		t.Parallel()
+
+		const target = 10 * time.Second
+		h := make(http.Header)
+		h.Set("Retry-After", time.Now().Add(target).UTC().Format(http.TimeFormat))
+		resp := &http.Response{Header: h}
+
+		got := retryAfterOrDefault(resp)
+
+		// The header only carries second resolution and some wall-clock time
+		// elapses between construction and parsing, so bound the result
+		// instead of asserting it equals target exactly: it must be positive,
+		// must not exceed target, and must not be more than a generous
+		// tolerance below it.
+		const tolerance = 3 * time.Second
+		if got <= 0 || got > target || target-got > tolerance {
+			t.Errorf("retryAfterOrDefault() = %v, want within (%v, %v]", got, target-tolerance, target)
+		}
+	})
+
+	t.Run("far-future date clamps to max", func(t *testing.T) {
+		t.Parallel()
+
+		h := make(http.Header)
+		h.Set("Retry-After", time.Now().Add(24*time.Hour).UTC().Format(http.TimeFormat))
+		resp := &http.Response{Header: h}
+
+		got := retryAfterOrDefault(resp)
+		if got != maxRateLimitCooldown {
+			t.Errorf("retryAfterOrDefault() = %v, want %v (must clamp)", got, maxRateLimitCooldown)
+		}
+	})
 }
 
 // ── Model-level fallback on 429 ──────────────────────────────────────────────

--- a/internal/proxy/cooldown_failover_test.go
+++ b/internal/proxy/cooldown_failover_test.go
@@ -1,0 +1,488 @@
+package proxy
+
+// cooldown_failover_test.go covers the 429 failover + cooldown feature
+// (GitHub issue #184): a 429 from an upstream deployment triggers failover to
+// the next candidate (or fallback model), is recorded in the cooldown
+// registry so the router deprioritizes that deployment on subsequent
+// requests, and is treated as NEUTRAL by the circuit breaker — neither a
+// success nor a failure.
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/voidmind-io/voidllm/internal/circuitbreaker"
+	"github.com/voidmind-io/voidllm/internal/cooldown"
+)
+
+// newTestCircuitBreakers returns a circuit breaker registry configured with
+// the given failure threshold and a Timeout long enough that the circuit
+// never auto-recovers mid-test.
+func newTestCircuitBreakers(threshold int) *circuitbreaker.Registry {
+	return circuitbreaker.NewRegistry(circuitbreaker.Config{
+		Threshold:   threshold,
+		Timeout:     10 * time.Minute,
+		HalfOpenMax: 1,
+	})
+}
+
+// twoDeploymentRegistry builds a Registry containing a single model with two
+// explicit deployments, following the construction pattern used by
+// TestPII_VULN001_MultiDeploymentPerDeploymentBodySelection in
+// pii_handler_test.go.
+func twoDeploymentRegistry(modelName string, dep1, dep2 Deployment) *Registry {
+	model := Model{
+		Name:        modelName,
+		Provider:    dep1.Provider,
+		BaseURL:     dep1.BaseURL,
+		APIKey:      dep1.APIKey,
+		Strategy:    "priority",
+		Deployments: []Deployment{dep1, dep2},
+	}
+	return &Registry{
+		models:  map[string]*Model{modelName: &model},
+		aliases: make(map[string]string),
+	}
+}
+
+// rateLimitedServer returns an httptest.Server that always responds 429 and
+// increments *calls on every request.
+func rateLimitedServer(t *testing.T, calls *int32) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(calls, 1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		fmt.Fprint(w, `{"error":{"message":"rate limited"}}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// okServer returns an httptest.Server that always responds 200 with a minimal
+// chat-completion body and increments *calls on every request.
+func okServer(t *testing.T, calls *int32) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"cmp-ok","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"ok"}}]}`)
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// ── Failover on 429 ──────────────────────────────────────────────────────────
+
+// TestHandle_429_FailsOverToNextDeployment verifies that a 429 from the first
+// deployment candidate causes the proxy to retry the next candidate, and that
+// the client receives that candidate's successful response.
+func TestHandle_429_FailsOverToNextDeployment(t *testing.T) {
+	t.Parallel()
+
+	var dep1Calls, dep2Calls int32
+	srv1 := rateLimitedServer(t, &dep1Calls)
+	srv2 := okServer(t, &dep2Calls)
+
+	dep1 := Deployment{Name: "dep-1", Provider: "openai", BaseURL: srv1.URL, APIKey: "k1", Priority: 1}
+	dep2 := Deployment{Name: "dep-2", Provider: "openai", BaseURL: srv2.URL, APIKey: "k2", Priority: 2}
+
+	reg := twoDeploymentRegistry("failover-model", dep1, dep2)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.Router = &staticDeploymentPicker{deps: []Deployment{dep1, dep2}}
+	handler.CircuitBreakers = newTestCircuitBreakers(1)
+	handler.Cooldowns = cooldown.NewRegistry()
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"failover-model","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+	if atomic.LoadInt32(&dep1Calls) == 0 {
+		t.Error("rate-limited deployment (dep-1) was never called")
+	}
+	if atomic.LoadInt32(&dep2Calls) == 0 {
+		t.Error("second deployment (dep-2) was never called")
+	}
+}
+
+// ── Circuit breaker neutrality ───────────────────────────────────────────────
+
+// TestHandle_429_LeavesBreakerClosed verifies that a 429 response does not
+// trip the circuit breaker for the deployment that returned it. The registry
+// uses Threshold=1 so that a single (incorrect) RecordFailure call would be
+// immediately observable as an Open breaker.
+func TestHandle_429_LeavesBreakerClosed(t *testing.T) {
+	t.Parallel()
+
+	var dep1Calls, dep2Calls int32
+	srv1 := rateLimitedServer(t, &dep1Calls)
+	srv2 := okServer(t, &dep2Calls)
+
+	dep1 := Deployment{Name: "dep-1", Provider: "openai", BaseURL: srv1.URL, APIKey: "k1", Priority: 1}
+	dep2 := Deployment{Name: "dep-2", Provider: "openai", BaseURL: srv2.URL, APIKey: "k2", Priority: 2}
+
+	reg := twoDeploymentRegistry("breaker-neutral-model", dep1, dep2)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.Router = &staticDeploymentPicker{deps: []Deployment{dep1, dep2}}
+	handler.CircuitBreakers = newTestCircuitBreakers(1)
+	handler.Cooldowns = cooldown.NewRegistry()
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"breaker-neutral-model","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	depKey := deploymentKey("breaker-neutral-model", "dep-1")
+	state := handler.CircuitBreakers.Get(depKey).CurrentState()
+	if state != circuitbreaker.Closed {
+		t.Errorf("breaker for %q state = %v after a single 429, want Closed (429 must not record a breaker failure)", depKey, state)
+	}
+}
+
+// TestHandle_429_DoesNotResetFailureCounter is the subtle regression guard:
+// it proves that a 429 neither increments NOR resets the circuit breaker's
+// failure counter. A deployment breaker starts with one pre-recorded failure
+// (below the Threshold=2 trip point). A 429 is sent to it — this must be a
+// pure no-op for the breaker. A genuine failure (5xx) is then sent to the
+// same deployment; if the 429 had incorrectly called RecordSuccess (which
+// resets the counter to zero), this second failure would only bring the
+// count to 1 and the breaker would stay Closed. If the 429 had incorrectly
+// called RecordFailure, the breaker would already have tripped Open before
+// the second request is even sent. Only the correct "neutral" behaviour
+// leaves the breaker Closed after the pre-existing failure + 429, and Open
+// after the pre-existing failure + 429 + one genuine failure.
+func TestHandle_429_DoesNotResetFailureCounter(t *testing.T) {
+	t.Parallel()
+
+	// respondStatus is flipped between requests: first 429, then 500.
+	var respondStatus int32 = http.StatusTooManyRequests
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(int(atomic.LoadInt32(&respondStatus)))
+		fmt.Fprint(w, `{"error":{"message":"upstream"}}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	const modelName = "counter-model"
+	reg := singleDeploymentRegistry(modelName, "openai", srv.URL)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.CircuitBreakers = newTestCircuitBreakers(2)
+	handler.Cooldowns = cooldown.NewRegistry()
+	app := testApp(t, handler)
+
+	// Single-deployment synthesis uses model.Name as the deployment name, so
+	// the breaker key equals the model name (see deploymentKey).
+	depKey := deploymentKey(modelName, modelName)
+
+	// Pre-record one failure directly on the breaker: failures=1, still Closed.
+	handler.CircuitBreakers.Get(depKey).RecordFailure()
+	if state := handler.CircuitBreakers.Get(depKey).CurrentState(); state != circuitbreaker.Closed {
+		t.Fatalf("setup: breaker state = %v after 1/2 failures, want Closed", state)
+	}
+
+	// Request 1: upstream returns 429. Must be neutral (neither
+	// RecordSuccess nor RecordFailure).
+	req1 := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"`+modelName+`","messages":[]}`))
+	req1.Header.Set("Content-Type", "application/json")
+	resp1, err := app.Test(req1, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test (429): %v", err)
+	}
+	resp1.Body.Close()
+	if resp1.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("request 1 status = %d, want 429", resp1.StatusCode)
+	}
+	if state := handler.CircuitBreakers.Get(depKey).CurrentState(); state != circuitbreaker.Closed {
+		t.Fatalf("breaker state after 429 = %v, want Closed", state)
+	}
+
+	// Request 2: upstream now returns 500 — a genuine failure.
+	atomic.StoreInt32(&respondStatus, http.StatusInternalServerError)
+	req2 := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"`+modelName+`","messages":[]}`))
+	req2.Header.Set("Content-Type", "application/json")
+	resp2, err := app.Test(req2, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test (500): %v", err)
+	}
+	resp2.Body.Close()
+
+	// The breaker must now be Open: pre-existing failure (1) + this genuine
+	// failure (2) reaches Threshold=2. If the 429 had reset the counter via
+	// RecordSuccess, this would still be Closed (count=1).
+	if state := handler.CircuitBreakers.Get(depKey).CurrentState(); state != circuitbreaker.Open {
+		t.Errorf("breaker state after pre-failure + 429 + genuine failure = %v, want Open "+
+			"(a 429 must not reset the failure counter via RecordSuccess)", state)
+	}
+}
+
+// singleDeploymentRegistry builds a Registry containing a single
+// no-Deployments-slice model backed by upstreamURL, mirroring the shape
+// tryModel synthesizes a single candidate from.
+func singleDeploymentRegistry(modelName, provider, upstreamURL string) *Registry {
+	model := Model{
+		Name:     modelName,
+		Provider: provider,
+		BaseURL:  upstreamURL,
+		APIKey:   "key",
+	}
+	return &Registry{
+		models:  map[string]*Model{modelName: &model},
+		aliases: make(map[string]string),
+	}
+}
+
+// ── All candidates rate limited ──────────────────────────────────────────────
+
+// TestHandle_429_AllCandidatesRateLimited verifies that when every deployment
+// candidate returns 429, the client receives 429 — not a 502 (upstream
+// unavailable) or 503 (circuit open) synthetic error.
+func TestHandle_429_AllCandidatesRateLimited(t *testing.T) {
+	t.Parallel()
+
+	var dep1Calls, dep2Calls int32
+	srv1 := rateLimitedServer(t, &dep1Calls)
+	srv2 := rateLimitedServer(t, &dep2Calls)
+
+	dep1 := Deployment{Name: "dep-1", Provider: "openai", BaseURL: srv1.URL, APIKey: "k1", Priority: 1}
+	dep2 := Deployment{Name: "dep-2", Provider: "openai", BaseURL: srv2.URL, APIKey: "k2", Priority: 2}
+
+	reg := twoDeploymentRegistry("all-limited-model", dep1, dep2)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.Router = &staticDeploymentPicker{deps: []Deployment{dep1, dep2}}
+	handler.CircuitBreakers = newTestCircuitBreakers(1)
+	handler.Cooldowns = cooldown.NewRegistry()
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"all-limited-model","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 429; body: %s", resp.StatusCode, body)
+	}
+	if atomic.LoadInt32(&dep1Calls) == 0 {
+		t.Error("dep-1 was never called")
+	}
+	if atomic.LoadInt32(&dep2Calls) == 0 {
+		t.Error("dep-2 was never called")
+	}
+}
+
+// ── Cooldown marking ─────────────────────────────────────────────────────────
+
+// TestHandle_429_MarksCooldown verifies that a 429 from a deployment marks
+// that deployment as cooling in the shared cooldown.Registry, keyed exactly
+// as deploymentKey builds it.
+func TestHandle_429_MarksCooldown(t *testing.T) {
+	t.Parallel()
+
+	var dep1Calls, dep2Calls int32
+	srv1 := rateLimitedServer(t, &dep1Calls)
+	srv2 := okServer(t, &dep2Calls)
+
+	dep1 := Deployment{Name: "dep-1", Provider: "openai", BaseURL: srv1.URL, APIKey: "k1", Priority: 1}
+	dep2 := Deployment{Name: "dep-2", Provider: "openai", BaseURL: srv2.URL, APIKey: "k2", Priority: 2}
+
+	const modelName = "cooldown-mark-model"
+	reg := twoDeploymentRegistry(modelName, dep1, dep2)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.Router = &staticDeploymentPicker{deps: []Deployment{dep1, dep2}}
+	handler.CircuitBreakers = newTestCircuitBreakers(1)
+	handler.Cooldowns = cooldown.NewRegistry()
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"`+modelName+`","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	resp.Body.Close()
+
+	depKey := deploymentKey(modelName, "dep-1")
+	if !handler.Cooldowns.Cooling(depKey) {
+		t.Errorf("Cooldowns.Cooling(%q) = false after a 429, want true", depKey)
+	}
+
+	// The deployment that succeeded must NOT be marked cooling.
+	okKey := deploymentKey(modelName, "dep-2")
+	if handler.Cooldowns.Cooling(okKey) {
+		t.Errorf("Cooldowns.Cooling(%q) = true for the successful deployment, want false", okKey)
+	}
+}
+
+// ── retryAfterOrDefault ──────────────────────────────────────────────────────
+
+// TestRetryAfterOrDefault covers header parsing, precedence, and clamping.
+func TestRetryAfterOrDefault(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		headers map[string]string
+		nilResp bool
+		want    time.Duration
+	}{
+		{
+			name:    "nil response uses default",
+			nilResp: true,
+			want:    defaultRateLimitCooldown,
+		},
+		{
+			name:    "no headers present uses default",
+			headers: map[string]string{},
+			want:    defaultRateLimitCooldown,
+		},
+		{
+			name:    "retry-after-ms present",
+			headers: map[string]string{"retry-after-ms": "1500"},
+			want:    1500 * time.Millisecond,
+		},
+		{
+			name:    "retry-after-ms takes precedence over Retry-After",
+			headers: map[string]string{"retry-after-ms": "2000", "Retry-After": "30"},
+			want:    2 * time.Second,
+		},
+		{
+			name:    "Retry-After delta-seconds form",
+			headers: map[string]string{"Retry-After": "5"},
+			want:    5 * time.Second,
+		},
+		{
+			name:    "Retry-After HTTP-date far in the future clamps to max",
+			headers: map[string]string{"Retry-After": time.Now().Add(24 * time.Hour).UTC().Format(http.TimeFormat)},
+			want:    maxRateLimitCooldown,
+		},
+		{
+			name:    "Retry-After HTTP-date in the past clamps to zero",
+			headers: map[string]string{"Retry-After": time.Now().Add(-24 * time.Hour).UTC().Format(http.TimeFormat)},
+			want:    0,
+		},
+		{
+			name:    "Retry-After unparseable garbage uses default",
+			headers: map[string]string{"Retry-After": "not-a-valid-value"},
+			want:    defaultRateLimitCooldown,
+		},
+		{
+			name:    "retry-after-ms far above max clamps",
+			headers: map[string]string{"retry-after-ms": "999999999"},
+			want:    maxRateLimitCooldown,
+		},
+		{
+			name:    "retry-after-ms negative falls through to default",
+			headers: map[string]string{"retry-after-ms": "-100"},
+			want:    defaultRateLimitCooldown,
+		},
+		{
+			name:    "retry-after-ms zero is honored (not clamped to default)",
+			headers: map[string]string{"retry-after-ms": "0"},
+			want:    0,
+		},
+		{
+			name:    "Retry-After negative delta-seconds falls through to default",
+			headers: map[string]string{"Retry-After": "-5"},
+			want:    defaultRateLimitCooldown,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var resp *http.Response
+			if !tc.nilResp {
+				h := make(http.Header)
+				for k, v := range tc.headers {
+					h.Set(k, v)
+				}
+				resp = &http.Response{Header: h}
+			}
+
+			got := retryAfterOrDefault(resp)
+			if got != tc.want {
+				t.Errorf("retryAfterOrDefault() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// ── Model-level fallback on 429 ──────────────────────────────────────────────
+
+// TestHandle_429_TriggersModelFallback verifies that a 429 on model A's only
+// deployment triggers the model-level fallback chain to model B, mirroring
+// TestHandle_FallbackOn500's pattern but for a rate-limit response.
+func TestHandle_429_TriggersModelFallback(t *testing.T) {
+	t.Parallel()
+
+	upstreamA, _ := upstreamCapture(t, http.StatusTooManyRequests,
+		`{"error":{"message":"rate limited"}}`,
+		map[string]string{"Content-Type": "application/json"},
+	)
+	upstreamB, _ := upstreamCapture(t, http.StatusOK,
+		`{"id":"cmp-3","object":"chat.completion","choices":[]}`,
+		map[string]string{"Content-Type": "application/json"},
+	)
+
+	reg := testRegistryWithFallback(t, upstreamA.URL, upstreamB.URL)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.FallbackMaxDepth = 1
+	handler.Cooldowns = cooldown.NewRegistry()
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"model-a","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want %d; body: %s", resp.StatusCode, http.StatusOK, body)
+	}
+}

--- a/internal/proxy/cooldown_failover_test.go
+++ b/internal/proxy/cooldown_failover_test.go
@@ -8,6 +8,7 @@ package proxy
 // success nor a failure.
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"log/slog"
@@ -264,6 +265,226 @@ func singleDeploymentRegistry(modelName, provider, upstreamURL string) *Registry
 	}
 }
 
+// ── Streaming 429 must not touch the breaker ─────────────────────────────────
+
+// TestHandle_StreamingSSE429_LeavesBreakerClosed verifies that when an
+// upstream returns HTTP 429 with Content-Type: text/event-stream, Handle
+// never resolves a circuit breaker for the streaming path — its neutral
+// outcome was already recorded once via RecordNeutral() inside tryModel, and
+// resolving a breaker for handleStreamingResponse as well would let the SSE
+// scan loop additionally record a success or failure once the stream
+// completes, defeating that neutrality.
+//
+// To make a would-be regression observable, the mock upstream's SSE body
+// ends WITHOUT a [DONE] sentinel: handleStreamingResponse's own
+// classification treats a stream that ends without [DONE] as incomplete and
+// calls breaker.RecordFailure() whenever a non-nil breaker was passed in.
+// With a Threshold=1 registry, a regression that still resolves a breaker
+// for a 429 SSE response would trip it Open; the fix (never resolving a
+// breaker for a rate-limited SSE response) leaves it Closed.
+func TestHandle_StreamingSSE429_LeavesBreakerClosed(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusTooManyRequests)
+		flusher := w.(http.Flusher)
+		fmt.Fprintln(w, `data: {"choices":[{"delta":{"content":"a"}}]}`)
+		fmt.Fprintln(w)
+		flusher.Flush()
+		// No [DONE] is ever sent: the handler returns here, so the upstream
+		// connection closes and the client observes a truncated stream.
+	}))
+	t.Cleanup(srv.Close)
+
+	const modelName = "sse-429-model"
+	reg := singleDeploymentRegistry(modelName, "vllm", srv.URL)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.CircuitBreakers = newTestCircuitBreakers(1)
+	handler.Cooldowns = cooldown.NewRegistry()
+
+	baseURL, rawKey := startAuthedTestServer(t, handler, terminationKeyInfo("org-sse-429"))
+
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/v1/chat/completions",
+		strings.NewReader(`{"model":"`+modelName+`","messages":[{"role":"user","content":"hi"}],"stream":true}`))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+rawKey)
+
+	client := &http.Client{Timeout: testTimeout.Timeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429", resp.StatusCode)
+	}
+
+	// Read the full body to EOF. handleStreamingResponse's SendStreamWriter
+	// goroutine performs any breaker recording before it returns, and that
+	// return closes the connection — so observing EOF here happens-after
+	// any such recording, making the subsequent CurrentState() check race-free.
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatalf("read streamed body: %v", err)
+	}
+
+	depKey := deploymentKey(modelName, modelName)
+	if state := handler.CircuitBreakers.Get(depKey).CurrentState(); state != circuitbreaker.Closed {
+		t.Errorf("breaker for %q state = %v after a streaming 429, want Closed (the streaming path "+
+			"must never resolve a breaker for a rate-limited SSE response)", depKey, state)
+	}
+}
+
+// ── Bounded drain: byte cap ───────────────────────────────────────────────────
+
+// TestHandle_429_EndlessBody_FailsOverWithoutBlocking verifies that an
+// unbounded response body on a rate-limited candidate does not prevent
+// failover: tryModel's drain is capped by the effective response-body limit
+// via io.CopyN, so an upstream that keeps writing forever is cut off after
+// exactly that many bytes instead of blocking until EOF (which never
+// arrives).
+func TestHandle_429_EndlessBody_FailsOverWithoutBlocking(t *testing.T) {
+	t.Parallel()
+
+	var dep2Calls int32
+	chunk := bytes.Repeat([]byte("x"), 4096)
+	srv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		flusher := w.(http.Flusher)
+		// Bounded only as a hard safety net (409600 bytes @ 4096/write): the
+		// real termination path is the connection closing once the client
+		// (voidllm) has read its capped share and moved on, either observed
+		// via context cancellation or a failing Write.
+		for i := 0; i < 100_000; i++ {
+			select {
+			case <-r.Context().Done():
+				return
+			default:
+			}
+			if _, err := w.Write(chunk); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}))
+	t.Cleanup(srv1.Close)
+	srv2 := okServer(t, &dep2Calls)
+
+	dep1 := Deployment{Name: "dep-1", Provider: "openai", BaseURL: srv1.URL, APIKey: "k1", Priority: 1}
+	dep2 := Deployment{Name: "dep-2", Provider: "openai", BaseURL: srv2.URL, APIKey: "k2", Priority: 2}
+
+	reg := twoDeploymentRegistry("endless-body-model", dep1, dep2)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.Router = &staticDeploymentPicker{deps: []Deployment{dep1, dep2}}
+	handler.CircuitBreakers = newTestCircuitBreakers(1)
+	handler.Cooldowns = cooldown.NewRegistry()
+	handler.MaxResponseBody = 4096 // small cap: proves the drain stops far short of "endless"
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"endless-body-model","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	start := time.Now()
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+	if atomic.LoadInt32(&dep2Calls) == 0 {
+		t.Error("second deployment (dep-2) was never called")
+	}
+	// The byte cap (4096 bytes) is reached almost instantly, so failover
+	// must complete far faster than the drain time budget — if the drain
+	// were unbounded in size, this request would never return within the
+	// test's overall timeout at all.
+	if elapsed >= failoverDrainBudget {
+		t.Errorf("request took %v, want well under failoverDrainBudget (%v): the byte cap should stop "+
+			"the drain almost immediately regardless of how much more data the upstream has to send",
+			elapsed, failoverDrainBudget)
+	}
+}
+
+// ── Bounded drain: time budget ────────────────────────────────────────────────
+
+// TestHandle_429_StalledBody_FailsOverWithinDrainBudget verifies that a
+// rate-limited candidate whose response headers arrive but whose body never
+// does cannot block failover longer than failoverDrainBudget: the
+// time.AfterFunc armed around the drain cancels the upstream context, which
+// unblocks the stalled read.
+func TestHandle_429_StalledBody_FailsOverWithinDrainBudget(t *testing.T) {
+	t.Parallel()
+
+	var dep2Calls int32
+	stopCh := make(chan struct{})
+	srv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.(http.Flusher).Flush()
+		// Headers are sent; the body never arrives until the test unblocks
+		// this handler at teardown. Registered as a t.Cleanup (closed before
+		// the server itself is, see below) so this goroutine never leaks.
+		<-stopCh
+	}))
+	// Registered before the stopCh-closing cleanup below so it runs AFTER it
+	// (t.Cleanup runs LIFO): stopCh must be closed, unblocking the handler,
+	// before srv1.Close() waits for the in-flight request to finish.
+	t.Cleanup(srv1.Close)
+	t.Cleanup(func() { close(stopCh) })
+	srv2 := okServer(t, &dep2Calls)
+
+	dep1 := Deployment{Name: "dep-1", Provider: "openai", BaseURL: srv1.URL, APIKey: "k1", Priority: 1}
+	dep2 := Deployment{Name: "dep-2", Provider: "openai", BaseURL: srv2.URL, APIKey: "k2", Priority: 2}
+
+	reg := twoDeploymentRegistry("stalled-body-model", dep1, dep2)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.Router = &staticDeploymentPicker{deps: []Deployment{dep1, dep2}}
+	handler.CircuitBreakers = newTestCircuitBreakers(1)
+	handler.Cooldowns = cooldown.NewRegistry()
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"stalled-body-model","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	start := time.Now()
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+	if atomic.LoadInt32(&dep2Calls) == 0 {
+		t.Error("second deployment (dep-2) was never called")
+	}
+
+	// The drain must unblock at failoverDrainBudget, not later. The bound is
+	// derived from the constant itself (rather than a hardcoded duration) so
+	// this assertion tracks failoverDrainBudget if it is ever retuned, while
+	// still catching a regression where the drain blocks indefinitely.
+	bound := 2 * failoverDrainBudget
+	if elapsed >= bound {
+		t.Errorf("request took %v, want < %v (2x failoverDrainBudget=%v): a stalled response body "+
+			"must not block failover longer than the drain budget", elapsed, bound, failoverDrainBudget)
+	}
+}
+
 // ── All candidates rate limited ──────────────────────────────────────────────
 
 // TestHandle_429_AllCandidatesRateLimited verifies that when every deployment
@@ -464,6 +685,45 @@ func TestRetryAfterOrDefault(t *testing.T) {
 			name:    "Retry-After exactly at cap in seconds is honored",
 			headers: map[string]string{"Retry-After": fmt.Sprintf("%d", maxRateLimitCooldownSecs)},
 			want:    maxRateLimitCooldown,
+		},
+		{
+			// Distinct from the math.MaxInt64 case above: this value is too
+			// large for strconv.ParseInt to represent AT ALL (25 digits, far
+			// beyond math.MaxInt64's 19 digits), so ParseInt itself returns
+			// strconv.ErrRange rather than a parsed (and then bounds-checked)
+			// int64. Without isPositiveRangeOverflow catching this via the
+			// "err == nil" check failing, the value would fall through to
+			// HTTP-date parsing (which fails on a bare number) and then
+			// silently return defaultRateLimitCooldown — ignoring an upstream
+			// that unambiguously asked for a very long cooldown, the opposite
+			// of a clamp.
+			name:    "Retry-After 25 digits (beyond math.MaxInt64 parse range) clamps to max",
+			headers: map[string]string{"Retry-After": "9999999999999999999999999"},
+			want:    maxRateLimitCooldown,
+		},
+		{
+			// Same ParseInt-range-overflow case, but for retry-after-ms.
+			name:    "retry-after-ms 25 digits (beyond math.MaxInt64 parse range) clamps to max",
+			headers: map[string]string{"retry-after-ms": "9999999999999999999999999"},
+			want:    maxRateLimitCooldown,
+		},
+		{
+			// The negative counterpart of the ParseInt-range-overflow case:
+			// isPositiveRangeOverflow must return false for a value below
+			// math.MinInt64 (this is nonsensical input, not "ask for a very
+			// long cooldown"), so it must NOT clamp to maxRateLimitCooldown —
+			// it keeps falling through the existing behavior (failed
+			// HTTP-date parse) to defaultRateLimitCooldown, exactly like the
+			// in-range negative cases above.
+			name:    "Retry-After negative 25 digits (beyond range) does not clamp",
+			headers: map[string]string{"Retry-After": "-9999999999999999999999999"},
+			want:    defaultRateLimitCooldown,
+		},
+		{
+			// Same negative-overflow case for retry-after-ms.
+			name:    "retry-after-ms negative 25 digits (beyond range) does not clamp",
+			headers: map[string]string{"retry-after-ms": "-9999999999999999999999999"},
+			want:    defaultRateLimitCooldown,
 		},
 	}
 

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -25,6 +25,7 @@ import (
 	"github.com/voidmind-io/voidllm/internal/apierror"
 	"github.com/voidmind-io/voidllm/internal/auth"
 	"github.com/voidmind-io/voidllm/internal/circuitbreaker"
+	"github.com/voidmind-io/voidllm/internal/cooldown"
 	"github.com/voidmind-io/voidllm/internal/jsonx"
 	"github.com/voidmind-io/voidllm/internal/metrics"
 	"github.com/voidmind-io/voidllm/internal/pii"
@@ -48,6 +49,7 @@ type ProxyHandler struct {
 	AccessCache       *ModelAccessCache        // in-memory model access control; nil disables access checks
 	AliasCache        *AliasCache              // in-memory scoped alias resolution; nil disables alias lookup
 	CircuitBreakers   *circuitbreaker.Registry // per-model circuit breaker registry; nil disables circuit breaking
+	Cooldowns         *cooldown.Registry       // per-deployment rate-limit cooldown tracker; nil disables cooldown tracking
 	Router            DeploymentPicker         // deployment selector; nil falls back to single-deployment behavior
 	HTTPClient        *http.Client
 	UsageLogger       *usage.Logger           // nil disables usage logging
@@ -633,24 +635,44 @@ func (p *ProxyHandler) tryModel(
 
 		metrics.UpstreamRequestsTotal.WithLabelValues(m.Name, m.Provider, strconv.Itoa(currentResp.StatusCode)).Inc()
 
-		if isRetryable(currentResp.StatusCode) && i < len(candidates)-1 {
-			// 5xx response from upstream — try the next deployment. Drain
-			// and close the body before moving on so the connection is
+		if (isRetryable(currentResp.StatusCode) || isRateLimited(currentResp.StatusCode)) && i < len(candidates)-1 {
+			// 5xx or 429 response from upstream — try the next deployment.
+			// Drain and close the body before moving on so the connection is
 			// returned to the pool.
+			rateLimited := isRateLimited(currentResp.StatusCode)
+			retryAfter := retryAfterOrDefault(currentResp)
 			_, _ = io.Copy(io.Discard, currentResp.Body)
 			_ = currentResp.Body.Close()
 			cancelUpstream()
-			if p.CircuitBreakers != nil {
-				p.CircuitBreakers.Get(depKey).RecordFailure()
+			if rateLimited {
+				// A rate-limited upstream is not broken — recording it as a
+				// circuit-breaker failure would erase real accumulated
+				// failures on RecordSuccess and mis-trip the breaker on
+				// RecordFailure. Instead, park the deployment in the
+				// cooldown registry so the router deprioritizes it for a
+				// short window.
+				p.Cooldowns.Mark(depKey, retryAfter)
+				metrics.RateLimitFailoversTotal.WithLabelValues(model.Name, depKey).Inc()
+				p.Log.LogAttrs(c.Context(), slog.LevelWarn, "upstream rate limited, retrying next deployment",
+					slog.String("model", m.Name),
+					slog.String("deployment", d.Name),
+					slog.String("provider", m.Provider),
+					slog.Int("candidate", i),
+					slog.Duration("cooldown", retryAfter),
+				)
+			} else {
+				if p.CircuitBreakers != nil {
+					p.CircuitBreakers.Get(depKey).RecordFailure()
+				}
+				metrics.UpstreamErrorsTotal.WithLabelValues(m.Name, m.Provider).Inc()
+				p.Log.LogAttrs(c.Context(), slog.LevelWarn, "upstream returned retryable error, retrying next deployment",
+					slog.String("model", m.Name),
+					slog.String("deployment", d.Name),
+					slog.String("provider", m.Provider),
+					slog.Int("candidate", i),
+					slog.Int("status", currentResp.StatusCode),
+				)
 			}
-			metrics.UpstreamErrorsTotal.WithLabelValues(m.Name, m.Provider).Inc()
-			p.Log.LogAttrs(c.Context(), slog.LevelWarn, "upstream returned retryable error, retrying next deployment",
-				slog.String("model", m.Name),
-				slog.String("deployment", d.Name),
-				slog.String("provider", m.Provider),
-				slog.Int("candidate", i),
-				slog.Int("status", currentResp.StatusCode),
-			)
 			lastErr = errors.New("upstream returned " + strconv.Itoa(currentResp.StatusCode))
 			req = nil
 			cancelUpstream = nil
@@ -659,11 +681,17 @@ func (p *ProxyHandler) tryModel(
 			continue
 		}
 
-		// Success or non-retryable status (4xx, or last retryable with no
-		// more candidates). Record circuit breaker outcome for non-streaming
-		// responses immediately; streaming outcome is recorded inside the
-		// goroutine once the stream completes.
-		if p.CircuitBreakers != nil && !isStreamingResponse(currentResp) {
+		// Success or non-retryable status (4xx, or last retryable/rate-limited
+		// with no more candidates). Record circuit breaker outcome for
+		// non-streaming responses immediately; streaming outcome is recorded
+		// inside the goroutine once the stream completes. A 429 is NEUTRAL —
+		// it is neither a success (RecordSuccess would erase real accumulated
+		// failures) nor a breaker failure (a rate-limited upstream is not
+		// broken) — but the deployment is still marked cooling so the next
+		// request does not try it first again.
+		if isRateLimited(currentResp.StatusCode) {
+			p.Cooldowns.Mark(depKey, retryAfterOrDefault(currentResp))
+		} else if p.CircuitBreakers != nil && !isStreamingResponse(currentResp) {
 			breaker := p.CircuitBreakers.Get(depKey)
 			if currentResp.StatusCode >= 500 {
 				breaker.RecordFailure()
@@ -1810,11 +1838,90 @@ func applyDeployment(model *Model, dep Deployment) {
 // indicate a server-side problem that a different backend may not share.
 // 4xx errors are client errors that will recur regardless of which deployment
 // is used, so they are not retried.
+//
+// isRetryable is deliberately kept separate from isRateLimited even though
+// callers usually OR the two together to decide whether to try the next
+// candidate: the two carry different circuit-breaker semantics. A 5xx means
+// the deployment itself is broken and must count as a circuit-breaker
+// failure; a 429 (see isRateLimited) means the deployment is healthy but
+// temporarily throttled and must never trip or reset the circuit breaker —
+// it is tracked separately via the cooldown registry instead.
 func isRetryable(statusCode int) bool {
 	return statusCode == http.StatusInternalServerError ||
 		statusCode == http.StatusBadGateway ||
 		statusCode == http.StatusServiceUnavailable ||
 		statusCode == http.StatusGatewayTimeout
+}
+
+// isRateLimited reports whether an HTTP status code from an upstream response
+// is a rate-limit rejection (429). See isRetryable's godoc for why this is a
+// distinct predicate rather than folded into isRetryable.
+func isRateLimited(statusCode int) bool {
+	return statusCode == http.StatusTooManyRequests
+}
+
+// defaultRateLimitCooldown and maxRateLimitCooldown govern how long a
+// deployment is parked in the cooldown registry after returning HTTP 429.
+// Neither is configurable in v1.
+const (
+	// defaultRateLimitCooldown is applied when the upstream response carries
+	// no usable Retry-After / retry-after-ms hint. A few seconds is enough to
+	// skip the deployment for the next handful of requests without assuming a
+	// specific rate-limit window when the upstream did not say one.
+	defaultRateLimitCooldown = 3 * time.Second
+
+	// maxRateLimitCooldown caps the cooldown even when the upstream requests
+	// a much longer wait (e.g. "Retry-After: 3600"). A single 429 response
+	// must never park a deployment for anywhere close to that long; one
+	// minute is a generous upper bound that still meaningfully deprioritizes
+	// the deployment without contributing to an hour of reduced capacity.
+	maxRateLimitCooldown = 60 * time.Second
+)
+
+// retryAfterOrDefault returns the cooldown duration to apply for a 429
+// response. It reads the standard Retry-After header (RFC 7231), supporting
+// both the delta-seconds form ("120") and the HTTP-date form ("Fri, 31 Dec
+// 1999 23:59:59 GMT"), and the OpenAI-specific "retry-after-ms" header
+// (milliseconds) as a higher-resolution alternative, preferring the latter
+// when both are present. When neither header is present or parseable,
+// defaultRateLimitCooldown is used. The result is always clamped to
+// [0, maxRateLimitCooldown].
+func retryAfterOrDefault(resp *http.Response) time.Duration {
+	if resp == nil {
+		return defaultRateLimitCooldown
+	}
+
+	if ms := resp.Header.Get("retry-after-ms"); ms != "" {
+		if n, err := strconv.Atoi(strings.TrimSpace(ms)); err == nil && n >= 0 {
+			return clampCooldown(time.Duration(n) * time.Millisecond)
+		}
+	}
+
+	ra := resp.Header.Get("Retry-After")
+	if ra == "" {
+		return defaultRateLimitCooldown
+	}
+	if secs, err := strconv.Atoi(strings.TrimSpace(ra)); err == nil && secs >= 0 {
+		return clampCooldown(time.Duration(secs) * time.Second)
+	}
+	if when, err := http.ParseTime(ra); err == nil {
+		return clampCooldown(time.Until(when))
+	}
+
+	return defaultRateLimitCooldown
+}
+
+// clampCooldown bounds d to [0, maxRateLimitCooldown]. A negative input
+// (e.g. an HTTP-date Retry-After value already in the past) clamps to zero,
+// which makes the subsequent Registry.Mark call a no-op.
+func clampCooldown(d time.Duration) time.Duration {
+	if d < 0 {
+		return 0
+	}
+	if d > maxRateLimitCooldown {
+		return maxRateLimitCooldown
+	}
+	return d
 }
 
 // extractUsage parses token counts from a non-streaming OpenAI-format response
@@ -1863,8 +1970,9 @@ func mutateRequestBody(body []byte, canonicalModel string, injectUsage bool) []b
 //
 // Network / DNS / dial / timeout errors are eligible. Context cancellation is
 // NOT eligible — the client went away and there is no point retrying. 5xx
-// responses are eligible; 4xx are not (bad request or auth failure will recur
-// on any backend).
+// responses are eligible, as is 429 (rate limited — a different model may
+// have separate quota); other 4xx are not (bad request or auth failure will
+// recur on any backend).
 func isFallbackEligible(statusCode int, err error) bool {
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
@@ -1872,7 +1980,7 @@ func isFallbackEligible(statusCode int, err error) bool {
 		}
 		return true
 	}
-	return statusCode >= 500 && statusCode < 600
+	return (statusCode >= 500 && statusCode < 600) || statusCode == http.StatusTooManyRequests
 }
 
 // rewriteModelInBody replaces the "model" field inside a JSON request body

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -139,6 +139,34 @@ const (
 // when the upstream is actually stuck.
 const failoverDrainBudget = 2 * time.Second
 
+// boundedDrainAndClose drains up to maxRespBody bytes from body, then closes
+// it and cancels the upstream request context. It is used before every
+// failover hop (both across candidate deployments within a model, in
+// tryModel, and across models in the fallback chain, in Handle) so the
+// underlying TCP connection can be returned to the transport's pool for
+// reuse. The drain is a courtesy only — it has no effect on the failover
+// decision itself, and any error it returns is discarded.
+//
+// The byte cap alone does not bound a stalled upstream: an upstream that
+// sends response headers and then never sends another body byte would block
+// io.CopyN forever, and failover would never happen. A wall-clock timer
+// (failoverDrainBudget) cancels the upstream context to unblock the in-flight
+// read; the timer is always stopped before this function returns, so no
+// goroutine is left behind. The context cancellation this produces (like any
+// other drain error, e.g. the normal io.EOF when the body is shorter than
+// the cap) is ignored — this is a best-effort drain, not a read whose
+// outcome affects the response.
+func boundedDrainAndClose(body io.ReadCloser, cancel context.CancelFunc, maxRespBody int) {
+	drainTimer := time.AfterFunc(failoverDrainBudget, cancel)
+	// Discarded: best-effort drain only, see godoc above.
+	_, _ = io.CopyN(io.Discard, body, int64(maxRespBody))
+	drainTimer.Stop()
+	// Discarded: closing an already-failed-over connection cannot fail in a
+	// way that affects the caller.
+	_ = body.Close()
+	cancel()
+}
+
 // streamUsageExtractor observes OpenAI-format SSE lines and records the last
 // usage object seen. Passthrough providers (vllm, custom) emit usage only on
 // the final data chunk when stream_options.include_usage is set.
@@ -460,12 +488,13 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 			slog.Int("depth", depth+1),
 		)
 
-		// Drain and discard the current 5xx response before moving on so
-		// the upstream connection is returned to the pool cleanly.
+		// Drain and discard the current 5xx/429 response before moving on so
+		// the upstream connection is returned to the pool cleanly. Bounded in
+		// both size (maxRespBody) and time (failoverDrainBudget) — see
+		// boundedDrainAndClose — so a stalled or endlessly streaming upstream
+		// cannot block this fallback hop indefinitely.
 		if resp != nil {
-			_, _ = io.Copy(io.Discard, resp.Body)
-			_ = resp.Body.Close()
-			cancelUpstream()
+			boundedDrainAndClose(resp.Body, cancelUpstream, maxRespBody)
 			resp = nil
 			cancelUpstream = nil
 		}
@@ -672,22 +701,10 @@ func (p *ProxyHandler) tryModel(
 			rateLimited := isRateLimited(currentResp.StatusCode)
 			retryAfter := retryAfterOrDefault(currentResp)
 			// Bounded drain: an upstream that sends headers and then stalls or
-			// streams endlessly must never block failover. maxRespBody bounds
-			// the drain in size; failoverDrainBudget bounds it in time — a
-			// stalled upstream (headers sent, body never arrives) would
-			// otherwise block io.CopyN forever regardless of the byte cap. The
-			// timer cancels the upstream context, which unblocks the in-flight
-			// body read immediately; it is always stopped before this branch
-			// returns so no goroutine is left behind. Any drain error
-			// (including io.EOF, the normal case when the body is shorter than
-			// the cap, and context.Canceled from the timer firing) is ignored —
-			// this is a best-effort drain to return the connection to the pool
-			// cleanly, not a read whose outcome affects the response.
-			drainTimer := time.AfterFunc(failoverDrainBudget, cancelUpstream)
-			_, _ = io.CopyN(io.Discard, currentResp.Body, int64(maxRespBody))
-			drainTimer.Stop()
-			_ = currentResp.Body.Close()
-			cancelUpstream()
+			// streams endlessly must never block failover. See
+			// boundedDrainAndClose for the size/time bounds and why the
+			// resulting drain error is always ignored.
+			boundedDrainAndClose(currentResp.Body, cancelUpstream, maxRespBody)
 			if rateLimited {
 				// A rate-limited upstream is not broken — recording it as a
 				// circuit-breaker failure would erase real accumulated

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -1876,6 +1876,18 @@ const (
 	// minute is a generous upper bound that still meaningfully deprioritizes
 	// the deployment without contributing to an hour of reduced capacity.
 	maxRateLimitCooldown = 60 * time.Second
+
+	// maxRateLimitCooldownMs and maxRateLimitCooldownSecs are
+	// maxRateLimitCooldown expressed in the unit of the corresponding
+	// Retry-After header. Both are compile-time constant expressions (no
+	// runtime division), used by retryAfterOrDefault to bounds-check a
+	// parsed header value BEFORE multiplying it into a time.Duration —
+	// multiplying an attacker- or upstream-controlled integer first and
+	// clamping afterwards lets a large-enough value overflow int64 and wrap
+	// to a negative duration, which is exactly the failure clampCooldown
+	// cannot recover from.
+	maxRateLimitCooldownMs   = int64(maxRateLimitCooldown / time.Millisecond)
+	maxRateLimitCooldownSecs = int64(maxRateLimitCooldown / time.Second)
 )
 
 // retryAfterOrDefault returns the cooldown duration to apply for a 429
@@ -1884,15 +1896,25 @@ const (
 // 1999 23:59:59 GMT"), and the OpenAI-specific "retry-after-ms" header
 // (milliseconds) as a higher-resolution alternative, preferring the latter
 // when both are present. When neither header is present or parseable,
-// defaultRateLimitCooldown is used. The result is always clamped to
-// [0, maxRateLimitCooldown].
+// defaultRateLimitCooldown is used.
+//
+// The result is always within [0, maxRateLimitCooldown]. Header values are
+// parsed as 64-bit integers and bounds-checked against maxRateLimitCooldown
+// (expressed in the header's own unit) before the multiplication that
+// converts them into a time.Duration, so a value large enough to otherwise
+// overflow int64 — e.g. "Retry-After: 9999999999" or a comparably large
+// "retry-after-ms" — clamps to maxRateLimitCooldown directly instead of
+// silently wrapping to a negative duration.
 func retryAfterOrDefault(resp *http.Response) time.Duration {
 	if resp == nil {
 		return defaultRateLimitCooldown
 	}
 
 	if ms := resp.Header.Get("retry-after-ms"); ms != "" {
-		if n, err := strconv.Atoi(strings.TrimSpace(ms)); err == nil && n >= 0 {
+		if n, err := strconv.ParseInt(strings.TrimSpace(ms), 10, 64); err == nil && n >= 0 {
+			if n > maxRateLimitCooldownMs {
+				return maxRateLimitCooldown
+			}
 			return clampCooldown(time.Duration(n) * time.Millisecond)
 		}
 	}
@@ -1901,7 +1923,10 @@ func retryAfterOrDefault(resp *http.Response) time.Duration {
 	if ra == "" {
 		return defaultRateLimitCooldown
 	}
-	if secs, err := strconv.Atoi(strings.TrimSpace(ra)); err == nil && secs >= 0 {
+	if secs, err := strconv.ParseInt(strings.TrimSpace(ra), 10, 64); err == nil && secs >= 0 {
+		if secs > maxRateLimitCooldownSecs {
+			return maxRateLimitCooldown
+		}
 		return clampCooldown(time.Duration(secs) * time.Second)
 	}
 	if when, err := http.ParseTime(ra); err == nil {

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -614,11 +614,16 @@ func (p *ProxyHandler) tryModel(
 	for i, d := range candidates {
 		depKey := deploymentKey(model.Name, d.Name)
 
-		// Per-deployment circuit breaker check. The router's filterAvailable
-		// already excludes open breakers when Router is non-nil, so we only
-		// guard the synthesized single-candidate ourselves when Router is nil.
-		if p.CircuitBreakers != nil && p.Router == nil {
-			breaker := p.CircuitBreakers.Get(depKey)
+		// Per-deployment circuit breaker check, consulted for EVERY candidate
+		// at the moment it is about to be attempted — regardless of whether a
+		// Router is configured. The router's filterAvailable only peeks with
+		// the non-reserving Permits() when building the candidate list (see
+		// its godoc); Allow() here is the sole place that actually reserves a
+		// probe slot, so it must run once per candidate actually attempted,
+		// not be skipped just because a Router already looked at it.
+		var breaker *circuitbreaker.Breaker
+		if p.CircuitBreakers != nil {
+			breaker = p.CircuitBreakers.Get(depKey)
 			if !breaker.Allow() {
 				metrics.CircuitBreakerRejectionsTotal.WithLabelValues(depKey).Inc()
 				// Continue to the next candidate; if this is the only one,
@@ -626,6 +631,31 @@ func (p *ProxyHandler) tryModel(
 				// below.
 				continue
 			}
+		}
+
+		// resolved and handedToCaller track whether the probe reservation
+		// breaker.Allow() just granted (if breaker != nil) has been accounted
+		// for by the time this iteration's control flow leaves the loop body.
+		// Allow's godoc requires every true return to be balanced by exactly
+		// one RecordSuccess/RecordFailure/RecordNeutral call; resolved is set
+		// at every point below that makes one. handedToCaller marks the sole
+		// legitimate exception: the streaming branch deliberately leaves the
+		// reservation open because handleStreamingResponse records the
+		// verdict once the stream completes — see the comment there.
+		//
+		// The defer is what makes this structural rather than a "remember to
+		// call it" convention: it fires no later than tryModel's return (in
+		// particular, immediately, on the buildUpstreamRequest failure path
+		// below) and releases the reservation whenever neither flag ended up
+		// set, so a future early return or continue added to this iteration
+		// cannot silently reintroduce a leaked reservation.
+		var resolved, handedToCaller bool
+		if breaker != nil {
+			defer func() {
+				if !resolved && !handedToCaller {
+					breaker.RecordNeutral()
+				}
+			}()
 		}
 
 		// Overlay the deployment's endpoint fields onto a copy of the resolved
@@ -673,8 +703,9 @@ func (p *ProxyHandler) tryModel(
 		if doErr != nil {
 			// Connection-level error: transport failure, DNS, timeout.
 			cancelUpstream()
-			if p.CircuitBreakers != nil {
-				p.CircuitBreakers.Get(depKey).RecordFailure()
+			if breaker != nil {
+				breaker.RecordFailure()
+				resolved = true
 			}
 			metrics.UpstreamErrorsTotal.WithLabelValues(m.Name, m.Provider).Inc()
 			p.Log.LogAttrs(c.Context(), slog.LevelWarn, "upstream request failed, retrying next deployment",
@@ -712,11 +743,12 @@ func (p *ProxyHandler) tryModel(
 				// RecordFailure. Instead, park the deployment in the
 				// cooldown registry so the router deprioritizes it for a
 				// short window.
-				if p.CircuitBreakers != nil {
+				if breaker != nil {
 					// Neutral: releases the half-open probe reservation Allow()
 					// took for this request (if any) without treating the 429 as
 					// a success or a failure. See RecordNeutral's godoc.
-					p.CircuitBreakers.Get(depKey).RecordNeutral()
+					breaker.RecordNeutral()
+					resolved = true
 				}
 				p.Cooldowns.Mark(depKey, retryAfter)
 				metrics.RateLimitFailoversTotal.WithLabelValues(model.Name, depKey).Inc()
@@ -728,8 +760,9 @@ func (p *ProxyHandler) tryModel(
 					slog.Duration("cooldown", retryAfter),
 				)
 			} else {
-				if p.CircuitBreakers != nil {
-					p.CircuitBreakers.Get(depKey).RecordFailure()
+				if breaker != nil {
+					breaker.RecordFailure()
+					resolved = true
 				}
 				metrics.UpstreamErrorsTotal.WithLabelValues(m.Name, m.Provider).Inc()
 				p.Log.LogAttrs(c.Context(), slog.LevelWarn, "upstream returned retryable error, retrying next deployment",
@@ -757,20 +790,28 @@ func (p *ProxyHandler) tryModel(
 		// broken) — but the deployment is still marked cooling so the next
 		// request does not try it first again.
 		if isRateLimited(currentResp.StatusCode) {
-			if p.CircuitBreakers != nil {
+			if breaker != nil {
 				// Neutral: releases the half-open probe reservation Allow() took
 				// for this request (if any) without treating the 429 as a
 				// success or a failure. See RecordNeutral's godoc.
-				p.CircuitBreakers.Get(depKey).RecordNeutral()
+				breaker.RecordNeutral()
+				resolved = true
 			}
 			p.Cooldowns.Mark(depKey, retryAfterOrDefault(currentResp))
-		} else if p.CircuitBreakers != nil && !isStreamingResponse(currentResp) {
-			breaker := p.CircuitBreakers.Get(depKey)
+		} else if breaker != nil && !isStreamingResponse(currentResp) {
 			if currentResp.StatusCode >= 500 {
 				breaker.RecordFailure()
 			} else {
 				breaker.RecordSuccess()
 			}
+			resolved = true
+		} else if breaker != nil {
+			// Streaming response, not rate-limited: the reservation is
+			// deliberately left open. The response (and this reservation)
+			// are being handed back to the caller — handleStreamingResponse
+			// records the verdict once the stream completes, so recording
+			// one here would double-record against the same reservation.
+			handedToCaller = true
 		}
 
 		dep = d
@@ -1428,7 +1469,12 @@ func (p *ProxyHandler) handleStreamingResponse(c fiber.Ctx, resp *http.Response,
 				case streamAborted:
 					breaker.RecordFailure()
 				case clientDisconnected:
-					// Client hung up — neither success nor failure on the upstream side.
+					// Client hung up — neither success nor failure on the
+					// upstream side, but the reservation Allow() took for
+					// this request (if any) must still be released so a
+					// future request can probe again. See RecordNeutral's
+					// godoc.
+					breaker.RecordNeutral()
 				case !terminalSeen:
 					// Upstream closed the connection without sending [DONE].
 					// This is a truncated response — treat as upstream failure.
@@ -1695,7 +1741,11 @@ func (p *ProxyHandler) handleStreamingResponse(c fiber.Ctx, resp *http.Response,
 				switch {
 				case clientDisconnected:
 					// Client hung up — neither success nor failure on the
-					// upstream side.
+					// upstream side, but the reservation Allow() took for
+					// this request (if any) must still be released so a
+					// future request can probe again. See RecordNeutral's
+					// godoc.
+					breaker.RecordNeutral()
 				case terminalSeen:
 					breaker.RecordSuccess()
 				default:

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -122,6 +122,23 @@ const (
 	defaultMaxStreamDuration = 300 * time.Second // 5 minutes
 )
 
+// failoverDrainBudget bounds, in wall-clock time, how long tryModel will
+// block draining a discarded 5xx/429 response body before giving up on
+// connection reuse and moving on to the next candidate deployment.
+//
+// The byte cap (maxRespBody) alone does not bound a stalled upstream: an
+// upstream that sends response headers and then never sends another body
+// byte would block io.CopyN forever, and failover would never happen.
+// Draining exists purely as a courtesy so the underlying TCP connection can
+// be returned to the transport's pool for reuse — it has no effect on
+// correctness of the failover decision itself. Giving up quickly and
+// losing that connection (it gets closed instead of pooled) is strictly
+// better than blocking failover on a stalled upstream, so this budget is
+// kept short: two seconds is enough for a healthy, merely-slow upstream to
+// finish flushing a small discarded body, while still failing over fast
+// when the upstream is actually stuck.
+const failoverDrainBudget = 2 * time.Second
+
 // streamUsageExtractor observes OpenAI-format SSE lines and records the last
 // usage object seen. Passthrough providers (vllm, custom) emit usage only on
 // the final data chunk when stream_options.include_usage is set.
@@ -351,7 +368,7 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 		// body variant per deployment, after applyDeployment has resolved the
 		// effective provider. This is the fix for VULN-001: the body selection
 		// must happen inside the deployment loop, not at the loop's call site.
-		resp, cancelUpstream, adapter, usedDep, lastErr, lastStatus, tryErr = p.tryModel(c, currentModel, pickBody, envelope)
+		resp, cancelUpstream, adapter, usedDep, lastErr, lastStatus, tryErr = p.tryModel(c, currentModel, pickBody, envelope, maxRespBody)
 		if tryErr != nil {
 			// tryModel wrote an error response to c (errResponseSent) or
 			// returned a framework error. Either way, stop immediately.
@@ -474,7 +491,14 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 
 	if isStreamingResponse(resp) {
 		var breaker *circuitbreaker.Breaker
-		if p.CircuitBreakers != nil {
+		// A 429 can carry Content-Type: text/event-stream and still be
+		// dispatched into handleStreamingResponse below. Its neutral outcome
+		// was already recorded via RecordNeutral() in tryModel; resolving a
+		// breaker here as well would let handleStreamingResponse additionally
+		// record success/failure when the stream ends, defeating that
+		// neutrality. isStreamingResponse itself is left untouched so the
+		// handling of other non-2xx SSE responses is unaffected.
+		if p.CircuitBreakers != nil && !isRateLimited(resp.StatusCode) {
 			breaker = p.CircuitBreakers.Get(deploymentKey(currentModel.Name, usedDep.Name))
 		}
 		return p.handleStreamingResponse(c, resp, cancelUpstream, currentModel,
@@ -500,6 +524,11 @@ func (p *ProxyHandler) Handle(c fiber.Ctx) error {
 // model-level provider field. When PII anonymization is disabled, pickBody
 // always returns the original body.
 //
+// maxRespBody is the caller's resolved response-body limit (see
+// resolveEffectiveLimits) and bounds the drain of a retryable/rate-limited
+// response body before failing over to the next candidate, so a stalling or
+// endlessly streaming upstream cannot block failover indefinitely.
+//
 // Return values:
 //   - resp: the upstream response, or nil if all candidates failed.
 //   - cancel: the cancel func for the upstream request context. Non-nil only
@@ -515,6 +544,7 @@ func (p *ProxyHandler) tryModel(
 	model Model,
 	pickBody func(dep Deployment) []byte,
 	envelope requestEnvelope,
+	maxRespBody int,
 ) (*http.Response, context.CancelFunc, Adapter, Deployment, error, int, error) {
 	// Build the ordered list of deployment candidates. When Router is nil or
 	// the model has no multi-deployment configuration, synthesize a single
@@ -641,7 +671,21 @@ func (p *ProxyHandler) tryModel(
 			// returned to the pool.
 			rateLimited := isRateLimited(currentResp.StatusCode)
 			retryAfter := retryAfterOrDefault(currentResp)
-			_, _ = io.Copy(io.Discard, currentResp.Body)
+			// Bounded drain: an upstream that sends headers and then stalls or
+			// streams endlessly must never block failover. maxRespBody bounds
+			// the drain in size; failoverDrainBudget bounds it in time — a
+			// stalled upstream (headers sent, body never arrives) would
+			// otherwise block io.CopyN forever regardless of the byte cap. The
+			// timer cancels the upstream context, which unblocks the in-flight
+			// body read immediately; it is always stopped before this branch
+			// returns so no goroutine is left behind. Any drain error
+			// (including io.EOF, the normal case when the body is shorter than
+			// the cap, and context.Canceled from the timer firing) is ignored —
+			// this is a best-effort drain to return the connection to the pool
+			// cleanly, not a read whose outcome affects the response.
+			drainTimer := time.AfterFunc(failoverDrainBudget, cancelUpstream)
+			_, _ = io.CopyN(io.Discard, currentResp.Body, int64(maxRespBody))
+			drainTimer.Stop()
 			_ = currentResp.Body.Close()
 			cancelUpstream()
 			if rateLimited {
@@ -651,6 +695,12 @@ func (p *ProxyHandler) tryModel(
 				// RecordFailure. Instead, park the deployment in the
 				// cooldown registry so the router deprioritizes it for a
 				// short window.
+				if p.CircuitBreakers != nil {
+					// Neutral: releases the half-open probe reservation Allow()
+					// took for this request (if any) without treating the 429 as
+					// a success or a failure. See RecordNeutral's godoc.
+					p.CircuitBreakers.Get(depKey).RecordNeutral()
+				}
 				p.Cooldowns.Mark(depKey, retryAfter)
 				metrics.RateLimitFailoversTotal.WithLabelValues(model.Name, depKey).Inc()
 				p.Log.LogAttrs(c.Context(), slog.LevelWarn, "upstream rate limited, retrying next deployment",
@@ -690,6 +740,12 @@ func (p *ProxyHandler) tryModel(
 		// broken) — but the deployment is still marked cooling so the next
 		// request does not try it first again.
 		if isRateLimited(currentResp.StatusCode) {
+			if p.CircuitBreakers != nil {
+				// Neutral: releases the half-open probe reservation Allow() took
+				// for this request (if any) without treating the 429 as a
+				// success or a failure. See RecordNeutral's godoc.
+				p.CircuitBreakers.Get(depKey).RecordNeutral()
+			}
 			p.Cooldowns.Mark(depKey, retryAfterOrDefault(currentResp))
 		} else if p.CircuitBreakers != nil && !isStreamingResponse(currentResp) {
 			breaker := p.CircuitBreakers.Get(depKey)
@@ -1905,17 +1961,30 @@ const (
 // overflow int64 — e.g. "Retry-After: 9999999999" or a comparably large
 // "retry-after-ms" — clamps to maxRateLimitCooldown directly instead of
 // silently wrapping to a negative duration.
+//
+// A positive decimal value too large for strconv.ParseInt to represent at
+// all (i.e. larger than math.MaxInt64) also clamps to maxRateLimitCooldown,
+// via isPositiveRangeOverflow, rather than falling through to HTTP-date
+// parsing (which would fail) and then the default cooldown — that fallback
+// would silently ignore an upstream that unambiguously asked for a very long
+// cooldown. A negative value that overflows (below math.MinInt64) is
+// nonsensical input and keeps falling through to the existing behavior.
 func retryAfterOrDefault(resp *http.Response) time.Duration {
 	if resp == nil {
 		return defaultRateLimitCooldown
 	}
 
 	if ms := resp.Header.Get("retry-after-ms"); ms != "" {
-		if n, err := strconv.ParseInt(strings.TrimSpace(ms), 10, 64); err == nil && n >= 0 {
-			if n > maxRateLimitCooldownMs {
-				return maxRateLimitCooldown
+		trimmed := strings.TrimSpace(ms)
+		if n, err := strconv.ParseInt(trimmed, 10, 64); err == nil {
+			if n >= 0 {
+				if n > maxRateLimitCooldownMs {
+					return maxRateLimitCooldown
+				}
+				return clampCooldown(time.Duration(n) * time.Millisecond)
 			}
-			return clampCooldown(time.Duration(n) * time.Millisecond)
+		} else if isPositiveRangeOverflow(trimmed, err) {
+			return maxRateLimitCooldown
 		}
 	}
 
@@ -1923,17 +1992,34 @@ func retryAfterOrDefault(resp *http.Response) time.Duration {
 	if ra == "" {
 		return defaultRateLimitCooldown
 	}
-	if secs, err := strconv.ParseInt(strings.TrimSpace(ra), 10, 64); err == nil && secs >= 0 {
-		if secs > maxRateLimitCooldownSecs {
-			return maxRateLimitCooldown
+	trimmedRA := strings.TrimSpace(ra)
+	if secs, err := strconv.ParseInt(trimmedRA, 10, 64); err == nil {
+		if secs >= 0 {
+			if secs > maxRateLimitCooldownSecs {
+				return maxRateLimitCooldown
+			}
+			return clampCooldown(time.Duration(secs) * time.Second)
 		}
-		return clampCooldown(time.Duration(secs) * time.Second)
+	} else if isPositiveRangeOverflow(trimmedRA, err) {
+		return maxRateLimitCooldown
 	}
 	if when, err := http.ParseTime(ra); err == nil {
 		return clampCooldown(time.Until(when))
 	}
 
 	return defaultRateLimitCooldown
+}
+
+// isPositiveRangeOverflow reports whether err is the strconv.ErrRange range
+// error produced by parsing s (already trimmed) as a positive decimal
+// integer literal that does not fit in an int64. strconv.ParseInt returns
+// ErrRange both for positive values above math.MaxInt64 and for negative
+// values below math.MinInt64; only the positive case unambiguously means
+// "the upstream asked for a cooldown longer than we will ever honor" and
+// should clamp to maxRateLimitCooldown instead of falling through to the
+// existing default-cooldown behavior.
+func isPositiveRangeOverflow(s string, err error) bool {
+	return errors.Is(err, strconv.ErrRange) && !strings.HasPrefix(s, "-")
 }
 
 // clampCooldown bounds d to [0, maxRateLimitCooldown]. A negative input

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -1465,8 +1465,9 @@ func TestIsFallbackEligible(t *testing.T) {
 		{"401 not eligible", 401, nil, false},
 		{"403 not eligible", 403, nil, false},
 		{"404 not eligible", 404, nil, false},
-		// 429 is 4xx — not eligible per production code.
-		{"429 not eligible", 429, nil, false},
+		// 429 is rate limiting, not a broken deployment — a different model
+		// may have separate quota, so fallback is eligible per production code.
+		{"429 eligible", 429, nil, true},
 		// 200 success is not eligible.
 		{"200 not eligible", 200, nil, false},
 		// Network error with no status is eligible.

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -1106,6 +1106,79 @@ func TestHandle_FallbackOn500(t *testing.T) {
 	}
 }
 
+// TestHandle_ModelFallback_429StalledBody_FailsOverWithinDrainBudget verifies
+// that the model-level fallback hop in Handle (as opposed to tryModel's
+// per-deployment retry) is not blocked by a stalled 429 body: model-a's only
+// deployment sends 429 response headers and then never writes body bytes.
+// Handle must drain that response via boundedDrainAndClose — bounded by
+// failoverDrainBudget — before hopping to model-b, whose 200 response the
+// client must ultimately receive within a bound derived from
+// failoverDrainBudget itself.
+func TestHandle_ModelFallback_429StalledBody_FailsOverWithinDrainBudget(t *testing.T) {
+	t.Parallel()
+
+	var bCalls int32
+	stopCh := make(chan struct{})
+	upstreamA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.(http.Flusher).Flush()
+		// Headers are sent; the body never arrives until the test unblocks
+		// this handler at teardown. Registered as a t.Cleanup (closed before
+		// the server itself is, see below) so this goroutine never leaks.
+		<-stopCh
+	}))
+	// Registered before the stopCh-closing cleanup below so it runs AFTER it
+	// (t.Cleanup runs LIFO): stopCh must be closed, unblocking the handler,
+	// before upstreamA.Close() waits for the in-flight request to finish.
+	t.Cleanup(upstreamA.Close)
+	t.Cleanup(func() { close(stopCh) })
+
+	upstreamB := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&bCalls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"id":"cmp-3","object":"chat.completion","choices":[{"message":{"role":"assistant","content":"hello from B"}}]}`)
+	}))
+	t.Cleanup(upstreamB.Close)
+
+	reg := testRegistryWithFallback(t, upstreamA.URL, upstreamB.URL)
+	handler := NewProxyHandler(reg, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	handler.FallbackMaxDepth = 1
+	app := testApp(t, handler)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"model-a","messages":[]}`))
+	req.Header.Set("Content-Type", "application/json")
+
+	start := time.Now()
+	resp, err := app.Test(req, testTimeout)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want %d; body: %s", resp.StatusCode, http.StatusOK, body)
+	}
+	if atomic.LoadInt32(&bCalls) == 0 {
+		t.Error("model-b was never called")
+	}
+
+	// The drain must unblock at failoverDrainBudget, not later. The bound is
+	// derived from the constant itself (rather than a hardcoded duration) so
+	// this assertion tracks failoverDrainBudget if it is ever retuned, while
+	// still catching a regression where the model-level fallback drain in
+	// Handle blocks indefinitely on a stalled body.
+	bound := 2 * failoverDrainBudget
+	if elapsed >= bound {
+		t.Errorf("request took %v, want < %v (2x failoverDrainBudget=%v): a stalled 429 body "+
+			"must not block model-level fallback longer than the drain budget", elapsed, bound, failoverDrainBudget)
+	}
+}
+
 // TestHandle_NoFallbackOn400 verifies that 4xx responses do not trigger
 // fallback — the client error is forwarded and model-b is never tried.
 func TestHandle_NoFallbackOn400(t *testing.T) {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -94,12 +94,11 @@ func (r *Router) Pick(model proxy.Model) []proxy.Deployment {
 	// stable partition (not a filter) moves cooling deployments to the end
 	// while preserving the strategy's relative order within each partition.
 	// This is deliberately not a filter: Pick reinstates the full candidate
-	// list whenever filterAvailable above returns empty, and the proxy
-	// handler skips Allow() entirely when a Router is configured — so a
-	// cooldown filter here would be defeated in exactly the situation it
-	// exists to handle. A stable sort instead guarantees that when every
-	// candidate is cooling, the full list still survives in order, and the
-	// MaxRetries cap below naturally trims cooling entries first.
+	// list whenever filterAvailable above returns empty, so a cooldown filter
+	// here would be defeated in exactly the situation it exists to handle. A
+	// stable sort instead guarantees that when every candidate is cooling,
+	// the full list still survives in order, and the MaxRetries cap below
+	// naturally trims cooling entries first.
 	r.applyCooldownOrder(model.Name, ordered)
 
 	// Limit result length to maxRetries+1 so the caller does not attempt more
@@ -157,7 +156,19 @@ func (r *Router) applyCooldownOrder(modelName string, ordered []proxy.Deployment
 }
 
 // filterAvailable returns the subset of deployments whose circuit breaker
-// allows requests AND whose health status (if known) is not "unhealthy".
+// currently permits requests AND whose health status (if known) is not
+// "unhealthy".
+//
+// This is candidate selection, not an attempt: it uses Breaker.Permits, the
+// non-reserving peek, rather than Allow. Allow reserves a HalfOpen probe slot
+// as a side effect, and filterAvailable is called once per Pick to build the
+// whole candidate list — most of these candidates are never actually
+// attempted (an earlier one succeeds, MaxRetries trims the tail, or cooldown
+// ordering moves them to the back). Calling Allow here would reserve probes
+// for deployments that are only ever considered, not tried, exhausting
+// halfOpenMax on candidates the proxy handler never sends a request to. The
+// real reservation happens once, per candidate actually attempted, in
+// tryModel's own Allow call at attempt time.
 func (r *Router) filterAvailable(model proxy.Model) []proxy.Deployment {
 	result := make([]proxy.Deployment, 0, len(model.Deployments))
 	for _, d := range model.Deployments {
@@ -165,7 +176,7 @@ func (r *Router) filterAvailable(model proxy.Model) []proxy.Deployment {
 
 		// Circuit breaker check — nil registry means feature is disabled.
 		if r.circuitBreakers != nil {
-			if !r.circuitBreakers.Get(key).Allow() {
+			if !r.circuitBreakers.Get(key).Permits() {
 				continue
 			}
 		}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -111,19 +111,49 @@ func (r *Router) Pick(model proxy.Model) []proxy.Deployment {
 	return ordered[:limit]
 }
 
-// applyCooldownOrder stable-sorts ordered in place so that deployments
+// applyCooldownOrder partitions ordered in place so that deployments
 // currently cooling down (see cooldown.Registry) are moved after all
 // non-cooling deployments, without disturbing the relative order within
 // either group. A nil cooldowns registry makes this a no-op.
+//
+// The cooldown registry is never nil in production (app.go always
+// constructs one), so this must stay cheap on the common case where nothing
+// is cooling: Cooling() is read exactly once per candidate into a local
+// slice, and if none of them are cooling the function returns before doing
+// any reordering work at all. When at least one candidate is cooling, the
+// partition is applied as an explicit two-pass copy rather than
+// sort.SliceStable: sort's Swap only rearranges ordered itself, so a
+// separately-cached per-index boolean slice would desync from ordered's
+// elements as soon as the sort swapped anything, whereas indexing the cache
+// by original position and consuming it in a single forward pass is both
+// correct and O(n) instead of O(n log n).
 func (r *Router) applyCooldownOrder(modelName string, ordered []proxy.Deployment) {
 	if r.cooldowns == nil {
 		return
 	}
-	sort.SliceStable(ordered, func(i, j int) bool {
-		iCooling := r.cooldowns.Cooling(DeploymentKey(modelName, ordered[i].Name))
-		jCooling := r.cooldowns.Cooling(DeploymentKey(modelName, ordered[j].Name))
-		return !iCooling && jCooling
-	})
+
+	cooling := make([]bool, len(ordered))
+	anyCooling := false
+	for i, d := range ordered {
+		cooling[i] = r.cooldowns.Cooling(DeploymentKey(modelName, d.Name))
+		anyCooling = anyCooling || cooling[i]
+	}
+	if !anyCooling {
+		return
+	}
+
+	partitioned := make([]proxy.Deployment, 0, len(ordered))
+	for i, d := range ordered {
+		if !cooling[i] {
+			partitioned = append(partitioned, d)
+		}
+	}
+	for i, d := range ordered {
+		if cooling[i] {
+			partitioned = append(partitioned, d)
+		}
+	}
+	copy(ordered, partitioned)
 }
 
 // filterAvailable returns the subset of deployments whose circuit breaker

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 
 	"github.com/voidmind-io/voidllm/internal/circuitbreaker"
+	"github.com/voidmind-io/voidllm/internal/cooldown"
 	"github.com/voidmind-io/voidllm/internal/health"
 	"github.com/voidmind-io/voidllm/internal/proxy"
 )
@@ -20,14 +21,16 @@ import (
 type Router struct {
 	healthChecker   *health.Checker
 	circuitBreakers *circuitbreaker.Registry
+	cooldowns       *cooldown.Registry
 	counters        sync.Map // model name → *atomic.Uint64 (round-robin)
 }
 
-// NewRouter creates a Router. Both dependencies are optional (nil-safe).
-func NewRouter(hc *health.Checker, cb *circuitbreaker.Registry) *Router {
+// NewRouter creates a Router. All three dependencies are optional (nil-safe).
+func NewRouter(hc *health.Checker, cb *circuitbreaker.Registry, cd *cooldown.Registry) *Router {
 	return &Router{
 		healthChecker:   hc,
 		circuitBreakers: cb,
+		cooldowns:       cd,
 	}
 }
 
@@ -87,6 +90,18 @@ func (r *Router) Pick(model proxy.Model) []proxy.Deployment {
 		ordered = r.roundRobin(model.Name, candidates)
 	}
 
+	// Deprioritize deployments that are currently rate-limit-cooling: a
+	// stable partition (not a filter) moves cooling deployments to the end
+	// while preserving the strategy's relative order within each partition.
+	// This is deliberately not a filter: Pick reinstates the full candidate
+	// list whenever filterAvailable above returns empty, and the proxy
+	// handler skips Allow() entirely when a Router is configured — so a
+	// cooldown filter here would be defeated in exactly the situation it
+	// exists to handle. A stable sort instead guarantees that when every
+	// candidate is cooling, the full list still survives in order, and the
+	// MaxRetries cap below naturally trims cooling entries first.
+	r.applyCooldownOrder(model.Name, ordered)
+
 	// Limit result length to maxRetries+1 so the caller does not attempt more
 	// deployments than the model policy allows. Zero means try all candidates.
 	limit := len(ordered)
@@ -94,6 +109,21 @@ func (r *Router) Pick(model proxy.Model) []proxy.Deployment {
 		limit = model.MaxRetries + 1
 	}
 	return ordered[:limit]
+}
+
+// applyCooldownOrder stable-sorts ordered in place so that deployments
+// currently cooling down (see cooldown.Registry) are moved after all
+// non-cooling deployments, without disturbing the relative order within
+// either group. A nil cooldowns registry makes this a no-op.
+func (r *Router) applyCooldownOrder(modelName string, ordered []proxy.Deployment) {
+	if r.cooldowns == nil {
+		return
+	}
+	sort.SliceStable(ordered, func(i, j int) bool {
+		iCooling := r.cooldowns.Cooling(DeploymentKey(modelName, ordered[i].Name))
+		jCooling := r.cooldowns.Cooling(DeploymentKey(modelName, ordered[j].Name))
+		return !iCooling && jCooling
+	})
 }
 
 // filterAvailable returns the subset of deployments whose circuit breaker

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -769,6 +769,60 @@ func TestPick_CircuitBreaker_NilRegistry(t *testing.T) {
 	}
 }
 
+// TestPick_CircuitBreaker_HalfOpen_DoesNotConsumeProbeSlot is the regression
+// case for the Allow()->Permits() fix in filterAvailable: building a
+// candidate list is a peek, not an attempt, so it must never reserve the
+// single HalfOpen probe slot a deployment with HalfOpenMax=1 has available.
+// Before the fix, filterAvailable called Allow() while scanning candidates,
+// which consumed the one free slot on every Pick — so by the time the proxy
+// handler actually tried to attempt the deployment, Allow() had nothing left
+// to grant and the deployment was locked out of ever probing again.
+func TestPick_CircuitBreaker_HalfOpen_DoesNotConsumeProbeSlot(t *testing.T) {
+	t.Parallel()
+
+	const modelName = "half-open-model"
+	depKey := modelName + "/dep"
+
+	cbReg := circuitbreaker.NewRegistry(circuitbreaker.Config{
+		Enabled:     true,
+		Threshold:   1,
+		Timeout:     10 * time.Millisecond,
+		HalfOpenMax: 1,
+	})
+	b := cbReg.Get(depKey)
+	b.RecordFailure() // trips Open
+	if b.CurrentState() != circuitbreaker.Open {
+		t.Fatalf("setup: breaker state = %v, want Open", b.CurrentState())
+	}
+	time.Sleep(25 * time.Millisecond) // past Timeout: Permits()/Allow() now see HalfOpen-eligible
+
+	r := router.NewRouter(nil, cbReg, nil)
+	m := proxy.Model{
+		Name:     modelName,
+		Strategy: "round-robin",
+		Deployments: []proxy.Deployment{
+			{Name: "dep"},
+		},
+	}
+
+	// Building the candidate list must not itself transition the breaker or
+	// consume its single probe slot, however many times it is called.
+	for i := range 5 {
+		got := r.Pick(m)
+		if !containsName(got, "dep") {
+			t.Fatalf("call %d: Pick() = %v, want [dep]", i, deploymentNames(got))
+		}
+	}
+
+	// The slot must still be available for a genuine attempt: Allow() is the
+	// real reservation call and must succeed exactly as if Pick had never
+	// been called.
+	if !b.Allow() {
+		t.Fatal("Allow() after repeated Pick() calls = false, want true — " +
+			"Pick()/filterAvailable must not have consumed the HalfOpen probe slot")
+	}
+}
+
 // --- Health filtering ------------------------------------------------------
 
 // TestPick_Health_UnhealthyFiltered verifies that a deployment whose health

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/voidmind-io/voidllm/internal/circuitbreaker"
 	"github.com/voidmind-io/voidllm/internal/config"
+	"github.com/voidmind-io/voidllm/internal/cooldown"
 	"github.com/voidmind-io/voidllm/internal/health"
 	"github.com/voidmind-io/voidllm/internal/proxy"
 	"github.com/voidmind-io/voidllm/internal/router"
@@ -192,7 +193,7 @@ func TestDeploymentKey(t *testing.T) {
 func TestPick_SingleDeployment(t *testing.T) {
 	t.Parallel()
 
-	r := router.NewRouter(nil, nil)
+	r := router.NewRouter(nil, nil, nil)
 	m := proxy.Model{
 		Name:            "gpt-4o",
 		Provider:        "openai",
@@ -234,7 +235,7 @@ func TestPick_SingleDeployment(t *testing.T) {
 func TestPick_SingleDeployment_AzureFields(t *testing.T) {
 	t.Parallel()
 
-	r := router.NewRouter(nil, nil)
+	r := router.NewRouter(nil, nil, nil)
 	m := proxy.Model{
 		Name:            "azure-gpt4",
 		Provider:        "azure",
@@ -266,7 +267,7 @@ func TestPick_SingleDeployment_AzureFields(t *testing.T) {
 func TestPick_RoundRobin(t *testing.T) {
 	t.Parallel()
 
-	r := router.NewRouter(nil, nil)
+	r := router.NewRouter(nil, nil, nil)
 	m := proxy.Model{
 		Name:     "gpt-4o",
 		Strategy: "round-robin",
@@ -310,7 +311,7 @@ func TestPick_RoundRobin(t *testing.T) {
 func TestPick_RoundRobin_DefaultStrategy(t *testing.T) {
 	t.Parallel()
 
-	r := router.NewRouter(nil, nil)
+	r := router.NewRouter(nil, nil, nil)
 	m := proxy.Model{
 		Name:     "gpt-4o",
 		Strategy: "", // empty → round-robin
@@ -333,7 +334,7 @@ func TestPick_RoundRobin_DefaultStrategy(t *testing.T) {
 func TestPick_RoundRobin_FullSliceIsRotated(t *testing.T) {
 	t.Parallel()
 
-	r := router.NewRouter(nil, nil)
+	r := router.NewRouter(nil, nil, nil)
 	m := proxy.Model{
 		Name:     "model",
 		Strategy: "round-robin",
@@ -421,7 +422,7 @@ func TestPick_Priority(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			r := router.NewRouter(nil, nil)
+			r := router.NewRouter(nil, nil, nil)
 			m := proxy.Model{
 				Name:        "model",
 				Strategy:    "priority",
@@ -444,7 +445,7 @@ func TestPick_Priority(t *testing.T) {
 func TestPick_Priority_FullOrder(t *testing.T) {
 	t.Parallel()
 
-	r := router.NewRouter(nil, nil)
+	r := router.NewRouter(nil, nil, nil)
 	m := proxy.Model{
 		Name:     "model",
 		Strategy: "priority",
@@ -478,7 +479,7 @@ func TestPick_Priority_FullOrder(t *testing.T) {
 func TestPick_Weighted_Distribution(t *testing.T) {
 	t.Parallel()
 
-	r := router.NewRouter(nil, nil)
+	r := router.NewRouter(nil, nil, nil)
 	m := proxy.Model{
 		Name:     "model",
 		Strategy: "weighted",
@@ -510,7 +511,7 @@ func TestPick_Weighted_Distribution(t *testing.T) {
 func TestPick_Weighted_ZeroWeightTreatedAsOne(t *testing.T) {
 	t.Parallel()
 
-	r := router.NewRouter(nil, nil)
+	r := router.NewRouter(nil, nil, nil)
 	m := proxy.Model{
 		Name:     "model",
 		Strategy: "weighted",
@@ -541,7 +542,7 @@ func TestPick_Weighted_ZeroWeightTreatedAsOne(t *testing.T) {
 func TestPick_Weighted_RestIsShuffled(t *testing.T) {
 	t.Parallel()
 
-	r := router.NewRouter(nil, nil)
+	r := router.NewRouter(nil, nil, nil)
 	m := proxy.Model{
 		Name:     "model",
 		Strategy: "weighted",
@@ -603,7 +604,7 @@ func TestPick_LeastLatency_SortsByLatency(t *testing.T) {
 		}
 	}
 
-	r := router.NewRouter(checker, nil)
+	r := router.NewRouter(checker, nil, nil)
 	m := proxy.Model{
 		Name:     "model",
 		Strategy: "least-latency",
@@ -642,7 +643,7 @@ func TestPick_LeastLatency_FallsBackToRoundRobin(t *testing.T) {
 	stop := checker.Start()
 	t.Cleanup(stop)
 
-	r := router.NewRouter(checker, nil)
+	r := router.NewRouter(checker, nil, nil)
 	m := proxy.Model{
 		Name:     "model",
 		Strategy: "least-latency",
@@ -671,7 +672,7 @@ func TestPick_LeastLatency_FallsBackToRoundRobin(t *testing.T) {
 func TestPick_LeastLatency_NilChecker(t *testing.T) {
 	t.Parallel()
 
-	r := router.NewRouter(nil, nil) // nil health checker
+	r := router.NewRouter(nil, nil, nil) // nil health checker
 	m := proxy.Model{
 		Name:     "model",
 		Strategy: "least-latency",
@@ -697,7 +698,7 @@ func TestPick_CircuitBreaker_FiltersOpenBreaker(t *testing.T) {
 	// Open the breaker for "model/broken".
 	cbReg := openCircuitBreaker(t, "model/broken")
 
-	r := router.NewRouter(nil, cbReg)
+	r := router.NewRouter(nil, cbReg, nil)
 	m := proxy.Model{
 		Name:     "model",
 		Strategy: "round-robin",
@@ -732,7 +733,7 @@ func TestPick_CircuitBreaker_ClosedBreakerAllowed(t *testing.T) {
 	// Access the breaker to ensure it is created but leave it in Closed state.
 	_ = cbReg.Get("model/ok")
 
-	r := router.NewRouter(nil, cbReg)
+	r := router.NewRouter(nil, cbReg, nil)
 	m := proxy.Model{
 		Name:     "model",
 		Strategy: "round-robin",
@@ -752,7 +753,7 @@ func TestPick_CircuitBreaker_ClosedBreakerAllowed(t *testing.T) {
 func TestPick_CircuitBreaker_NilRegistry(t *testing.T) {
 	t.Parallel()
 
-	r := router.NewRouter(nil, nil)
+	r := router.NewRouter(nil, nil, nil)
 	m := proxy.Model{
 		Name:     "model",
 		Strategy: "round-robin",
@@ -802,7 +803,7 @@ func TestPick_Health_UnhealthyFiltered(t *testing.T) {
 		}
 	}
 
-	r := router.NewRouter(checker, nil)
+	r := router.NewRouter(checker, nil, nil)
 	m := proxy.Model{
 		Name:     "model",
 		Strategy: "round-robin",
@@ -893,7 +894,7 @@ func TestPick_Health_DegradedNotFiltered(t *testing.T) {
 		t.Skipf("expected degraded status but got %q; skipping degraded-not-filtered assertion", mh.Status)
 	}
 
-	r := router.NewRouter(checker, nil)
+	r := router.NewRouter(checker, nil, nil)
 	m := proxy.Model{
 		Name:     "model",
 		Strategy: "round-robin",
@@ -936,7 +937,7 @@ func TestPick_AllFiltered_Fallback(t *testing.T) {
 	cbReg2.Get(modelName + "/a").RecordFailure()
 	cbReg2.Get(modelName + "/b").RecordFailure()
 
-	r := router.NewRouter(nil, cbReg2)
+	r := router.NewRouter(nil, cbReg2, nil)
 	m := proxy.Model{
 		Name:     modelName,
 		Strategy: "round-robin",
@@ -975,7 +976,7 @@ func TestPick_AllFiltered_FallbackPreservesOriginalOrder(t *testing.T) {
 		cbReg.Get(modelName + "/" + dep).RecordFailure()
 	}
 
-	r := router.NewRouter(nil, cbReg)
+	r := router.NewRouter(nil, cbReg, nil)
 	m := proxy.Model{
 		Name:     modelName,
 		Strategy: "priority",
@@ -1044,7 +1045,7 @@ func TestPick_MaxRetries_LimitsLength(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			r := router.NewRouter(nil, nil)
+			r := router.NewRouter(nil, nil, nil)
 
 			deps := make([]proxy.Deployment, tc.deployments)
 			for i := range tc.deployments {
@@ -1066,6 +1067,147 @@ func TestPick_MaxRetries_LimitsLength(t *testing.T) {
 	}
 }
 
+// --- Cooldown ordering (429 failover) --------------------------------------
+
+// TestPick_Cooldown_CoolingDeploymentOrderedLast verifies that a deployment
+// currently marked as cooling in the cooldown.Registry is moved to the end of
+// the candidate list, while the relative order of the non-cooling deployments
+// is preserved. The "priority" strategy is used so the pre-cooldown order is
+// deterministic: a, b, c.
+func TestPick_Cooldown_CoolingDeploymentOrderedLast(t *testing.T) {
+	t.Parallel()
+
+	const modelName = "cooldown-order-model"
+	cd := cooldown.NewRegistry()
+	cd.Mark(router.DeploymentKey(modelName, "b"), time.Minute)
+
+	r := router.NewRouter(nil, nil, cd)
+	m := proxy.Model{
+		Name:     modelName,
+		Strategy: "priority",
+		Deployments: []proxy.Deployment{
+			{Name: "a", Priority: 1},
+			{Name: "b", Priority: 2},
+			{Name: "c", Priority: 3},
+		},
+	}
+
+	got := deploymentNames(r.Pick(m))
+	want := []string{"a", "c", "b"}
+	if len(got) != len(want) {
+		t.Fatalf("Pick order = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Pick order = %v, want %v (cooling deployment %q must be last)", got, want, "b")
+		}
+	}
+}
+
+// TestPick_Cooldown_AllCoolingReturnsFullListUnchanged verifies that when
+// every deployment is cooling, applyCooldownOrder's stable partition is a
+// no-op: the full candidate list survives (no drop), in the same order it
+// would have had without any cooldown registry at all.
+func TestPick_Cooldown_AllCoolingReturnsFullListUnchanged(t *testing.T) {
+	t.Parallel()
+
+	const modelName = "all-cooling-model"
+	deployments := []proxy.Deployment{
+		{Name: "x", Priority: 1},
+		{Name: "y", Priority: 2},
+		{Name: "z", Priority: 3},
+	}
+	m := proxy.Model{Name: modelName, Strategy: "priority", Deployments: deployments}
+
+	// Baseline: no cooldown registry at all.
+	baseline := router.NewRouter(nil, nil, nil)
+	want := deploymentNames(baseline.Pick(m))
+
+	// All three deployments marked cooling.
+	cd := cooldown.NewRegistry()
+	for _, d := range deployments {
+		cd.Mark(router.DeploymentKey(modelName, d.Name), time.Minute)
+	}
+	r := router.NewRouter(nil, nil, cd)
+	got := deploymentNames(r.Pick(m))
+
+	if len(got) != len(deployments) {
+		t.Fatalf("Pick with all deployments cooling returned %d, want %d (must not drop candidates)",
+			len(got), len(deployments))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Pick order with all cooling = %v, want unchanged order %v", got, want)
+		}
+	}
+}
+
+// TestPick_Cooldown_MaxRetriesTrimsCoolingFirst verifies that when MaxRetries
+// limits the result length, cooling deployments — having been moved to the
+// end by applyCooldownOrder — are the ones trimmed off, not the healthy ones.
+func TestPick_Cooldown_MaxRetriesTrimsCoolingFirst(t *testing.T) {
+	t.Parallel()
+
+	const modelName = "trim-cooling-model"
+	cd := cooldown.NewRegistry()
+	// "a" would normally be first (lowest Priority) but is cooling.
+	cd.Mark(router.DeploymentKey(modelName, "a"), time.Minute)
+
+	r := router.NewRouter(nil, nil, cd)
+	m := proxy.Model{
+		Name:       modelName,
+		Strategy:   "priority",
+		MaxRetries: 1, // limit to 2 candidates
+		Deployments: []proxy.Deployment{
+			{Name: "a", Priority: 1},
+			{Name: "b", Priority: 2},
+			{Name: "c", Priority: 3},
+		},
+	}
+
+	got := deploymentNames(r.Pick(m))
+	want := []string{"b", "c"}
+	if len(got) != len(want) {
+		t.Fatalf("Pick = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Pick = %v, want %v", got, want)
+		}
+	}
+	if containsName(r.Pick(m), "a") {
+		t.Error("cooling deployment 'a' should have been trimmed by MaxRetries, but is present")
+	}
+}
+
+// TestPick_Cooldown_NilRegistryChangesNothing verifies that a nil cooldown
+// registry produces the exact same order as the strategy alone, for both the
+// three-argument and explicit nil-cooldown NewRouter calls.
+func TestPick_Cooldown_NilRegistryChangesNothing(t *testing.T) {
+	t.Parallel()
+
+	const modelName = "nil-cooldown-model"
+	deployments := []proxy.Deployment{
+		{Name: "a", Priority: 1},
+		{Name: "b", Priority: 2},
+		{Name: "c", Priority: 3},
+	}
+	m := proxy.Model{Name: modelName, Strategy: "priority", Deployments: deployments}
+
+	rWithNilCooldown := router.NewRouter(nil, nil, nil)
+	got := deploymentNames(rWithNilCooldown.Pick(m))
+	want := []string{"a", "b", "c"}
+
+	if len(got) != len(want) {
+		t.Fatalf("Pick = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Pick with nil cooldown registry = %v, want %v (strategy order unchanged)", got, want)
+		}
+	}
+}
+
 // --- Nil dependencies ------------------------------------------------------
 
 // TestNewRouter_NilDependencies verifies that a Router created with nil health
@@ -1078,7 +1220,7 @@ func TestNewRouter_NilDependencies(t *testing.T) {
 	for _, strategy := range strategies {
 		t.Run("strategy="+strategy, func(t *testing.T) {
 			t.Parallel()
-			r := router.NewRouter(nil, nil)
+			r := router.NewRouter(nil, nil, nil)
 			m := proxy.Model{
 				Name:     "model",
 				Strategy: strategy,
@@ -1103,7 +1245,7 @@ func TestNewRouter_NilDependencies(t *testing.T) {
 func TestPick_ConcurrentRoundRobin(t *testing.T) {
 	t.Parallel()
 
-	r := router.NewRouter(nil, nil)
+	r := router.NewRouter(nil, nil, nil)
 	m := proxy.Model{
 		Name:     "concurrent-model",
 		Strategy: "round-robin",
@@ -1141,7 +1283,7 @@ func TestPick_ConcurrentRoundRobin(t *testing.T) {
 // BenchmarkPick_RoundRobin measures the hot-path cost of a round-robin Pick
 // with no health or circuit-breaker checks.
 func BenchmarkPick_RoundRobin(b *testing.B) {
-	r := router.NewRouter(nil, nil)
+	r := router.NewRouter(nil, nil, nil)
 	m := proxy.Model{
 		Name:     "bench-model",
 		Strategy: "round-robin",
@@ -1162,7 +1304,7 @@ func BenchmarkPick_RoundRobin(b *testing.B) {
 
 // BenchmarkPick_Priority measures priority-sorted Pick overhead.
 func BenchmarkPick_Priority(b *testing.B) {
-	r := router.NewRouter(nil, nil)
+	r := router.NewRouter(nil, nil, nil)
 	m := proxy.Model{
 		Name:     "bench-model",
 		Strategy: "priority",
@@ -1183,7 +1325,7 @@ func BenchmarkPick_Priority(b *testing.B) {
 
 // BenchmarkPick_Weighted measures weighted-random Pick overhead.
 func BenchmarkPick_Weighted(b *testing.B) {
-	r := router.NewRouter(nil, nil)
+	r := router.NewRouter(nil, nil, nil)
 	m := proxy.Model{
 		Name:     "bench-model",
 		Strategy: "weighted",

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -1281,9 +1281,12 @@ func TestPick_ConcurrentRoundRobin(t *testing.T) {
 // --- Benchmark -------------------------------------------------------------
 
 // BenchmarkPick_RoundRobin measures the hot-path cost of a round-robin Pick
-// with no health or circuit-breaker checks.
+// with no health or circuit-breaker checks, against a real (empty) cooldown
+// registry — the same shape the production Router is always constructed
+// with — so the benchmark exercises applyCooldownOrder's no-op fast path
+// instead of skipping it via a nil registry.
 func BenchmarkPick_RoundRobin(b *testing.B) {
-	r := router.NewRouter(nil, nil, nil)
+	r := router.NewRouter(nil, nil, cooldown.NewRegistry())
 	m := proxy.Model{
 		Name:     "bench-model",
 		Strategy: "round-robin",
@@ -1302,9 +1305,10 @@ func BenchmarkPick_RoundRobin(b *testing.B) {
 	})
 }
 
-// BenchmarkPick_Priority measures priority-sorted Pick overhead.
+// BenchmarkPick_Priority measures priority-sorted Pick overhead against a
+// real (empty) cooldown registry, matching the production Router shape.
 func BenchmarkPick_Priority(b *testing.B) {
-	r := router.NewRouter(nil, nil, nil)
+	r := router.NewRouter(nil, nil, cooldown.NewRegistry())
 	m := proxy.Model{
 		Name:     "bench-model",
 		Strategy: "priority",
@@ -1323,9 +1327,10 @@ func BenchmarkPick_Priority(b *testing.B) {
 	})
 }
 
-// BenchmarkPick_Weighted measures weighted-random Pick overhead.
+// BenchmarkPick_Weighted measures weighted-random Pick overhead against a
+// real (empty) cooldown registry, matching the production Router shape.
 func BenchmarkPick_Weighted(b *testing.B) {
-	r := router.NewRouter(nil, nil, nil)
+	r := router.NewRouter(nil, nil, cooldown.NewRegistry())
 	m := proxy.Model{
 		Name:     "bench-model",
 		Strategy: "weighted",
@@ -1333,6 +1338,34 @@ func BenchmarkPick_Weighted(b *testing.B) {
 			{Name: "a", Weight: 5},
 			{Name: "b", Weight: 3},
 			{Name: "c", Weight: 2},
+		},
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = r.Pick(m)
+		}
+	})
+}
+
+// BenchmarkPick_RoundRobin_OneCooling measures round-robin Pick when one of
+// the three deployments is marked cooling, so applyCooldownOrder must take
+// its partition path instead of the no-op fast path exercised by
+// BenchmarkPick_RoundRobin.
+func BenchmarkPick_RoundRobin_OneCooling(b *testing.B) {
+	const modelName = "bench-model-cooling"
+	cd := cooldown.NewRegistry()
+	cd.Mark(router.DeploymentKey(modelName, "b"), time.Minute)
+
+	r := router.NewRouter(nil, nil, cd)
+	m := proxy.Model{
+		Name:     modelName,
+		Strategy: "round-robin",
+		Deployments: []proxy.Deployment{
+			{Name: "a"},
+			{Name: "b"},
+			{Name: "c"},
 		},
 	}
 


### PR DESCRIPTION
Closes #184.

An upstream `429 Too Many Requests` did not trigger failover to another deployment, and the terminal branch recorded every status below 500 as a circuit-breaker success - so a 429 also reset the accumulated failure counter and erased real failures. Running several deployments across provider accounts is the standard way to stay under per-account limits, and that setup did nothing for the most common upstream failure.

## What changed

- **429 fails over** like a 5xx, but stays **breaker-neutral**: a throttled upstream is not a broken one. "Neutral" turned out to need its own primitive - when the router's candidate filter calls `Allow()` on a breaker whose open timeout has elapsed, the breaker moves to half-open and reserves its single probe slot. Recording nothing left that reservation dangling and locked the deployment out permanently, which is worse than the behaviour being replaced. `Breaker.RecordNeutral()` releases the probe without touching state, failure count or timestamp.
- **Cooldown**: the deployment is skipped for a short window derived from `Retry-After` / `retry-after-ms`, clamped so a large value cannot park it. The router orders cooling deployments last via a stable partition rather than filtering them - filtering would be defeated by the existing reinstate-all fallback, which puts every deployment back when the filtered list is empty.
- **Model-level fallback** now treats 429 as eligible.
- **Both discarded-response drains are bounded** in bytes and in time. The upstream context carries no deadline for streaming requests or models without a per-model timeout, so an upstream that sends headers and then stalls would otherwise block failover indefinitely.
- A 429 carrying `Content-Type: text/event-stream` no longer reaches the streaming handler with a breaker attached, which would have recorded an outcome at stream end and defeated neutrality.

## Verification

`internal/circuitbreaker` had no tests at all and now covers the state machine plus the lockout regression. New tests across proxy, router, cooldown and circuitbreaker cover failover, neutrality, the failure counter surviving a 429, all-candidates-limited, cooldown ordering and eviction, `Retry-After` parsing including int64 overflow, stalled and endless bodies, and the streaming-429 case.

Every fix was mutation-checked: reverting it turns the corresponding test red. Full suite and `-race` on the four touched packages are green.

Four review rounds; the last two found real defects in the fixes themselves, which is why the branch has four commits.