### PR TITLE
ci: cache Go and npm dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
 
       - name: Build UI (required for Go embed)
         working-directory: ui
@@ -28,6 +30,8 @@ jobs:
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: "1.26"
+          cache: true
+          cache-dependency-path: go.sum
 
       - name: Build
         run: go build ./...
@@ -56,6 +60,8 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "24"
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
 
       - name: Install
         working-directory: ui


### PR DESCRIPTION
The test job takes around seven minutes, most of it recompiling race-instrumented packages and re-downloading node modules that have not changed.

- `setup-node` had **no** cache configured in either job, so `npm ci` fetched the whole dependency tree on every run. Now caches on `ui/package-lock.json`.
- `setup-go` caches by default, but the dependency path is now stated explicitly so the key is derived from `go.sum` rather than whatever the action infers.

Nothing about what runs changes: the full suite still executes with `-race` and coverage, so there is no loss of race detection. The first run after merge will be a cache miss and no faster; the gain shows from the second run on.