### PR TITLE
feat(usage): track cached prompt tokens and price them correctly

### DIFF
--- a/internal/api/admin/models.go
+++ b/internal/api/admin/models.go
@@ -82,10 +82,12 @@ type updateModelRequest struct {
 	InputPricePer1M  *float64 `json:"input_price_per_1m"`
 	OutputPricePer1M *float64 `json:"output_price_per_1m"`
 	// CachedInputPricePer1M, when non-nil, replaces the stored cached-read
-	// price. 0 explicitly configures "no cache discount" rather than
-	// falling back to InputPricePer1M.
+	// price. 0 means "no cache discount": cached reads are then billed at the
+	// base input rate, the same effective result as leaving the price unset.
 	CachedInputPricePer1M *float64 `json:"cached_input_price_per_1m"`
-	// CacheWritePricePer1M, when non-nil, replaces the stored cache-write price.
+	// CacheWritePricePer1M, when non-nil, replaces the stored cache-write
+	// price. 0 behaves like CachedInputPricePer1M: cache writes fall back to
+	// the base input rate.
 	CacheWritePricePer1M *float64 `json:"cache_write_price_per_1m"`
 	AzureDeployment      *string  `json:"azure_deployment"`
 	AzureAPIVersion      *string  `json:"azure_api_version"`

--- a/internal/api/admin/models.go
+++ b/internal/api/admin/models.go
@@ -35,8 +35,14 @@ type createModelRequest struct {
 	MaxContextTokens int     `json:"max_context_tokens"`
 	InputPricePer1M  float64 `json:"input_price_per_1m"`
 	OutputPricePer1M float64 `json:"output_price_per_1m"`
-	AzureDeployment  string  `json:"azure_deployment,omitempty"`
-	AzureAPIVersion  string  `json:"azure_api_version,omitempty"`
+	// CachedInputPricePer1M is the price per million cached-read prompt
+	// tokens. Omit or pass 0 to fall back to InputPricePer1M for that bucket.
+	CachedInputPricePer1M float64 `json:"cached_input_price_per_1m,omitempty"`
+	// CacheWritePricePer1M is the price per million cache-write prompt
+	// tokens (Anthropic only). Omit or pass 0 to fall back to InputPricePer1M.
+	CacheWritePricePer1M float64 `json:"cache_write_price_per_1m,omitempty"`
+	AzureDeployment      string  `json:"azure_deployment,omitempty"`
+	AzureAPIVersion      string  `json:"azure_api_version,omitempty"`
 	// GCPProject is the Google Cloud project ID. Required when provider is "vertex".
 	GCPProject string `json:"gcp_project,omitempty"`
 	// GCPLocation is the Google Cloud region (e.g. "us-central1"). Required when provider is "vertex".
@@ -75,8 +81,14 @@ type updateModelRequest struct {
 	MaxContextTokens *int     `json:"max_context_tokens"`
 	InputPricePer1M  *float64 `json:"input_price_per_1m"`
 	OutputPricePer1M *float64 `json:"output_price_per_1m"`
-	AzureDeployment  *string  `json:"azure_deployment"`
-	AzureAPIVersion  *string  `json:"azure_api_version"`
+	// CachedInputPricePer1M, when non-nil, replaces the stored cached-read
+	// price. 0 explicitly configures "no cache discount" rather than
+	// falling back to InputPricePer1M.
+	CachedInputPricePer1M *float64 `json:"cached_input_price_per_1m"`
+	// CacheWritePricePer1M, when non-nil, replaces the stored cache-write price.
+	CacheWritePricePer1M *float64 `json:"cache_write_price_per_1m"`
+	AzureDeployment      *string  `json:"azure_deployment"`
+	AzureAPIVersion      *string  `json:"azure_api_version"`
 	// GCPProject, when non-nil, replaces the Google Cloud project ID.
 	GCPProject *string `json:"gcp_project"`
 	// GCPLocation, when non-nil, replaces the Google Cloud region.
@@ -136,8 +148,14 @@ type modelResponse struct {
 	MaxContextTokens int     `json:"max_context_tokens"`
 	InputPricePer1M  float64 `json:"input_price_per_1m"`
 	OutputPricePer1M float64 `json:"output_price_per_1m"`
-	AzureDeployment  string  `json:"azure_deployment,omitempty"`
-	AzureAPIVersion  string  `json:"azure_api_version,omitempty"`
+	// CachedInputPricePer1M is the price per million cached-read prompt
+	// tokens. 0 means not configured.
+	CachedInputPricePer1M float64 `json:"cached_input_price_per_1m,omitempty"`
+	// CacheWritePricePer1M is the price per million cache-write prompt
+	// tokens (Anthropic only). 0 means not configured.
+	CacheWritePricePer1M float64 `json:"cache_write_price_per_1m,omitempty"`
+	AzureDeployment      string  `json:"azure_deployment,omitempty"`
+	AzureAPIVersion      string  `json:"azure_api_version,omitempty"`
 	// GCPProject is the Google Cloud project ID. Non-empty only for provider "vertex".
 	GCPProject string `json:"gcp_project,omitempty"`
 	// GCPLocation is the Google Cloud region. Non-empty only for provider "vertex".
@@ -208,28 +226,30 @@ func modelToResponse(m *db.Model, fallbackName string) modelResponse {
 		modelType = "chat"
 	}
 	return modelResponse{
-		ID:                m.ID,
-		Name:              m.Name,
-		Provider:          m.Provider,
-		Type:              modelType,
-		BaseURL:           m.BaseURL,
-		MaxContextTokens:  m.MaxContextTokens,
-		InputPricePer1M:   m.InputPricePer1M,
-		OutputPricePer1M:  m.OutputPricePer1M,
-		AzureDeployment:   m.AzureDeployment,
-		AzureAPIVersion:   m.AzureAPIVersion,
-		GCPProject:        m.GCPProject,
-		GCPLocation:       m.GCPLocation,
-		IsActive:          m.IsActive,
-		Source:            m.Source,
-		Aliases:           aliases,
-		Timeout:           m.Timeout,
-		Strategy:          m.Strategy,
-		MaxRetries:        m.MaxRetries,
-		FallbackModelName: fallbackName,
-		PIIFilter:         m.PIIFilter,
-		CreatedAt:         m.CreatedAt,
-		UpdatedAt:         m.UpdatedAt,
+		ID:                    m.ID,
+		Name:                  m.Name,
+		Provider:              m.Provider,
+		Type:                  modelType,
+		BaseURL:               m.BaseURL,
+		MaxContextTokens:      m.MaxContextTokens,
+		InputPricePer1M:       m.InputPricePer1M,
+		OutputPricePer1M:      m.OutputPricePer1M,
+		CachedInputPricePer1M: db.Float64Value(m.CachedInputPricePer1M),
+		CacheWritePricePer1M:  db.Float64Value(m.CacheWritePricePer1M),
+		AzureDeployment:       m.AzureDeployment,
+		AzureAPIVersion:       m.AzureAPIVersion,
+		GCPProject:            m.GCPProject,
+		GCPLocation:           m.GCPLocation,
+		IsActive:              m.IsActive,
+		Source:                m.Source,
+		Aliases:               aliases,
+		Timeout:               m.Timeout,
+		Strategy:              m.Strategy,
+		MaxRetries:            m.MaxRetries,
+		FallbackModelName:     fallbackName,
+		PIIFilter:             m.PIIFilter,
+		CreatedAt:             m.CreatedAt,
+		UpdatedAt:             m.UpdatedAt,
 	}
 }
 
@@ -253,14 +273,19 @@ func dbModelToProxy(m *db.Model, apiKeyPlaintext string, fallbackName string) pr
 		modelType = "chat"
 	}
 	return proxy.Model{
-		Name:              m.Name,
-		Provider:          m.Provider,
-		Type:              modelType,
-		BaseURL:           m.BaseURL,
-		APIKey:            apiKeyPlaintext,
-		Aliases:           aliases,
-		MaxContextTokens:  m.MaxContextTokens,
-		Pricing:           config.PricingConfig{InputPer1M: m.InputPricePer1M, OutputPer1M: m.OutputPricePer1M},
+		Name:             m.Name,
+		Provider:         m.Provider,
+		Type:             modelType,
+		BaseURL:          m.BaseURL,
+		APIKey:           apiKeyPlaintext,
+		Aliases:          aliases,
+		MaxContextTokens: m.MaxContextTokens,
+		Pricing: config.PricingConfig{
+			InputPer1M:       m.InputPricePer1M,
+			OutputPer1M:      m.OutputPricePer1M,
+			CachedInputPer1M: db.Float64Value(m.CachedInputPricePer1M),
+			CacheWritePer1M:  db.Float64Value(m.CacheWritePricePer1M),
+		},
 		AzureDeployment:   m.AzureDeployment,
 		AzureAPIVersion:   m.AzureAPIVersion,
 		GCPProject:        m.GCPProject,
@@ -549,26 +574,28 @@ func (h *Handler) CreateModel(c fiber.Ctx) error {
 	reqType := req.Type
 	// Insert without the API key so we have the model ID available as AAD.
 	m, err := h.DB.CreateModel(ctx, db.CreateModelParams{
-		Name:             req.Name,
-		Provider:         req.Provider,
-		ModelType:        &reqType,
-		BaseURL:          req.BaseURL,
-		APIKeyEncrypted:  nil,
-		MaxContextTokens: req.MaxContextTokens,
-		InputPricePer1M:  req.InputPricePer1M,
-		OutputPricePer1M: req.OutputPricePer1M,
-		AzureDeployment:  req.AzureDeployment,
-		AzureAPIVersion:  req.AzureAPIVersion,
-		GCPProject:       req.GCPProject,
-		GCPLocation:      req.GCPLocation,
-		Source:           "api",
-		CreatedBy:        createdBy,
-		Aliases:          aliasStr,
-		Timeout:          req.Timeout,
-		Strategy:         &req.Strategy,
-		MaxRetries:       &req.MaxRetries,
-		FallbackModelID:  fallbackModelID,
-		PIIFilter:        req.PIIFilter,
+		Name:                  req.Name,
+		Provider:              req.Provider,
+		ModelType:             &reqType,
+		BaseURL:               req.BaseURL,
+		APIKeyEncrypted:       nil,
+		MaxContextTokens:      req.MaxContextTokens,
+		InputPricePer1M:       req.InputPricePer1M,
+		OutputPricePer1M:      req.OutputPricePer1M,
+		CachedInputPricePer1M: req.CachedInputPricePer1M,
+		CacheWritePricePer1M:  req.CacheWritePricePer1M,
+		AzureDeployment:       req.AzureDeployment,
+		AzureAPIVersion:       req.AzureAPIVersion,
+		GCPProject:            req.GCPProject,
+		GCPLocation:           req.GCPLocation,
+		Source:                "api",
+		CreatedBy:             createdBy,
+		Aliases:               aliasStr,
+		Timeout:               req.Timeout,
+		Strategy:              &req.Strategy,
+		MaxRetries:            &req.MaxRetries,
+		FallbackModelID:       fallbackModelID,
+		PIIFilter:             req.PIIFilter,
 	})
 	if err != nil {
 		if errors.Is(err, db.ErrConflict) {
@@ -837,22 +864,24 @@ func (h *Handler) UpdateModel(c fiber.Ctx) error {
 	}
 
 	params := db.UpdateModelParams{
-		Name:             req.Name,
-		Provider:         req.Provider,
-		ModelType:        req.Type,
-		BaseURL:          req.BaseURL,
-		MaxContextTokens: req.MaxContextTokens,
-		InputPricePer1M:  req.InputPricePer1M,
-		OutputPricePer1M: req.OutputPricePer1M,
-		AzureDeployment:  req.AzureDeployment,
-		AzureAPIVersion:  req.AzureAPIVersion,
-		GCPProject:       req.GCPProject,
-		GCPLocation:      req.GCPLocation,
-		Timeout:          req.Timeout,
-		Strategy:         req.Strategy,
-		MaxRetries:       req.MaxRetries,
-		PIIFilter:        piiFilter,
-		ClearPIIFilter:   clearPIIFilter,
+		Name:                  req.Name,
+		Provider:              req.Provider,
+		ModelType:             req.Type,
+		BaseURL:               req.BaseURL,
+		MaxContextTokens:      req.MaxContextTokens,
+		InputPricePer1M:       req.InputPricePer1M,
+		OutputPricePer1M:      req.OutputPricePer1M,
+		CachedInputPricePer1M: req.CachedInputPricePer1M,
+		CacheWritePricePer1M:  req.CacheWritePricePer1M,
+		AzureDeployment:       req.AzureDeployment,
+		AzureAPIVersion:       req.AzureAPIVersion,
+		GCPProject:            req.GCPProject,
+		GCPLocation:           req.GCPLocation,
+		Timeout:               req.Timeout,
+		Strategy:              req.Strategy,
+		MaxRetries:            req.MaxRetries,
+		PIIFilter:             piiFilter,
+		ClearPIIFilter:        clearPIIFilter,
 	}
 
 	if req.Aliases != nil {

--- a/internal/api/admin/usage.go
+++ b/internal/api/admin/usage.go
@@ -22,12 +22,18 @@ type usageResponse struct {
 
 // usageDataPoint holds aggregated metrics for one group within a usage response.
 type usageDataPoint struct {
-	GroupKey         string  `json:"group_key,omitempty"`
-	GroupLabel       string  `json:"group_label,omitempty"`
-	TotalRequests    int64   `json:"total_requests"`
-	PromptTokens     int64   `json:"prompt_tokens"`
-	CompletionTokens int64   `json:"completion_tokens"`
-	TotalTokens      int64   `json:"total_tokens"`
+	GroupKey         string `json:"group_key,omitempty"`
+	GroupLabel       string `json:"group_label,omitempty"`
+	TotalRequests    int64  `json:"total_requests"`
+	PromptTokens     int64  `json:"prompt_tokens"`
+	CompletionTokens int64  `json:"completion_tokens"`
+	TotalTokens      int64  `json:"total_tokens"`
+	// CachedReadTokens is the subset of PromptTokens served from an upstream
+	// prompt cache.
+	CachedReadTokens int64 `json:"cached_read_tokens"`
+	// CacheWriteTokens is the subset of PromptTokens written to an upstream
+	// prompt cache (Anthropic only).
+	CacheWriteTokens int64   `json:"cache_write_tokens"`
 	CostEstimate     float64 `json:"cost_estimate"`
 	AvgDurationMS    float64 `json:"avg_duration_ms"`
 }
@@ -152,6 +158,8 @@ func aggregatesToDataPoints(aggs []db.UsageAggregate) []usageDataPoint {
 			PromptTokens:     a.PromptTokens,
 			CompletionTokens: a.CompletionTokens,
 			TotalTokens:      a.TotalTokens,
+			CachedReadTokens: a.CachedReadTokens,
+			CacheWriteTokens: a.CacheWriteTokens,
 			CostEstimate:     a.CostEstimate,
 			AvgDurationMS:    a.AvgDurationMS,
 		}

--- a/internal/api/admin/usage_test.go
+++ b/internal/api/admin/usage_test.go
@@ -40,6 +40,36 @@ func insertUsageEventHTTP(t *testing.T, database *db.DB, id, keyID, teamID, orgI
 	}
 }
 
+// insertUsageEventWithCacheHTTP inserts a single usage_events row with
+// explicit cached_read_tokens/cache_write_tokens values, for tests that
+// verify the cache-token fields surface through the HTTP usage endpoints.
+func insertUsageEventWithCacheHTTP(t *testing.T, database *db.DB, id, keyID, teamID, orgID, modelName string,
+	promptTokens, compTokens, totalTokens, cachedReadTokens, cacheWriteTokens int64, createdAt time.Time) {
+	t.Helper()
+
+	teamVal := "NULL"
+	if teamID != "" {
+		teamVal = fmt.Sprintf("'%s'", teamID)
+	}
+	query := fmt.Sprintf(
+		`INSERT INTO usage_events
+			(id, key_id, key_type, org_id, team_id, model_name,
+			 prompt_tokens, completion_tokens, total_tokens,
+			 cached_read_tokens, cache_write_tokens, status_code, created_at)
+		 VALUES
+			('%s', '%s', 'user_key', '%s', %s, '%s',
+			 %d, %d, %d,
+			 %d, %d, 200, '%s')`,
+		id, keyID, orgID, teamVal, modelName,
+		promptTokens, compTokens, totalTokens,
+		cachedReadTokens, cacheWriteTokens,
+		createdAt.UTC().Format(time.RFC3339),
+	)
+	if _, err := database.SQL().ExecContext(context.Background(), query); err != nil {
+		t.Fatalf("insertUsageEventWithCacheHTTP id=%q: %v", id, err)
+	}
+}
+
 // usageURL constructs the GET /api/v1/orgs/:org_id/usage URL with the given query params.
 func usageURL(orgID, from, to, groupBy string) string {
 	params := []string{}
@@ -627,6 +657,65 @@ func TestGetOrgUsage_ResponseShape(t *testing.T) {
 	}
 	if row.TotalTokens != 150 {
 		t.Errorf("total_tokens = %d, want 150", row.TotalTokens)
+	}
+}
+
+// TestGetOrgUsage_ResponseShape_CachedTokens verifies that
+// cached_read_tokens and cache_write_tokens (added for #179) appear in the
+// GET /api/v1/orgs/:org_id/usage JSON response and carry the summed values
+// from the underlying usage_events rows.
+func TestGetOrgUsage_ResponseShape_CachedTokens(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupTestApp(t, "file:TestGetOrgUsage_ShapeCached?mode=memory&cache=private")
+	org := mustCreateOrg(t, database, "Shape Cached Org", "usage-org-shape-cached")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	now := time.Now().UTC()
+	from := now.Add(-time.Hour)
+	to := now.Add(time.Minute)
+
+	insertUsageEventWithCacheHTTP(t, database, "shape-cache-1", "key-shape-cache", "", org.ID, "claude-3-5-sonnet",
+		100, 50, 150, 40, 15, now.Add(-30*time.Minute))
+
+	req := httptest.NewRequest("GET", usageURL(org.ID, from.Format(time.RFC3339), to.Format(time.RFC3339), ""), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var envelope struct {
+		Data []struct {
+			TotalTokens      int64 `json:"total_tokens"`
+			CachedReadTokens int64 `json:"cached_read_tokens"`
+			CacheWriteTokens int64 `json:"cache_write_tokens"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if len(envelope.Data) == 0 {
+		t.Fatal("data is empty, want at least one row")
+	}
+
+	row := envelope.Data[0]
+	if row.TotalTokens != 150 {
+		t.Errorf("total_tokens = %d, want 150", row.TotalTokens)
+	}
+	if row.CachedReadTokens != 40 {
+		t.Errorf("cached_read_tokens = %d, want 40", row.CachedReadTokens)
+	}
+	if row.CacheWriteTokens != 15 {
+		t.Errorf("cache_write_tokens = %d, want 15", row.CacheWriteTokens)
 	}
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -391,14 +391,19 @@ func New(cfg *config.Config, log *slog.Logger, devMode bool) (*Application, erro
 			}
 
 			registry.AddModel(proxy.Model{
-				Name:              m.Name,
-				Provider:          m.Provider,
-				Type:              modelType,
-				BaseURL:           m.BaseURL,
-				APIKey:            apiKey,
-				Aliases:           aliases,
-				MaxContextTokens:  m.MaxContextTokens,
-				Pricing:           config.PricingConfig{InputPer1M: m.InputPricePer1M, OutputPer1M: m.OutputPricePer1M},
+				Name:             m.Name,
+				Provider:         m.Provider,
+				Type:             modelType,
+				BaseURL:          m.BaseURL,
+				APIKey:           apiKey,
+				Aliases:          aliases,
+				MaxContextTokens: m.MaxContextTokens,
+				Pricing: config.PricingConfig{
+					InputPer1M:       m.InputPricePer1M,
+					OutputPer1M:      m.OutputPricePer1M,
+					CachedInputPer1M: db.Float64Value(m.CachedInputPricePer1M),
+					CacheWritePer1M:  db.Float64Value(m.CacheWritePricePer1M),
+				},
 				AzureDeployment:   m.AzureDeployment,
 				AzureAPIVersion:   m.AzureAPIVersion,
 				GCPProject:        m.GCPProject,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -194,6 +194,18 @@ func (m ModelConfig) LogValue() slog.Value {
 type PricingConfig struct {
 	InputPer1M  float64 `yaml:"input_per_1m"`
 	OutputPer1M float64 `yaml:"output_per_1m"`
+	// CachedInputPer1M is the price per million cached-read prompt tokens
+	// (tokens served from an upstream prompt cache). Zero means "not
+	// configured"; the cost formula falls back to InputPer1M for that bucket
+	// rather than pricing it at zero.
+	CachedInputPer1M float64 `yaml:"cached_input_per_1m"`
+	// CacheWritePer1M is the price per million cache-write prompt tokens
+	// (Anthropic's cache_creation_input_tokens — tokens spent populating the
+	// prompt cache, billed above the normal input rate). Zero means "not
+	// configured"; the cost formula falls back to InputPer1M for that bucket.
+	// Always zero-cost in practice for providers without a cache-write
+	// concept (OpenAI, Gemini), since they never report cache-write tokens.
+	CacheWritePer1M float64 `yaml:"cache_write_per_1m"`
 }
 
 // LoggingConfig controls log output level and format.

--- a/internal/db/migrations/0016_cached_tokens.down.sql
+++ b/internal/db/migrations/0016_cached_tokens.down.sql
@@ -1,0 +1,18 @@
+-- Migration: 0016_cached_tokens.down.sql
+-- Description: Reverses 0016_cached_tokens.up.sql.
+-- ALTER TABLE DROP COLUMN requires SQLite 3.35+ (modernc.org/sqlite ships
+-- 3.45+) and is standard on all supported PostgreSQL versions, following the
+-- precedent in 0011_model_fallback_chains.down.sql. Dropped in reverse order
+-- of creation.
+
+ALTER TABLE models DROP COLUMN cache_write_price_per_1m;
+
+ALTER TABLE models DROP COLUMN cached_input_price_per_1m;
+
+ALTER TABLE usage_hourly DROP COLUMN cache_write_tokens;
+
+ALTER TABLE usage_hourly DROP COLUMN cached_read_tokens;
+
+ALTER TABLE usage_events DROP COLUMN cache_write_tokens;
+
+ALTER TABLE usage_events DROP COLUMN cached_read_tokens;

--- a/internal/db/migrations/0016_cached_tokens.up.sql
+++ b/internal/db/migrations/0016_cached_tokens.up.sql
@@ -1,0 +1,43 @@
+-- Migration: 0016_cached_tokens.up.sql
+-- Description: Adds storage for prompt-cache token counts and their per-model
+-- prices, so cost estimates stay accurate for cache-heavy traffic (#179).
+-- Every major provider bills cached tokens differently from fresh input
+-- tokens, but VoidLLM previously stored no cached-token counts at all.
+--
+-- Naming: the read-side counter is named cached_read_tokens, not anything
+-- containing "content" -- internal/usage/logger_test.go
+-- (TestLog_NoContentColumns) asserts no usage_events column name contains
+-- "content", as a guard for the project's zero-knowledge, no-content-storage
+-- constraint. This migration stores only token counts, never content.
+--
+-- Two separate counters, not one: cache READS (tokens served from an
+-- existing prompt cache) are billed BELOW the normal input rate, while
+-- cache WRITES (Anthropic's cache_creation_input_tokens, i.e. tokens spent
+-- populating the cache) are billed ABOVE it. A single "cached tokens"
+-- counter cannot represent both directions of that price differential, so
+-- cached_read_tokens and cache_write_tokens are tracked independently, with
+-- matching cached_input_price_per_1m / cache_write_price_per_1m columns on
+-- models to price each side.
+--
+-- ALTER TABLE ADD COLUMN follows the precedent in
+-- 0011_model_fallback_chains.up.sql and is supported unchanged on both
+-- SQLite (modernc.org/sqlite ships 3.45+) and all PostgreSQL versions.
+
+ALTER TABLE usage_events
+    ADD COLUMN cached_read_tokens INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE usage_events
+    ADD COLUMN cache_write_tokens INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE usage_hourly
+    ADD COLUMN cached_read_tokens INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE usage_hourly
+    ADD COLUMN cache_write_tokens INTEGER NOT NULL DEFAULT 0;
+
+-- NULL = not configured, matching input_price_per_1m / output_price_per_1m.
+ALTER TABLE models
+    ADD COLUMN cached_input_price_per_1m REAL;
+
+ALTER TABLE models
+    ADD COLUMN cache_write_price_per_1m REAL;

--- a/internal/db/models.go
+++ b/internal/db/models.go
@@ -16,6 +16,7 @@ import (
 // It must match the scan order in scanModel exactly.
 const modelSelectColumns = "id, name, provider, model_type, base_url, api_key_encrypted, " +
 	"max_context_tokens, input_price_per_1m, output_price_per_1m, " +
+	"cached_input_price_per_1m, cache_write_price_per_1m, " +
 	"azure_deployment, azure_api_version, gcp_project, gcp_location, " +
 	"is_active, source, created_by, created_at, updated_at, deleted_at, aliases, timeout, " +
 	"strategy, max_retries, fallback_model_id, pii_filter"
@@ -33,8 +34,17 @@ type Model struct {
 	MaxContextTokens int
 	InputPricePer1M  float64
 	OutputPricePer1M float64
-	AzureDeployment  string
-	AzureAPIVersion  string
+	// CachedInputPricePer1M is the price per million cached-read prompt
+	// tokens. Nil means not configured (NULL in the DB) — this is genuinely
+	// nullable, unlike InputPricePer1M/OutputPricePer1M, because migration
+	// 0016 added this column without backfilling existing rows.
+	CachedInputPricePer1M *float64
+	// CacheWritePricePer1M is the price per million cache-write prompt
+	// tokens (Anthropic only). Nil means not configured (NULL in the DB);
+	// see CachedInputPricePer1M's doc for why this field is a pointer.
+	CacheWritePricePer1M *float64
+	AzureDeployment      string
+	AzureAPIVersion      string
 	// GCPProject is the Google Cloud project ID. Non-empty only for provider "vertex".
 	GCPProject string
 	// GCPLocation is the Google Cloud region. Non-empty only for provider "vertex".
@@ -77,8 +87,15 @@ type CreateModelParams struct {
 	MaxContextTokens int
 	InputPricePer1M  float64
 	OutputPricePer1M float64
-	AzureDeployment  string
-	AzureAPIVersion  string
+	// CachedInputPricePer1M is the price per million cached-read prompt
+	// tokens. Zero means "not configured"; new rows always store an explicit
+	// value here (never SQL NULL), matching InputPricePer1M/OutputPricePer1M.
+	CachedInputPricePer1M float64
+	// CacheWritePricePer1M is the price per million cache-write prompt
+	// tokens (Anthropic only). Zero means "not configured".
+	CacheWritePricePer1M float64
+	AzureDeployment      string
+	AzureAPIVersion      string
 	// GCPProject is the Google Cloud project ID. Required when Provider is "vertex".
 	GCPProject string
 	// GCPLocation is the Google Cloud region. Required when Provider is "vertex".
@@ -116,8 +133,15 @@ type UpdateModelParams struct {
 	MaxContextTokens *int
 	InputPricePer1M  *float64
 	OutputPricePer1M *float64
-	AzureDeployment  *string
-	AzureAPIVersion  *string
+	// CachedInputPricePer1M, when non-nil, replaces the stored cached-read
+	// price. Set to a pointer to 0 to explicitly configure "no cache
+	// discount"; there is no separate clear-to-NULL mechanism, matching
+	// InputPricePer1M/OutputPricePer1M.
+	CachedInputPricePer1M *float64
+	// CacheWritePricePer1M, when non-nil, replaces the stored cache-write price.
+	CacheWritePricePer1M *float64
+	AzureDeployment      *string
+	AzureAPIVersion      *string
 	// GCPProject, when non-nil, replaces the stored Google Cloud project ID.
 	GCPProject *string
 	// GCPLocation, when non-nil, replaces the stored Google Cloud region.
@@ -181,15 +205,17 @@ func (d *DB) CreateModel(ctx context.Context, params CreateModelParams) (*Model,
 	insertQuery := "INSERT INTO models " +
 		"(id, name, provider, model_type, base_url, api_key_encrypted, " +
 		"max_context_tokens, input_price_per_1m, output_price_per_1m, " +
+		"cached_input_price_per_1m, cache_write_price_per_1m, " +
 		"azure_deployment, azure_api_version, gcp_project, gcp_location, " +
 		"is_active, source, created_by, aliases, timeout, strategy, max_retries, " +
 		"fallback_model_id, pii_filter, created_at, updated_at) " +
 		"VALUES (" +
 		p(1) + ", " + p(2) + ", " + p(3) + ", " + p(4) + ", " + p(5) + ", " + p(6) + ", " +
 		p(7) + ", " + p(8) + ", " + p(9) + ", " +
-		p(10) + ", " + p(11) + ", " + p(12) + ", " + p(13) + ", " +
-		"1, " + p(14) + ", " + p(15) + ", " + p(16) + ", " + p(17) + ", " + p(18) + ", " + p(19) + ", " +
-		p(20) + ", " + p(21) + ", " +
+		p(10) + ", " + p(11) + ", " +
+		p(12) + ", " + p(13) + ", " + p(14) + ", " + p(15) + ", " +
+		"1, " + p(16) + ", " + p(17) + ", " + p(18) + ", " + p(19) + ", " + p(20) + ", " + p(21) + ", " +
+		p(22) + ", " + p(23) + ", " +
 		"CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)"
 
 	selectQuery := "SELECT " + modelSelectColumns +
@@ -207,6 +233,8 @@ func (d *DB) CreateModel(ctx context.Context, params CreateModelParams) (*Model,
 			params.MaxContextTokens,
 			params.InputPricePer1M,
 			params.OutputPricePer1M,
+			params.CachedInputPricePer1M,
+			params.CacheWritePricePer1M,
 			params.AzureDeployment,
 			params.AzureAPIVersion,
 			params.GCPProject,
@@ -366,6 +394,16 @@ func (d *DB) UpdateModel(ctx context.Context, id string, params UpdateModelParam
 	if params.OutputPricePer1M != nil {
 		setClauses = append(setClauses, "output_price_per_1m = "+p(argN))
 		args = append(args, *params.OutputPricePer1M)
+		argN++
+	}
+	if params.CachedInputPricePer1M != nil {
+		setClauses = append(setClauses, "cached_input_price_per_1m = "+p(argN))
+		args = append(args, *params.CachedInputPricePer1M)
+		argN++
+	}
+	if params.CacheWritePricePer1M != nil {
+		setClauses = append(setClauses, "cache_write_price_per_1m = "+p(argN))
+		args = append(args, *params.CacheWritePricePer1M)
 		argN++
 	}
 	if params.AzureDeployment != nil {
@@ -583,6 +621,17 @@ func boolPtrToNullableInt(v *bool) any {
 	return 0
 }
 
+// Float64Value dereferences a nullable price pointer, returning 0 when v is
+// nil. It bridges a DB-nullable price column (NULL = not configured) into a
+// plain float64 consumer such as config.PricingConfig, which uses 0 as its
+// own "not configured" sentinel.
+func Float64Value(v *float64) float64 {
+	if v == nil {
+		return 0
+	}
+	return *v
+}
+
 // nullableIntToBoolPtr converts a nullable integer column value (scanned as
 // *int64) back to a *bool. A nil pointer (NULL column) returns nil; 1 returns
 // a pointer to true; any other value returns a pointer to false.
@@ -603,6 +652,7 @@ func scanModel(scanner interface{ Scan(...any) error }) (*Model, error) {
 	err := scanner.Scan(
 		&m.ID, &m.Name, &m.Provider, &m.ModelType, &m.BaseURL, &m.APIKeyEncrypted,
 		&m.MaxContextTokens, &m.InputPricePer1M, &m.OutputPricePer1M,
+		&m.CachedInputPricePer1M, &m.CacheWritePricePer1M,
 		&m.AzureDeployment, &m.AzureAPIVersion, &m.GCPProject, &m.GCPLocation,
 		&isActiveInt, &m.Source, &m.CreatedBy,
 		&m.CreatedAt, &m.UpdatedAt, &m.DeletedAt, &m.Aliases, &m.Timeout,
@@ -672,23 +722,25 @@ func (d *DB) SyncYAMLModels(ctx context.Context, models []config.ModelConfig, en
 			strategy := m.Strategy
 			maxRetries := m.MaxRetries
 			created, createErr := d.CreateModel(ctx, CreateModelParams{
-				Name:             m.Name,
-				Provider:         m.Provider,
-				ModelType:        &modelType,
-				BaseURL:          m.BaseURL,
-				MaxContextTokens: m.MaxContextTokens,
-				InputPricePer1M:  m.Pricing.InputPer1M,
-				OutputPricePer1M: m.Pricing.OutputPer1M,
-				AzureDeployment:  m.AzureDeployment,
-				AzureAPIVersion:  m.AzureAPIVersion,
-				GCPProject:       m.GCPProject,
-				GCPLocation:      m.GCPLocation,
-				Source:           "yaml",
-				Aliases:          aliases,
-				Timeout:          m.Timeout,
-				Strategy:         &strategy,
-				MaxRetries:       &maxRetries,
-				PIIFilter:        m.PIIFilter,
+				Name:                  m.Name,
+				Provider:              m.Provider,
+				ModelType:             &modelType,
+				BaseURL:               m.BaseURL,
+				MaxContextTokens:      m.MaxContextTokens,
+				InputPricePer1M:       m.Pricing.InputPer1M,
+				OutputPricePer1M:      m.Pricing.OutputPer1M,
+				CachedInputPricePer1M: m.Pricing.CachedInputPer1M,
+				CacheWritePricePer1M:  m.Pricing.CacheWritePer1M,
+				AzureDeployment:       m.AzureDeployment,
+				AzureAPIVersion:       m.AzureAPIVersion,
+				GCPProject:            m.GCPProject,
+				GCPLocation:           m.GCPLocation,
+				Source:                "yaml",
+				Aliases:               aliases,
+				Timeout:               m.Timeout,
+				Strategy:              &strategy,
+				MaxRetries:            &maxRetries,
+				PIIFilter:             m.PIIFilter,
 			})
 			if createErr != nil {
 				return fmt.Errorf("sync yaml models: create %s: %w", m.Name, createErr)
@@ -732,6 +784,8 @@ func (d *DB) SyncYAMLModels(ctx context.Context, models []config.ModelConfig, en
 		maxCtx := m.MaxContextTokens
 		inputPrice := m.Pricing.InputPer1M
 		outputPrice := m.Pricing.OutputPer1M
+		cachedInputPrice := m.Pricing.CachedInputPer1M
+		cacheWritePrice := m.Pricing.CacheWritePer1M
 		azureDeploy := m.AzureDeployment
 		azureVersion := m.AzureAPIVersion
 		gcpProject := m.GCPProject
@@ -741,21 +795,23 @@ func (d *DB) SyncYAMLModels(ctx context.Context, models []config.ModelConfig, en
 		maxRetries := m.MaxRetries
 
 		params := UpdateModelParams{
-			Name:             &name,
-			Provider:         &provider,
-			ModelType:        &modelType,
-			BaseURL:          &baseURL,
-			MaxContextTokens: &maxCtx,
-			InputPricePer1M:  &inputPrice,
-			OutputPricePer1M: &outputPrice,
-			AzureDeployment:  &azureDeploy,
-			AzureAPIVersion:  &azureVersion,
-			GCPProject:       &gcpProject,
-			GCPLocation:      &gcpLocation,
-			Aliases:          &aliases,
-			Timeout:          &timeout,
-			Strategy:         &strategy,
-			MaxRetries:       &maxRetries,
+			Name:                  &name,
+			Provider:              &provider,
+			ModelType:             &modelType,
+			BaseURL:               &baseURL,
+			MaxContextTokens:      &maxCtx,
+			InputPricePer1M:       &inputPrice,
+			OutputPricePer1M:      &outputPrice,
+			CachedInputPricePer1M: &cachedInputPrice,
+			CacheWritePricePer1M:  &cacheWritePrice,
+			AzureDeployment:       &azureDeploy,
+			AzureAPIVersion:       &azureVersion,
+			GCPProject:            &gcpProject,
+			GCPLocation:           &gcpLocation,
+			Aliases:               &aliases,
+			Timeout:               &timeout,
+			Strategy:              &strategy,
+			MaxRetries:            &maxRetries,
 			// Sync the YAML pii_filter value. If the YAML does not set pii_filter
 			// (nil), we clear the column back to NULL so that a previously-set
 			// value does not persist after the YAML flag is removed.

--- a/internal/db/usage_aggregation.go
+++ b/internal/db/usage_aggregation.go
@@ -21,6 +21,12 @@ type HourlyRollup struct {
 	PromptTokens     int
 	CompletionTokens int
 	TotalTokens      int
+	// CachedReadTokens is the subset of PromptTokens served from an upstream
+	// prompt cache, summed across the bucket.
+	CachedReadTokens int
+	// CacheWriteTokens is the subset of PromptTokens written to an upstream
+	// prompt cache (Anthropic only), summed across the bucket.
+	CacheWriteTokens int
 	CostSum          float64
 	DurationSumMS    float64
 	TTFTSumMS        float64
@@ -66,14 +72,17 @@ func (d *DB) GetHourlyUsageTotals(ctx context.Context, filter UsageFilter, since
 
 	query := "SELECT COALESCE(SUM(request_count), 0), " +
 		"COALESCE(SUM(prompt_tokens), 0), COALESCE(SUM(completion_tokens), 0), " +
-		"COALESCE(SUM(total_tokens), 0), COALESCE(SUM(cost_sum), 0), " +
+		"COALESCE(SUM(total_tokens), 0), " +
+		"COALESCE(SUM(cached_read_tokens), 0), COALESCE(SUM(cache_write_tokens), 0), " +
+		"COALESCE(SUM(cost_sum), 0), " +
 		"CASE WHEN SUM(request_count) > 0 THEN SUM(duration_sum_ms) * 1.0 / SUM(request_count) ELSE 0 END " +
 		"FROM usage_hourly WHERE " + strings.Join(conditions, " AND ")
 
 	var a UsageAggregate
 	err := d.sql.QueryRowContext(ctx, query, args...).Scan(
 		&a.TotalRequests, &a.PromptTokens, &a.CompletionTokens,
-		&a.TotalTokens, &a.CostEstimate, &a.AvgDurationMS,
+		&a.TotalTokens, &a.CachedReadTokens, &a.CacheWriteTokens,
+		&a.CostEstimate, &a.AvgDurationMS,
 	)
 	if err != nil {
 		return a, fmt.Errorf("get hourly usage totals: %w", err)
@@ -89,16 +98,20 @@ func (d *DB) UpsertUsageHourly(ctx context.Context, r HourlyRollup) error {
 	query := "INSERT INTO usage_hourly (" +
 		"org_id, team_id, user_id, key_id, model_name, bucket_hour, " +
 		"request_count, prompt_tokens, completion_tokens, total_tokens, " +
+		"cached_read_tokens, cache_write_tokens, " +
 		"cost_sum, duration_sum_ms, ttft_sum_ms, ttft_count" +
 		") VALUES (" +
 		p(1) + ", " + p(2) + ", " + p(3) + ", " + p(4) + ", " + p(5) + ", " + p(6) + ", " +
 		p(7) + ", " + p(8) + ", " + p(9) + ", " + p(10) + ", " +
-		p(11) + ", " + p(12) + ", " + p(13) + ", " + p(14) +
+		p(11) + ", " + p(12) + ", " +
+		p(13) + ", " + p(14) + ", " + p(15) + ", " + p(16) +
 		") ON CONFLICT (key_id, model_name, bucket_hour) DO UPDATE SET " +
 		"request_count = request_count + excluded.request_count, " +
 		"prompt_tokens = prompt_tokens + excluded.prompt_tokens, " +
 		"completion_tokens = completion_tokens + excluded.completion_tokens, " +
 		"total_tokens = total_tokens + excluded.total_tokens, " +
+		"cached_read_tokens = cached_read_tokens + excluded.cached_read_tokens, " +
+		"cache_write_tokens = cache_write_tokens + excluded.cache_write_tokens, " +
 		"cost_sum = cost_sum + excluded.cost_sum, " +
 		"duration_sum_ms = duration_sum_ms + excluded.duration_sum_ms, " +
 		"ttft_sum_ms = ttft_sum_ms + excluded.ttft_sum_ms, " +
@@ -107,6 +120,7 @@ func (d *DB) UpsertUsageHourly(ctx context.Context, r HourlyRollup) error {
 	_, err := d.sql.ExecContext(ctx, query,
 		r.OrgID, r.TeamID, r.UserID, r.KeyID, r.ModelName, r.BucketHour,
 		r.RequestCount, r.PromptTokens, r.CompletionTokens, r.TotalTokens,
+		r.CachedReadTokens, r.CacheWriteTokens,
 		r.CostSum, r.DurationSumMS, r.TTFTSumMS, r.TTFTCount,
 	)
 	if err != nil {

--- a/internal/db/usage_aggregation_test.go
+++ b/internal/db/usage_aggregation_test.go
@@ -1,0 +1,433 @@
+package db
+
+// usage_aggregation_test.go covers internal/db/usage_aggregation.go, which had
+// zero test coverage before #179 — the hourly rollup layer (UpsertUsageHourly,
+// GetHourlyUsageTotals) that powers the fast-path recent-usage dashboard.
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+)
+
+// baseHourlyRollup returns a HourlyRollup with a fixed bucket hour and every
+// numeric column set to a distinct, non-zero value so that upsert-accumulation
+// bugs (e.g. a forgotten "+" in the ON CONFLICT clause) are caught even when a
+// column happens to start at zero.
+func baseHourlyRollup(keyID, modelName string) HourlyRollup {
+	return HourlyRollup{
+		OrgID:            "org-rollup",
+		TeamID:           "team-rollup",
+		UserID:           "user-rollup",
+		KeyID:            keyID,
+		ModelName:        modelName,
+		BucketHour:       "2026-03-20T14:00:00Z",
+		RequestCount:     1,
+		PromptTokens:     100,
+		CompletionTokens: 50,
+		TotalTokens:      150,
+		CachedReadTokens: 30,
+		CacheWriteTokens: 20,
+		CostSum:          0.015,
+		DurationSumMS:    250,
+		TTFTSumMS:        40,
+		TTFTCount:        1,
+	}
+}
+
+// ---- UpsertUsageHourly: fresh bucket ---------------------------------------
+
+// TestUpsertUsageHourly_InsertsFreshBucket verifies that upserting a bucket
+// that does not yet exist inserts a row with exactly the given values,
+// including the two cache-token columns added by migration 0016.
+func TestUpsertUsageHourly_InsertsFreshBucket(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	r := baseHourlyRollup("key-fresh", "model-fresh")
+	if err := d.UpsertUsageHourly(ctx, r); err != nil {
+		t.Fatalf("UpsertUsageHourly() error = %v", err)
+	}
+
+	var (
+		requestCount                    int
+		promptTokens, completionTokens  int
+		totalTokens                     int
+		cachedReadTokens, cacheWriteTok int
+		costSum, durationSumMS          float64
+		ttftSumMS                       float64
+		ttftCount                       int
+	)
+	row := d.sql.QueryRowContext(ctx,
+		`SELECT request_count, prompt_tokens, completion_tokens, total_tokens,
+		        cached_read_tokens, cache_write_tokens,
+		        cost_sum, duration_sum_ms, ttft_sum_ms, ttft_count
+		 FROM usage_hourly WHERE key_id = ? AND model_name = ? AND bucket_hour = ?`,
+		"key-fresh", "model-fresh", r.BucketHour,
+	)
+	if err := row.Scan(&requestCount, &promptTokens, &completionTokens, &totalTokens,
+		&cachedReadTokens, &cacheWriteTok, &costSum, &durationSumMS, &ttftSumMS, &ttftCount); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	if requestCount != r.RequestCount {
+		t.Errorf("request_count = %d, want %d", requestCount, r.RequestCount)
+	}
+	if promptTokens != r.PromptTokens {
+		t.Errorf("prompt_tokens = %d, want %d", promptTokens, r.PromptTokens)
+	}
+	if completionTokens != r.CompletionTokens {
+		t.Errorf("completion_tokens = %d, want %d", completionTokens, r.CompletionTokens)
+	}
+	if totalTokens != r.TotalTokens {
+		t.Errorf("total_tokens = %d, want %d", totalTokens, r.TotalTokens)
+	}
+	if cachedReadTokens != r.CachedReadTokens {
+		t.Errorf("cached_read_tokens = %d, want %d", cachedReadTokens, r.CachedReadTokens)
+	}
+	if cacheWriteTok != r.CacheWriteTokens {
+		t.Errorf("cache_write_tokens = %d, want %d", cacheWriteTok, r.CacheWriteTokens)
+	}
+	if math.Abs(costSum-r.CostSum) > 1e-9 {
+		t.Errorf("cost_sum = %v, want %v", costSum, r.CostSum)
+	}
+	if durationSumMS != r.DurationSumMS {
+		t.Errorf("duration_sum_ms = %v, want %v", durationSumMS, r.DurationSumMS)
+	}
+	if ttftSumMS != r.TTFTSumMS {
+		t.Errorf("ttft_sum_ms = %v, want %v", ttftSumMS, r.TTFTSumMS)
+	}
+	if ttftCount != r.TTFTCount {
+		t.Errorf("ttft_count = %d, want %d", ttftCount, r.TTFTCount)
+	}
+}
+
+// ---- UpsertUsageHourly: accumulation on conflict ---------------------------
+
+// TestUpsertUsageHourly_AccumulatesOnConflict verifies that a second upsert
+// for the same (key_id, model_name, bucket_hour) bucket adds to every numeric
+// column rather than overwriting it — including cached_read_tokens and
+// cache_write_tokens, which is the specific behavior #179 added.
+func TestUpsertUsageHourly_AccumulatesOnConflict(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	first := baseHourlyRollup("key-accum", "model-accum")
+	if err := d.UpsertUsageHourly(ctx, first); err != nil {
+		t.Fatalf("UpsertUsageHourly() first error = %v", err)
+	}
+
+	second := baseHourlyRollup("key-accum", "model-accum")
+	// Distinct values from `first` so an accidental overwrite (rather than
+	// accumulation) is detectable.
+	second.RequestCount = 2
+	second.PromptTokens = 40
+	second.CompletionTokens = 10
+	second.TotalTokens = 50
+	second.CachedReadTokens = 15
+	second.CacheWriteTokens = 5
+	second.CostSum = 0.008
+	second.DurationSumMS = 100
+	second.TTFTSumMS = 20
+	second.TTFTCount = 1
+
+	if err := d.UpsertUsageHourly(ctx, second); err != nil {
+		t.Fatalf("UpsertUsageHourly() second error = %v", err)
+	}
+
+	var (
+		requestCount                    int
+		promptTokens, completionTokens  int
+		totalTokens                     int
+		cachedReadTokens, cacheWriteTok int
+		costSum, durationSumMS          float64
+		ttftSumMS                       float64
+		ttftCount                       int
+	)
+	row := d.sql.QueryRowContext(ctx,
+		`SELECT request_count, prompt_tokens, completion_tokens, total_tokens,
+		        cached_read_tokens, cache_write_tokens,
+		        cost_sum, duration_sum_ms, ttft_sum_ms, ttft_count
+		 FROM usage_hourly WHERE key_id = ? AND model_name = ? AND bucket_hour = ?`,
+		"key-accum", "model-accum", first.BucketHour,
+	)
+	if err := row.Scan(&requestCount, &promptTokens, &completionTokens, &totalTokens,
+		&cachedReadTokens, &cacheWriteTok, &costSum, &durationSumMS, &ttftSumMS, &ttftCount); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+
+	// Every column below must be first+second, proving accumulation (not
+	// overwrite) for both the pre-existing columns and the two new ones.
+	if want := first.RequestCount + second.RequestCount; requestCount != want {
+		t.Errorf("request_count = %d, want %d (accumulated)", requestCount, want)
+	}
+	if want := first.PromptTokens + second.PromptTokens; promptTokens != want {
+		t.Errorf("prompt_tokens = %d, want %d (accumulated)", promptTokens, want)
+	}
+	if want := first.CompletionTokens + second.CompletionTokens; completionTokens != want {
+		t.Errorf("completion_tokens = %d, want %d (accumulated)", completionTokens, want)
+	}
+	if want := first.TotalTokens + second.TotalTokens; totalTokens != want {
+		t.Errorf("total_tokens = %d, want %d (accumulated)", totalTokens, want)
+	}
+	if want := first.CachedReadTokens + second.CachedReadTokens; cachedReadTokens != want {
+		t.Errorf("cached_read_tokens = %d, want %d (accumulated)", cachedReadTokens, want)
+	}
+	if want := first.CacheWriteTokens + second.CacheWriteTokens; cacheWriteTok != want {
+		t.Errorf("cache_write_tokens = %d, want %d (accumulated)", cacheWriteTok, want)
+	}
+	if want := first.CostSum + second.CostSum; math.Abs(costSum-want) > 1e-9 {
+		t.Errorf("cost_sum = %v, want %v (accumulated)", costSum, want)
+	}
+	if want := first.DurationSumMS + second.DurationSumMS; durationSumMS != want {
+		t.Errorf("duration_sum_ms = %v, want %v (accumulated)", durationSumMS, want)
+	}
+	if want := first.TTFTSumMS + second.TTFTSumMS; ttftSumMS != want {
+		t.Errorf("ttft_sum_ms = %v, want %v (accumulated)", ttftSumMS, want)
+	}
+	if want := first.TTFTCount + second.TTFTCount; ttftCount != want {
+		t.Errorf("ttft_count = %d, want %d (accumulated)", ttftCount, want)
+	}
+
+	// Exactly one row must exist for this bucket key — accumulation, not a
+	// second inserted row.
+	var rowCount int
+	if err := d.sql.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM usage_hourly WHERE key_id = ? AND model_name = ? AND bucket_hour = ?",
+		"key-accum", "model-accum", first.BucketHour,
+	).Scan(&rowCount); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if rowCount != 1 {
+		t.Errorf("row count for bucket = %d, want 1 (upsert must not duplicate rows)", rowCount)
+	}
+}
+
+// ---- GetHourlyUsageTotals ---------------------------------------------------
+
+// TestGetHourlyUsageTotals_SumsAcrossBuckets verifies that GetHourlyUsageTotals
+// sums prompt/completion/total/cached-read/cache-write tokens and cost across
+// multiple hourly buckets for the same org, and computes a request-weighted
+// average duration.
+func TestGetHourlyUsageTotals_SumsAcrossBuckets(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	bucket1 := HourlyRollup{
+		OrgID: "org-hourly-sum", KeyID: "key-hourly", ModelName: "model-a",
+		BucketHour:       "2026-03-20T13:00:00Z",
+		RequestCount:     2,
+		PromptTokens:     100,
+		CompletionTokens: 50,
+		TotalTokens:      150,
+		CachedReadTokens: 30,
+		CacheWriteTokens: 10,
+		CostSum:          0.01,
+		DurationSumMS:    400, // avg contribution: 400ms over 2 requests
+	}
+	bucket2 := HourlyRollup{
+		OrgID: "org-hourly-sum", KeyID: "key-hourly", ModelName: "model-b",
+		BucketHour:       "2026-03-20T14:00:00Z",
+		RequestCount:     1,
+		PromptTokens:     200,
+		CompletionTokens: 80,
+		TotalTokens:      280,
+		CachedReadTokens: 70,
+		CacheWriteTokens: 5,
+		CostSum:          0.02,
+		DurationSumMS:    300, // avg contribution: 300ms over 1 request
+	}
+
+	if err := d.UpsertUsageHourly(ctx, bucket1); err != nil {
+		t.Fatalf("UpsertUsageHourly(bucket1) error = %v", err)
+	}
+	if err := d.UpsertUsageHourly(ctx, bucket2); err != nil {
+		t.Fatalf("UpsertUsageHourly(bucket2) error = %v", err)
+	}
+
+	since, err := time.Parse(time.RFC3339, "2026-03-20T12:00:00Z")
+	if err != nil {
+		t.Fatalf("time.Parse: %v", err)
+	}
+
+	agg, err := d.GetHourlyUsageTotals(ctx, UsageFilter{OrgID: "org-hourly-sum"}, since)
+	if err != nil {
+		t.Fatalf("GetHourlyUsageTotals() error = %v", err)
+	}
+
+	if agg.TotalRequests != 3 {
+		t.Errorf("TotalRequests = %d, want 3", agg.TotalRequests)
+	}
+	if agg.PromptTokens != 300 {
+		t.Errorf("PromptTokens = %d, want 300", agg.PromptTokens)
+	}
+	if agg.CompletionTokens != 130 {
+		t.Errorf("CompletionTokens = %d, want 130", agg.CompletionTokens)
+	}
+	if agg.TotalTokens != 430 {
+		t.Errorf("TotalTokens = %d, want 430", agg.TotalTokens)
+	}
+	if agg.CachedReadTokens != 100 {
+		t.Errorf("CachedReadTokens = %d, want 100", agg.CachedReadTokens)
+	}
+	if agg.CacheWriteTokens != 15 {
+		t.Errorf("CacheWriteTokens = %d, want 15", agg.CacheWriteTokens)
+	}
+	const wantCost = 0.03
+	if math.Abs(agg.CostEstimate-wantCost) > 1e-9 {
+		t.Errorf("CostEstimate = %v, want %v", agg.CostEstimate, wantCost)
+	}
+	// avg = total_duration_sum / total_requests = 700 / 3.
+	const wantAvg = 700.0 / 3.0
+	if math.Abs(agg.AvgDurationMS-wantAvg) > 1e-6 {
+		t.Errorf("AvgDurationMS = %v, want %v", agg.AvgDurationMS, wantAvg)
+	}
+}
+
+// TestGetHourlyUsageTotals_SinceExcludesEarlierBuckets verifies that buckets
+// with bucket_hour before `since` (truncated to the hour) are excluded from
+// the sum.
+func TestGetHourlyUsageTotals_SinceExcludesEarlierBuckets(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	early := HourlyRollup{
+		OrgID: "org-hourly-since", KeyID: "key-since", ModelName: "model-early",
+		BucketHour: "2026-03-20T10:00:00Z", RequestCount: 1,
+		PromptTokens: 999, CompletionTokens: 999, TotalTokens: 1998,
+		CachedReadTokens: 999, CacheWriteTokens: 999,
+	}
+	late := HourlyRollup{
+		OrgID: "org-hourly-since", KeyID: "key-since", ModelName: "model-late",
+		BucketHour: "2026-03-20T15:00:00Z", RequestCount: 1,
+		PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15,
+		CachedReadTokens: 3, CacheWriteTokens: 2,
+	}
+	if err := d.UpsertUsageHourly(ctx, early); err != nil {
+		t.Fatalf("UpsertUsageHourly(early) error = %v", err)
+	}
+	if err := d.UpsertUsageHourly(ctx, late); err != nil {
+		t.Fatalf("UpsertUsageHourly(late) error = %v", err)
+	}
+
+	since, err := time.Parse(time.RFC3339, "2026-03-20T14:00:00Z")
+	if err != nil {
+		t.Fatalf("time.Parse: %v", err)
+	}
+
+	agg, err := d.GetHourlyUsageTotals(ctx, UsageFilter{OrgID: "org-hourly-since"}, since)
+	if err != nil {
+		t.Fatalf("GetHourlyUsageTotals() error = %v", err)
+	}
+
+	if agg.PromptTokens != 10 {
+		t.Errorf("PromptTokens = %d, want 10 (early bucket must be excluded)", agg.PromptTokens)
+	}
+	if agg.CachedReadTokens != 3 {
+		t.Errorf("CachedReadTokens = %d, want 3 (early bucket must be excluded)", agg.CachedReadTokens)
+	}
+}
+
+// TestGetHourlyUsageTotals_NoBuckets_ReturnsZero verifies that querying an org
+// with no hourly rollup rows returns an all-zero UsageAggregate rather than an
+// error, matching the COALESCE(SUM(...), 0) semantics of the SQL.
+func TestGetHourlyUsageTotals_NoBuckets_ReturnsZero(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	since := time.Now().UTC().Add(-time.Hour)
+	agg, err := d.GetHourlyUsageTotals(ctx, UsageFilter{OrgID: "org-hourly-empty"}, since)
+	if err != nil {
+		t.Fatalf("GetHourlyUsageTotals() error = %v", err)
+	}
+
+	if agg.TotalRequests != 0 {
+		t.Errorf("TotalRequests = %d, want 0", agg.TotalRequests)
+	}
+	if agg.PromptTokens != 0 || agg.CompletionTokens != 0 || agg.TotalTokens != 0 {
+		t.Errorf("token totals = %+v, want all zero", agg)
+	}
+	if agg.CachedReadTokens != 0 {
+		t.Errorf("CachedReadTokens = %d, want 0", agg.CachedReadTokens)
+	}
+	if agg.CacheWriteTokens != 0 {
+		t.Errorf("CacheWriteTokens = %d, want 0", agg.CacheWriteTokens)
+	}
+	if agg.CostEstimate != 0 {
+		t.Errorf("CostEstimate = %v, want 0", agg.CostEstimate)
+	}
+	if agg.AvgDurationMS != 0 {
+		t.Errorf("AvgDurationMS = %v, want 0", agg.AvgDurationMS)
+	}
+}
+
+// TestGetHourlyUsageTotals_ScopedByTeamAndUserAndKey verifies that the
+// optional TeamID/UserID/KeyID filters on UsageFilter narrow the sum, using
+// the cache-token columns as the distinguishing signal.
+func TestGetHourlyUsageTotals_ScopedByTeamAndUserAndKey(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	ctx := context.Background()
+
+	matching := HourlyRollup{
+		OrgID: "org-hourly-scope", TeamID: "team-x", UserID: "user-x", KeyID: "key-x",
+		ModelName: "model-x", BucketHour: "2026-03-20T14:00:00Z", RequestCount: 1,
+		PromptTokens: 50, CompletionTokens: 10, TotalTokens: 60,
+		CachedReadTokens: 20, CacheWriteTokens: 5,
+	}
+	other := HourlyRollup{
+		OrgID: "org-hourly-scope", TeamID: "team-y", UserID: "user-y", KeyID: "key-y",
+		ModelName: "model-y", BucketHour: "2026-03-20T14:00:00Z", RequestCount: 1,
+		PromptTokens: 1000, CompletionTokens: 1000, TotalTokens: 2000,
+		CachedReadTokens: 1000, CacheWriteTokens: 1000,
+	}
+	if err := d.UpsertUsageHourly(ctx, matching); err != nil {
+		t.Fatalf("UpsertUsageHourly(matching) error = %v", err)
+	}
+	if err := d.UpsertUsageHourly(ctx, other); err != nil {
+		t.Fatalf("UpsertUsageHourly(other) error = %v", err)
+	}
+
+	since, err := time.Parse(time.RFC3339, "2026-03-20T00:00:00Z")
+	if err != nil {
+		t.Fatalf("time.Parse: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		filter UsageFilter
+	}{
+		{name: "scoped by team", filter: UsageFilter{OrgID: "org-hourly-scope", TeamID: "team-x"}},
+		{name: "scoped by user", filter: UsageFilter{OrgID: "org-hourly-scope", UserID: "user-x"}},
+		{name: "scoped by key", filter: UsageFilter{OrgID: "org-hourly-scope", KeyID: "key-x"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			agg, err := d.GetHourlyUsageTotals(ctx, tc.filter, since)
+			if err != nil {
+				t.Fatalf("GetHourlyUsageTotals() error = %v", err)
+			}
+			if agg.CachedReadTokens != 20 {
+				t.Errorf("CachedReadTokens = %d, want 20 (only the matching-scope bucket)", agg.CachedReadTokens)
+			}
+			if agg.CacheWriteTokens != 5 {
+				t.Errorf("CacheWriteTokens = %d, want 5 (only the matching-scope bucket)", agg.CacheWriteTokens)
+			}
+		})
+	}
+}

--- a/internal/db/usage_queries.go
+++ b/internal/db/usage_queries.go
@@ -33,6 +33,12 @@ type UsageAggregate struct {
 	PromptTokens     int64
 	CompletionTokens int64
 	TotalTokens      int64
+	// CachedReadTokens is the subset of PromptTokens served from an upstream
+	// prompt cache, summed across the group.
+	CachedReadTokens int64
+	// CacheWriteTokens is the subset of PromptTokens written to an upstream
+	// prompt cache (Anthropic only), summed across the group.
+	CacheWriteTokens int64
 	CostEstimate     float64
 	AvgDurationMS    float64
 }
@@ -74,7 +80,9 @@ func (d *DB) GetUsageAggregates(ctx context.Context, orgID string, from, to time
 	if groupCol != "" {
 		query = "SELECT " + selectCol + ", COUNT(*), " +
 			"COALESCE(SUM(prompt_tokens), 0), COALESCE(SUM(completion_tokens), 0), " +
-			"COALESCE(SUM(total_tokens), 0), COALESCE(SUM(cost_estimate), 0), " +
+			"COALESCE(SUM(total_tokens), 0), " +
+			"COALESCE(SUM(cached_read_tokens), 0), COALESCE(SUM(cache_write_tokens), 0), " +
+			"COALESCE(SUM(cost_estimate), 0), " +
 			"COALESCE(AVG(request_duration_ms), 0) " +
 			"FROM usage_events " +
 			"WHERE org_id = " + d.dialect.Placeholder(1) +
@@ -85,7 +93,9 @@ func (d *DB) GetUsageAggregates(ctx context.Context, orgID string, from, to time
 	} else {
 		query = "SELECT '' AS group_key, COUNT(*), " +
 			"COALESCE(SUM(prompt_tokens), 0), COALESCE(SUM(completion_tokens), 0), " +
-			"COALESCE(SUM(total_tokens), 0), COALESCE(SUM(cost_estimate), 0), " +
+			"COALESCE(SUM(total_tokens), 0), " +
+			"COALESCE(SUM(cached_read_tokens), 0), COALESCE(SUM(cache_write_tokens), 0), " +
+			"COALESCE(SUM(cost_estimate), 0), " +
 			"COALESCE(AVG(request_duration_ms), 0) " +
 			"FROM usage_events " +
 			"WHERE org_id = " + d.dialect.Placeholder(1) +
@@ -108,6 +118,8 @@ func (d *DB) GetUsageAggregates(ctx context.Context, orgID string, from, to time
 			&a.PromptTokens,
 			&a.CompletionTokens,
 			&a.TotalTokens,
+			&a.CachedReadTokens,
+			&a.CacheWriteTokens,
 			&a.CostEstimate,
 			&a.AvgDurationMS,
 		); err != nil {
@@ -220,7 +232,9 @@ func (d *DB) GetScopedUsageAggregates(ctx context.Context, filter UsageFilter, f
 	if groupCol != "" {
 		query = "SELECT " + selectCol + ", COUNT(*), " +
 			"COALESCE(SUM(prompt_tokens), 0), COALESCE(SUM(completion_tokens), 0), " +
-			"COALESCE(SUM(total_tokens), 0), COALESCE(SUM(cost_estimate), 0), " +
+			"COALESCE(SUM(total_tokens), 0), " +
+			"COALESCE(SUM(cached_read_tokens), 0), COALESCE(SUM(cache_write_tokens), 0), " +
+			"COALESCE(SUM(cost_estimate), 0), " +
 			"COALESCE(AVG(request_duration_ms), 0) " +
 			"FROM usage_events " +
 			where +
@@ -229,7 +243,9 @@ func (d *DB) GetScopedUsageAggregates(ctx context.Context, filter UsageFilter, f
 	} else {
 		query = "SELECT '' AS group_key, COUNT(*), " +
 			"COALESCE(SUM(prompt_tokens), 0), COALESCE(SUM(completion_tokens), 0), " +
-			"COALESCE(SUM(total_tokens), 0), COALESCE(SUM(cost_estimate), 0), " +
+			"COALESCE(SUM(total_tokens), 0), " +
+			"COALESCE(SUM(cached_read_tokens), 0), COALESCE(SUM(cache_write_tokens), 0), " +
+			"COALESCE(SUM(cost_estimate), 0), " +
 			"COALESCE(AVG(request_duration_ms), 0) " +
 			"FROM usage_events " +
 			where
@@ -250,6 +266,8 @@ func (d *DB) GetScopedUsageAggregates(ctx context.Context, filter UsageFilter, f
 			&a.PromptTokens,
 			&a.CompletionTokens,
 			&a.TotalTokens,
+			&a.CachedReadTokens,
+			&a.CacheWriteTokens,
 			&a.CostEstimate,
 			&a.AvgDurationMS,
 		); err != nil {
@@ -301,7 +319,9 @@ func (d *DB) GetCrossOrgUsageAggregates(ctx context.Context, from, to time.Time,
 	if groupCol != "" {
 		query = "SELECT " + selectCol + ", COUNT(*), " +
 			"COALESCE(SUM(prompt_tokens), 0), COALESCE(SUM(completion_tokens), 0), " +
-			"COALESCE(SUM(total_tokens), 0), COALESCE(SUM(cost_estimate), 0), " +
+			"COALESCE(SUM(total_tokens), 0), " +
+			"COALESCE(SUM(cached_read_tokens), 0), COALESCE(SUM(cache_write_tokens), 0), " +
+			"COALESCE(SUM(cost_estimate), 0), " +
 			"COALESCE(AVG(request_duration_ms), 0) " +
 			"FROM usage_events " +
 			"WHERE created_at >= " + p(1) +
@@ -311,7 +331,9 @@ func (d *DB) GetCrossOrgUsageAggregates(ctx context.Context, from, to time.Time,
 	} else {
 		query = "SELECT '' AS group_key, COUNT(*), " +
 			"COALESCE(SUM(prompt_tokens), 0), COALESCE(SUM(completion_tokens), 0), " +
-			"COALESCE(SUM(total_tokens), 0), COALESCE(SUM(cost_estimate), 0), " +
+			"COALESCE(SUM(total_tokens), 0), " +
+			"COALESCE(SUM(cached_read_tokens), 0), COALESCE(SUM(cache_write_tokens), 0), " +
+			"COALESCE(SUM(cost_estimate), 0), " +
 			"COALESCE(AVG(request_duration_ms), 0) " +
 			"FROM usage_events " +
 			"WHERE created_at >= " + p(1) +
@@ -333,6 +355,8 @@ func (d *DB) GetCrossOrgUsageAggregates(ctx context.Context, from, to time.Time,
 			&a.PromptTokens,
 			&a.CompletionTokens,
 			&a.TotalTokens,
+			&a.CachedReadTokens,
+			&a.CacheWriteTokens,
 			&a.CostEstimate,
 			&a.AvgDurationMS,
 		); err != nil {

--- a/internal/db/usage_queries_test.go
+++ b/internal/db/usage_queries_test.go
@@ -43,9 +43,13 @@ type usageEventParams struct {
 	promptTokens int64
 	compTokens   int64
 	totalTokens  int64
-	costEstimate *float64 // nil → NULL
-	durationMS   *int64   // nil → NULL
-	createdAt    time.Time
+	// cachedReadTokens and cacheWriteTokens default to 0 (their DB column
+	// default) when left unset.
+	cachedReadTokens int64
+	cacheWriteTokens int64
+	costEstimate     *float64 // nil → NULL
+	durationMS       *int64   // nil → NULL
+	createdAt        time.Time
 }
 
 // insertUsageEvent inserts a fully-specified usage_events row for aggregate tests.
@@ -72,13 +76,16 @@ func insertUsageEvent(t *testing.T, d *DB, p usageEventParams) {
 		`INSERT INTO usage_events
 			(id, key_id, key_type, org_id, team_id, model_name,
 			 prompt_tokens, completion_tokens, total_tokens,
+			 cached_read_tokens, cache_write_tokens,
 			 cost_estimate, request_duration_ms, status_code, created_at)
 		 VALUES
 			('%s', '%s', 'user_key', '%s', %s, '%s',
 			 %d, %d, %d,
+			 %d, %d,
 			 %s, %s, 200, '%s')`,
 		p.id, p.keyID, p.orgID, teamVal, p.modelName,
 		p.promptTokens, p.compTokens, p.totalTokens,
+		p.cachedReadTokens, p.cacheWriteTokens,
 		costVal, durVal,
 		p.createdAt.UTC().Format(time.RFC3339),
 	)
@@ -842,5 +849,266 @@ func TestGetUsageAggregates_AvgDuration_Calculated(t *testing.T) {
 	const tolerance = 0.001
 	if math.Abs(rows[0].AvgDurationMS-wantAvg) > tolerance {
 		t.Errorf("AvgDurationMS = %f, want %f", rows[0].AvgDurationMS, wantAvg)
+	}
+}
+
+// ---- GetUsageAggregates: cached-token sums (#179) --------------------------
+
+// TestGetUsageAggregates_CachedTokens_UngroupedSum verifies that
+// cached_read_tokens and cache_write_tokens are summed correctly across
+// multiple events in the ungrouped (totals-only) query path.
+func TestGetUsageAggregates_CachedTokens_UngroupedSum(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	from := now.Add(-2 * time.Hour)
+	to := now.Add(time.Minute)
+
+	insertUsageEvent(t, d, usageEventParams{
+		id: "agg-cache-1", keyID: "key-cache", orgID: "org-agg-cache",
+		promptTokens: 100, compTokens: 20, totalTokens: 120,
+		cachedReadTokens: 40, cacheWriteTokens: 10,
+		createdAt: now.Add(-90 * time.Minute),
+	})
+	insertUsageEvent(t, d, usageEventParams{
+		id: "agg-cache-2", keyID: "key-cache", orgID: "org-agg-cache",
+		promptTokens: 200, compTokens: 30, totalTokens: 230,
+		cachedReadTokens: 70, cacheWriteTokens: 5,
+		createdAt: now.Add(-60 * time.Minute),
+	})
+
+	rows, err := d.GetUsageAggregates(ctx, "org-agg-cache", from, to, "")
+	if err != nil {
+		t.Fatalf("GetUsageAggregates() error = %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1", len(rows))
+	}
+	if rows[0].CachedReadTokens != 110 {
+		t.Errorf("CachedReadTokens = %d, want 110", rows[0].CachedReadTokens)
+	}
+	if rows[0].CacheWriteTokens != 15 {
+		t.Errorf("CacheWriteTokens = %d, want 15", rows[0].CacheWriteTokens)
+	}
+}
+
+// TestGetUsageAggregates_CachedTokens_GroupedByModel verifies that cached-token
+// sums are computed per group (not just globally) when group_by=model.
+func TestGetUsageAggregates_CachedTokens_GroupedByModel(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	from := now.Add(-2 * time.Hour)
+	to := now.Add(time.Minute)
+
+	insertUsageEvent(t, d, usageEventParams{
+		id: "agg-cache-m1", keyID: "key-cache-m", orgID: "org-agg-cache-m",
+		modelName: "gpt-4", promptTokens: 100, compTokens: 20, totalTokens: 120,
+		cachedReadTokens: 40, cacheWriteTokens: 0,
+		createdAt: now.Add(-90 * time.Minute),
+	})
+	insertUsageEvent(t, d, usageEventParams{
+		id: "agg-cache-m2", keyID: "key-cache-m", orgID: "org-agg-cache-m",
+		modelName: "claude-3-5-sonnet", promptTokens: 200, compTokens: 30, totalTokens: 230,
+		cachedReadTokens: 50, cacheWriteTokens: 25,
+		createdAt: now.Add(-60 * time.Minute),
+	})
+
+	rows, err := d.GetUsageAggregates(ctx, "org-agg-cache-m", from, to, "model")
+	if err != nil {
+		t.Fatalf("GetUsageAggregates() error = %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("len(rows) = %d, want 2", len(rows))
+	}
+
+	byGroup := make(map[string]UsageAggregate, len(rows))
+	for _, r := range rows {
+		byGroup[r.GroupKey] = r
+	}
+
+	gpt4, ok := byGroup["gpt-4"]
+	if !ok {
+		t.Fatal("missing group for gpt-4")
+	}
+	if gpt4.CachedReadTokens != 40 {
+		t.Errorf("gpt-4 CachedReadTokens = %d, want 40", gpt4.CachedReadTokens)
+	}
+	if gpt4.CacheWriteTokens != 0 {
+		t.Errorf("gpt-4 CacheWriteTokens = %d, want 0", gpt4.CacheWriteTokens)
+	}
+
+	claude, ok := byGroup["claude-3-5-sonnet"]
+	if !ok {
+		t.Fatal("missing group for claude-3-5-sonnet")
+	}
+	if claude.CachedReadTokens != 50 {
+		t.Errorf("claude-3-5-sonnet CachedReadTokens = %d, want 50", claude.CachedReadTokens)
+	}
+	if claude.CacheWriteTokens != 25 {
+		t.Errorf("claude-3-5-sonnet CacheWriteTokens = %d, want 25", claude.CacheWriteTokens)
+	}
+}
+
+// TestGetUsageAggregates_CachedTokens_EmptyResultIsZero verifies that an org
+// with no events in range returns zero (not NULL, not an error) for the two
+// new cached-token columns, matching the COALESCE(SUM(...), 0) pattern used
+// for the pre-existing token columns.
+func TestGetUsageAggregates_CachedTokens_EmptyResultIsZero(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	rows, err := d.GetUsageAggregates(ctx, "org-agg-cache-empty", now.Add(-time.Hour), now, "")
+	if err != nil {
+		t.Fatalf("GetUsageAggregates() error = %v", err)
+	}
+	if len(rows) == 0 {
+		return // acceptable — empty result is also valid, mirrors TestGetUsageAggregates_NoEvents_NoGrouping
+	}
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 0 or 1", len(rows))
+	}
+	if rows[0].CachedReadTokens != 0 {
+		t.Errorf("CachedReadTokens = %d, want 0", rows[0].CachedReadTokens)
+	}
+	if rows[0].CacheWriteTokens != 0 {
+		t.Errorf("CacheWriteTokens = %d, want 0", rows[0].CacheWriteTokens)
+	}
+}
+
+// ---- GetScopedUsageAggregates / GetCrossOrgUsageAggregates: cached tokens --
+//
+// These two functions had no test coverage at all prior to #179 (grouped and
+// ungrouped alike). The pair of smoke tests below exercises their cached-token
+// SQL literals specifically, since each function carries its own independent
+// COALESCE(SUM(cached_read_tokens/cache_write_tokens)) pair.
+
+// TestGetScopedUsageAggregates_CachedTokens_Summed verifies that
+// GetScopedUsageAggregates (used by MyUsage) sums the two new cache-token
+// columns correctly in both the ungrouped and grouped query paths.
+func TestGetScopedUsageAggregates_CachedTokens_Summed(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	from := now.Add(-2 * time.Hour)
+	to := now.Add(time.Minute)
+
+	insertUsageEvent(t, d, usageEventParams{
+		id: "scoped-cache-1", keyID: "key-scoped-cache", orgID: "org-scoped-cache",
+		promptTokens: 100, compTokens: 20, totalTokens: 120,
+		cachedReadTokens: 40, cacheWriteTokens: 10,
+		createdAt: now.Add(-90 * time.Minute),
+	})
+	insertUsageEvent(t, d, usageEventParams{
+		id: "scoped-cache-2", keyID: "key-scoped-cache", orgID: "org-scoped-cache",
+		promptTokens: 50, compTokens: 5, totalTokens: 55,
+		cachedReadTokens: 15, cacheWriteTokens: 0,
+		createdAt: now.Add(-60 * time.Minute),
+	})
+
+	filter := UsageFilter{OrgID: "org-scoped-cache", KeyID: "key-scoped-cache"}
+
+	ungrouped, err := d.GetScopedUsageAggregates(ctx, filter, from, to, "")
+	if err != nil {
+		t.Fatalf("GetScopedUsageAggregates(ungrouped) error = %v", err)
+	}
+	if len(ungrouped) != 1 {
+		t.Fatalf("len(ungrouped) = %d, want 1", len(ungrouped))
+	}
+	if ungrouped[0].CachedReadTokens != 55 {
+		t.Errorf("ungrouped CachedReadTokens = %d, want 55", ungrouped[0].CachedReadTokens)
+	}
+	if ungrouped[0].CacheWriteTokens != 10 {
+		t.Errorf("ungrouped CacheWriteTokens = %d, want 10", ungrouped[0].CacheWriteTokens)
+	}
+
+	grouped, err := d.GetScopedUsageAggregates(ctx, filter, from, to, "key")
+	if err != nil {
+		t.Fatalf("GetScopedUsageAggregates(grouped) error = %v", err)
+	}
+	if len(grouped) != 1 {
+		t.Fatalf("len(grouped) = %d, want 1", len(grouped))
+	}
+	if grouped[0].CachedReadTokens != 55 {
+		t.Errorf("grouped CachedReadTokens = %d, want 55", grouped[0].CachedReadTokens)
+	}
+	if grouped[0].CacheWriteTokens != 10 {
+		t.Errorf("grouped CacheWriteTokens = %d, want 10", grouped[0].CacheWriteTokens)
+	}
+}
+
+// TestGetCrossOrgUsageAggregates_CachedTokens_Summed verifies that
+// GetCrossOrgUsageAggregates (used by the system-admin usage endpoint) sums
+// the two new cache-token columns correctly in both the ungrouped and
+// grouped (by org) query paths, across events from multiple orgs.
+func TestGetCrossOrgUsageAggregates_CachedTokens_Summed(t *testing.T) {
+	t.Parallel()
+
+	d := openMigratedDB(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	from := now.Add(-2 * time.Hour)
+	to := now.Add(time.Minute)
+
+	insertUsageEvent(t, d, usageEventParams{
+		id: "xorg-cache-1", keyID: "key-xorg-1", orgID: "org-xorg-a",
+		promptTokens: 100, compTokens: 20, totalTokens: 120,
+		cachedReadTokens: 30, cacheWriteTokens: 5,
+		createdAt: now.Add(-90 * time.Minute),
+	})
+	insertUsageEvent(t, d, usageEventParams{
+		id: "xorg-cache-2", keyID: "key-xorg-2", orgID: "org-xorg-b",
+		promptTokens: 200, compTokens: 40, totalTokens: 240,
+		cachedReadTokens: 60, cacheWriteTokens: 15,
+		createdAt: now.Add(-60 * time.Minute),
+	})
+
+	ungrouped, err := d.GetCrossOrgUsageAggregates(ctx, from, to, "")
+	if err != nil {
+		t.Fatalf("GetCrossOrgUsageAggregates(ungrouped) error = %v", err)
+	}
+	if len(ungrouped) != 1 {
+		t.Fatalf("len(ungrouped) = %d, want 1", len(ungrouped))
+	}
+	if ungrouped[0].CachedReadTokens != 90 {
+		t.Errorf("ungrouped CachedReadTokens = %d, want 90", ungrouped[0].CachedReadTokens)
+	}
+	if ungrouped[0].CacheWriteTokens != 20 {
+		t.Errorf("ungrouped CacheWriteTokens = %d, want 20", ungrouped[0].CacheWriteTokens)
+	}
+
+	grouped, err := d.GetCrossOrgUsageAggregates(ctx, from, to, "org")
+	if err != nil {
+		t.Fatalf("GetCrossOrgUsageAggregates(grouped) error = %v", err)
+	}
+	byGroup := make(map[string]UsageAggregate, len(grouped))
+	for _, r := range grouped {
+		byGroup[r.GroupKey] = r
+	}
+	a, ok := byGroup["org-xorg-a"]
+	if !ok {
+		t.Fatal("missing group for org-xorg-a")
+	}
+	if a.CachedReadTokens != 30 {
+		t.Errorf("org-xorg-a CachedReadTokens = %d, want 30", a.CachedReadTokens)
+	}
+	b, ok := byGroup["org-xorg-b"]
+	if !ok {
+		t.Fatal("missing group for org-xorg-b")
+	}
+	if b.CachedReadTokens != 60 {
+		t.Errorf("org-xorg-b CachedReadTokens = %d, want 60", b.CachedReadTokens)
+	}
+	if b.CacheWriteTokens != 15 {
+		t.Errorf("org-xorg-b CacheWriteTokens = %d, want 15", b.CacheWriteTokens)
 	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -39,7 +39,12 @@ var ProxyTTFTSeconds = promauto.NewHistogramVec(prometheus.HistogramOpts{
 }, []string{"model"})
 
 // TokensTotal counts tokens processed by the proxy, partitioned by model name
-// and direction: "prompt" for input tokens and "completion" for output tokens.
+// and direction: "prompt" for input tokens, "completion" for output tokens,
+// "cached_read" for the subset of prompt tokens served from an upstream
+// prompt cache, and "cache_write" for prompt tokens written to an upstream
+// prompt cache (Anthropic only; always zero for other providers). The
+// cached_read and cache_write values are informational subsets already
+// included in "prompt" — they are not additional tokens.
 var TokensTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Name: "voidllm_tokens_total",
 	Help: "Total tokens processed by the proxy.",

--- a/internal/proxy/adapter.go
+++ b/internal/proxy/adapter.go
@@ -48,13 +48,43 @@ func isForwardedPseudonym(s string) bool {
 // For non-streaming responses the counts come from the response JSON; for
 // streaming responses they are accumulated by the adapter during
 // TransformStreamLine calls.
+//
+// PromptTokens always means ALL prompt tokens, inclusive of any cached ones,
+// for every provider — this is the one normalized meaning the proxy exposes
+// regardless of how the upstream itself counts. Providers do not agree on
+// how cached tokens relate to their own prompt-token total, and adapters are
+// responsible for reconciling that before returning UsageInfo:
+//
+//   - OpenAI: usage.prompt_tokens_details.cached_tokens is already a SUBSET
+//     of prompt_tokens. PromptTokens is used as reported; CachedReadTokens is
+//     the subset within it.
+//   - Gemini: usageMetadata.cachedContentTokenCount is likewise a SUBSET of
+//     promptTokenCount. Same handling as OpenAI.
+//   - Anthropic: cache_read_input_tokens and cache_creation_input_tokens are
+//     reported IN ADDITION TO input_tokens (not a subset). The Anthropic
+//     adapter adds both into PromptTokens (and TotalTokens) so that
+//     PromptTokens carries the same all-inclusive meaning as every other
+//     provider; CachedReadTokens and CacheWriteTokens still report the
+//     individual buckets for pricing.
 type UsageInfo struct {
-	// PromptTokens is the number of input tokens consumed.
+	// PromptTokens is the number of input tokens consumed, inclusive of any
+	// cached-read or cache-write tokens. See the type-level doc for the
+	// per-provider reconciliation this field represents.
 	PromptTokens int
 	// CompletionTokens is the number of output tokens produced.
 	CompletionTokens int
 	// TotalTokens is the sum of prompt and completion tokens.
 	TotalTokens int
+	// CachedReadTokens is the subset of PromptTokens that were served from an
+	// upstream prompt cache rather than freshly processed. Billed below the
+	// normal input rate. Zero when the provider reports no cache read or the
+	// adapter cannot extract it.
+	CachedReadTokens int
+	// CacheWriteTokens is the subset of PromptTokens that were written to an
+	// upstream prompt cache (Anthropic's cache_creation_input_tokens). Billed
+	// above the normal input rate. Always zero for providers without a
+	// cache-write concept (OpenAI, Gemini).
+	CacheWriteTokens int
 }
 
 // Adapter transforms requests and responses between the client's OpenAI-compatible

--- a/internal/proxy/anthropic.go
+++ b/internal/proxy/anthropic.go
@@ -37,6 +37,15 @@ type AnthropicAdapter struct {
 	modelName    string // stored from TransformRequest for use in TransformResponse
 	inputTokens  int    // accumulated from message_start usage
 	outputTokens int    // accumulated from message_delta usage
+	// cacheReadTokens is cache_read_input_tokens from message_start usage: the
+	// portion of prompt tokens served from Anthropic's prompt cache, billed
+	// below the normal input rate. Anthropic reports this IN ADDITION TO
+	// input_tokens, not as a subset — see UsageInfo's doc for the reconciliation.
+	cacheReadTokens int
+	// cacheWriteTokens is cache_creation_input_tokens from message_start usage:
+	// the portion of prompt tokens written to Anthropic's prompt cache, billed
+	// above the normal input rate. Also additive to input_tokens.
+	cacheWriteTokens int
 
 	// toolCallCounter is incremented each time a tool_use content_block_start
 	// is encountered. It maps the Anthropic content-block index to the
@@ -139,8 +148,13 @@ type anthropicResponse struct {
 	Content    []anthropicResponseBlock `json:"content"`
 	StopReason *string                  `json:"stop_reason"`
 	Usage      struct {
-		InputTokens  int `json:"input_tokens"`
-		OutputTokens int `json:"output_tokens"`
+		InputTokens int `json:"input_tokens"`
+		// CacheReadInputTokens and CacheCreationInputTokens are reported IN
+		// ADDITION TO InputTokens by Anthropic, not as a subset of it — see
+		// UsageInfo's doc comment for the cross-provider reconciliation.
+		CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+		CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+		OutputTokens             int `json:"output_tokens"`
 	} `json:"usage"`
 }
 
@@ -188,6 +202,40 @@ type openAIUsage struct {
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
+	// PromptTokensDetails carries cached/cache-write token counts through the
+	// buffered (non-streaming) response transform. handler.go's extractUsage
+	// runs against the POST-transform body when an adapter is present, so any
+	// count not present in this transformed JSON is lost — this field is what
+	// makes that round trip work for Anthropic and Gemini. Nil (omitted) when
+	// both counts are zero, matching the real OpenAI API's optional field.
+	PromptTokensDetails *openAIPromptTokensDetails `json:"prompt_tokens_details,omitempty"`
+}
+
+// openAIPromptTokensDetails is the usage.prompt_tokens_details object. See
+// wireUsageDetails in handler.go, which parses this same shape back out of
+// the transformed response body — the two types must stay in sync.
+type openAIPromptTokensDetails struct {
+	// CachedTokens is the OpenAI/Gemini-standard field: the subset of
+	// prompt_tokens served from cache.
+	CachedTokens int `json:"cached_tokens"`
+	// CacheCreationTokens is a proxy-internal extension (no OpenAI
+	// equivalent) carrying Anthropic's cache-write count through the same
+	// object rather than inventing a second top-level field.
+	CacheCreationTokens int `json:"cache_creation_tokens,omitempty"`
+}
+
+// cacheUsageDetails builds the prompt_tokens_details object for an
+// OpenAI-shaped usage payload so cached-token counts survive an adapter's
+// response transform. Returns nil when both counts are zero so an unaffected
+// response keeps the exact OpenAI wire shape (no empty object emitted).
+func cacheUsageDetails(cachedRead, cacheWrite int) *openAIPromptTokensDetails {
+	if cachedRead == 0 && cacheWrite == 0 {
+		return nil
+	}
+	return &openAIPromptTokensDetails{
+		CachedTokens:        cachedRead,
+		CacheCreationTokens: cacheWrite,
+	}
 }
 
 // openAIChunk is the shape of a single OpenAI streaming chunk.
@@ -660,6 +708,12 @@ func (a *AnthropicAdapter) TransformResponse(body []byte) ([]byte, error) {
 	if respModel == "" {
 		respModel = "claude"
 	}
+	// Anthropic reports cache_read_input_tokens and cache_creation_input_tokens
+	// IN ADDITION TO input_tokens (not as a subset — see UsageInfo's doc). Add
+	// both into promptTokens here so PromptTokens carries the same
+	// all-inclusive meaning for Anthropic as it does for every other
+	// provider; this is the under-reporting fix for #179.
+	promptTokens := ar.Usage.InputTokens + ar.Usage.CacheReadInputTokens + ar.Usage.CacheCreationInputTokens
 	resp := openAIResponse{
 		ID:     fmt.Sprintf("chatcmpl-%d", time.Now().UnixNano()),
 		Object: "chat.completion",
@@ -672,9 +726,10 @@ func (a *AnthropicAdapter) TransformResponse(body []byte) ([]byte, error) {
 			},
 		},
 		Usage: openAIUsage{
-			PromptTokens:     ar.Usage.InputTokens,
-			CompletionTokens: ar.Usage.OutputTokens,
-			TotalTokens:      ar.Usage.InputTokens + ar.Usage.OutputTokens,
+			PromptTokens:        promptTokens,
+			CompletionTokens:    ar.Usage.OutputTokens,
+			TotalTokens:         promptTokens + ar.Usage.OutputTokens,
+			PromptTokensDetails: cacheUsageDetails(ar.Usage.CacheReadInputTokens, ar.Usage.CacheCreationInputTokens),
 		},
 	}
 
@@ -745,12 +800,16 @@ func (a *AnthropicAdapter) TransformStreamLine(line []byte) ([][]byte, error) {
 
 	switch eventType {
 	case "message_start":
-		// Extract the message ID and input token count for this stream.
+		// Extract the message ID and input token counts for this stream.
+		// cache_read_input_tokens and cache_creation_input_tokens are only
+		// ever reported here (message_delta only updates output_tokens).
 		var ms struct {
 			Message struct {
 				ID    string `json:"id"`
 				Usage struct {
-					InputTokens int `json:"input_tokens"`
+					InputTokens              int `json:"input_tokens"`
+					CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+					CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
 				} `json:"usage"`
 			} `json:"message"`
 		}
@@ -759,6 +818,8 @@ func (a *AnthropicAdapter) TransformStreamLine(line []byte) ([][]byte, error) {
 				a.msgID = ms.Message.ID
 			}
 			a.inputTokens = ms.Message.Usage.InputTokens
+			a.cacheReadTokens = ms.Message.Usage.CacheReadInputTokens
+			a.cacheWriteTokens = ms.Message.Usage.CacheCreationInputTokens
 		}
 		if a.msgID == "" {
 			a.msgID = "chatcmpl-proxy"
@@ -906,13 +967,20 @@ func (a *AnthropicAdapter) TransformStreamLine(line []byte) ([][]byte, error) {
 }
 
 // StreamUsage returns the token counts accumulated during the Anthropic stream.
-// inputTokens is captured from the message_start event and outputTokens from
-// the message_delta event. Both are zero until those events have been processed.
+// inputTokens, cacheReadTokens, and cacheWriteTokens are captured from the
+// message_start event and outputTokens from the message_delta event. All are
+// zero until those events have been processed. cacheReadTokens and
+// cacheWriteTokens are added into PromptTokens (see UsageInfo's doc) so the
+// stream path reports the same all-inclusive prompt-token count as the
+// buffered path.
 func (a *AnthropicAdapter) StreamUsage() UsageInfo {
+	promptTokens := a.inputTokens + a.cacheReadTokens + a.cacheWriteTokens
 	return UsageInfo{
-		PromptTokens:     a.inputTokens,
+		PromptTokens:     promptTokens,
 		CompletionTokens: a.outputTokens,
-		TotalTokens:      a.inputTokens + a.outputTokens,
+		TotalTokens:      promptTokens + a.outputTokens,
+		CachedReadTokens: a.cacheReadTokens,
+		CacheWriteTokens: a.cacheWriteTokens,
 	}
 }
 

--- a/internal/proxy/cached_tokens_test.go
+++ b/internal/proxy/cached_tokens_test.go
@@ -1,0 +1,646 @@
+package proxy
+
+// cached_tokens_test.go covers the cached-token normalization introduced for
+// #179: OpenAI and Gemini report cached tokens as a SUBSET of their
+// prompt-token total, while Anthropic reports them IN ADDITION TO
+// input_tokens. See UsageInfo's doc comment in adapter.go for the full
+// per-provider reconciliation this file exercises.
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// ---- extractUsage (buffered, passthrough OpenAI-shaped bodies) -------------
+
+// TestExtractUsage_CachedTokens verifies that extractUsage recovers
+// CachedReadTokens and CacheWriteTokens from usage.prompt_tokens_details
+// without disturbing PromptTokens (OpenAI reports cached_tokens as a subset,
+// so PromptTokens is used exactly as the upstream reported it).
+func TestExtractUsage_CachedTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		body           string
+		wantPrompt     int
+		wantCompletion int
+		wantTotal      int
+		wantCachedRead int
+		wantCacheWrite int
+	}{
+		{
+			name:           "cached_tokens present as subset of prompt_tokens",
+			body:           `{"usage":{"prompt_tokens":100,"completion_tokens":20,"total_tokens":120,"prompt_tokens_details":{"cached_tokens":40}}}`,
+			wantPrompt:     100,
+			wantCompletion: 20,
+			wantTotal:      120,
+			wantCachedRead: 40,
+			wantCacheWrite: 0,
+		},
+		{
+			name:           "cache_creation_tokens (proxy-internal extension) also recovered",
+			body:           `{"usage":{"prompt_tokens":100,"completion_tokens":20,"total_tokens":120,"prompt_tokens_details":{"cached_tokens":40,"cache_creation_tokens":15}}}`,
+			wantPrompt:     100,
+			wantCompletion: 20,
+			wantTotal:      120,
+			wantCachedRead: 40,
+			wantCacheWrite: 15,
+		},
+		{
+			name:           "no prompt_tokens_details object leaves cache counts at zero",
+			body:           `{"usage":{"prompt_tokens":100,"completion_tokens":20,"total_tokens":120}}`,
+			wantPrompt:     100,
+			wantCompletion: 20,
+			wantTotal:      120,
+			wantCachedRead: 0,
+			wantCacheWrite: 0,
+		},
+		{
+			name:           "prompt_tokens_details present but all-zero",
+			body:           `{"usage":{"prompt_tokens":100,"completion_tokens":20,"total_tokens":120,"prompt_tokens_details":{"cached_tokens":0}}}`,
+			wantPrompt:     100,
+			wantCompletion: 20,
+			wantTotal:      120,
+			wantCachedRead: 0,
+			wantCacheWrite: 0,
+		},
+		{
+			name:           "no usage field at all returns zero UsageInfo",
+			body:           `{"choices":[]}`,
+			wantPrompt:     0,
+			wantCompletion: 0,
+			wantTotal:      0,
+			wantCachedRead: 0,
+			wantCacheWrite: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := extractUsage([]byte(tc.body))
+			if got.PromptTokens != tc.wantPrompt {
+				t.Errorf("PromptTokens = %d, want %d", got.PromptTokens, tc.wantPrompt)
+			}
+			if got.CompletionTokens != tc.wantCompletion {
+				t.Errorf("CompletionTokens = %d, want %d", got.CompletionTokens, tc.wantCompletion)
+			}
+			if got.TotalTokens != tc.wantTotal {
+				t.Errorf("TotalTokens = %d, want %d", got.TotalTokens, tc.wantTotal)
+			}
+			if got.CachedReadTokens != tc.wantCachedRead {
+				t.Errorf("CachedReadTokens = %d, want %d", got.CachedReadTokens, tc.wantCachedRead)
+			}
+			if got.CacheWriteTokens != tc.wantCacheWrite {
+				t.Errorf("CacheWriteTokens = %d, want %d", got.CacheWriteTokens, tc.wantCacheWrite)
+			}
+		})
+	}
+}
+
+// ---- streamUsageExtractor.observe (streaming, passthrough OpenAI-shaped) ---
+
+// TestStreamUsageExtractor_ObserveCachedTokens verifies that observe recovers
+// cached/cache-write counts from an SSE data line's prompt_tokens_details,
+// and that a later observe() call fully replaces (not merges with) the prior
+// lastUsage — matching the pre-existing behavior for prompt/completion tokens.
+func TestStreamUsageExtractor_ObserveCachedTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		lines          []string
+		wantPrompt     int
+		wantCachedRead int
+		wantCacheWrite int
+	}{
+		{
+			name:           "no usage line observed leaves zero UsageInfo",
+			lines:          []string{`data: {"choices":[{"delta":{"content":"hi"}}]}`},
+			wantPrompt:     0,
+			wantCachedRead: 0,
+			wantCacheWrite: 0,
+		},
+		{
+			name: "final chunk carries cached_tokens subset",
+			lines: []string{
+				`data: {"choices":[{"delta":{"content":"hi"}}]}`,
+				`data: {"choices":[{"delta":{}}],"usage":{"prompt_tokens":80,"completion_tokens":10,"total_tokens":90,"prompt_tokens_details":{"cached_tokens":30}}}`,
+			},
+			wantPrompt:     80,
+			wantCachedRead: 30,
+			wantCacheWrite: 0,
+		},
+		{
+			name: "cache_creation_tokens recovered alongside cached_tokens",
+			lines: []string{
+				`data: {"choices":[{"delta":{}}],"usage":{"prompt_tokens":80,"completion_tokens":10,"total_tokens":90,"prompt_tokens_details":{"cached_tokens":30,"cache_creation_tokens":12}}}`,
+			},
+			wantPrompt:     80,
+			wantCachedRead: 30,
+			wantCacheWrite: 12,
+		},
+		{
+			name: "a later usage line without details resets cache counts to zero",
+			lines: []string{
+				`data: {"choices":[{"delta":{}}],"usage":{"prompt_tokens":80,"completion_tokens":10,"total_tokens":90,"prompt_tokens_details":{"cached_tokens":30}}}`,
+				`data: {"choices":[{"delta":{}}],"usage":{"prompt_tokens":80,"completion_tokens":10,"total_tokens":90}}`,
+			},
+			wantPrompt:     80,
+			wantCachedRead: 0,
+			wantCacheWrite: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var ex streamUsageExtractor
+			for _, line := range tc.lines {
+				ex.observe([]byte(line))
+			}
+
+			if ex.lastUsage.PromptTokens != tc.wantPrompt {
+				t.Errorf("PromptTokens = %d, want %d", ex.lastUsage.PromptTokens, tc.wantPrompt)
+			}
+			if ex.lastUsage.CachedReadTokens != tc.wantCachedRead {
+				t.Errorf("CachedReadTokens = %d, want %d", ex.lastUsage.CachedReadTokens, tc.wantCachedRead)
+			}
+			if ex.lastUsage.CacheWriteTokens != tc.wantCacheWrite {
+				t.Errorf("CacheWriteTokens = %d, want %d", ex.lastUsage.CacheWriteTokens, tc.wantCacheWrite)
+			}
+		})
+	}
+}
+
+// ---- Gemini: buffered TransformResponse -----------------------------------
+
+// TestGeminiTransformResponse_CachedTokens verifies that cachedContentTokenCount
+// is surfaced in the transformed response's usage.prompt_tokens_details as a
+// SUBSET of prompt_tokens (PromptTokens itself is left unchanged), and that the
+// round trip through extractUsage recovers the same counts — this is the exact
+// path handleBufferedResponse exercises: TransformResponse's output is what
+// extractUsage actually parses.
+func TestGeminiTransformResponse_CachedTokens(t *testing.T) {
+	t.Parallel()
+
+	input := `{
+		"candidates":[{"content":{"role":"model","parts":[{"text":"hi"}]},"finishReason":"STOP"}],
+		"usageMetadata":{"promptTokenCount":50,"cachedContentTokenCount":20,"candidatesTokenCount":8,"totalTokenCount":58}
+	}`
+
+	a := &GeminiAdapter{}
+	out, err := a.TransformResponse([]byte(input))
+	if err != nil {
+		t.Fatalf("TransformResponse() error = %v", err)
+	}
+
+	var resp openAIResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		t.Fatalf("output is not valid openAIResponse JSON: %v", err)
+	}
+
+	if resp.Usage.PromptTokens != 50 {
+		t.Errorf("usage.prompt_tokens = %d, want 50 (cache is a subset, unchanged)", resp.Usage.PromptTokens)
+	}
+	if resp.Usage.PromptTokensDetails == nil {
+		t.Fatal("usage.prompt_tokens_details is nil, want non-nil")
+	}
+	if resp.Usage.PromptTokensDetails.CachedTokens != 20 {
+		t.Errorf("usage.prompt_tokens_details.cached_tokens = %d, want 20", resp.Usage.PromptTokensDetails.CachedTokens)
+	}
+
+	// Round trip: this is what extractUsage actually receives on the buffered path.
+	ui := extractUsage(out)
+	if ui.PromptTokens != 50 {
+		t.Errorf("extractUsage: PromptTokens = %d, want 50", ui.PromptTokens)
+	}
+	if ui.CachedReadTokens != 20 {
+		t.Errorf("extractUsage: CachedReadTokens = %d, want 20", ui.CachedReadTokens)
+	}
+	if ui.CacheWriteTokens != 0 {
+		t.Errorf("extractUsage: CacheWriteTokens = %d, want 0 (Gemini has no cache-write concept)", ui.CacheWriteTokens)
+	}
+}
+
+// TestGeminiTransformResponse_NoCachedTokens verifies that a response with no
+// cachedContentTokenCount omits prompt_tokens_details entirely, matching the
+// real OpenAI/Gemini wire shape for unaffected requests.
+func TestGeminiTransformResponse_NoCachedTokens(t *testing.T) {
+	t.Parallel()
+
+	input := `{
+		"candidates":[{"content":{"role":"model","parts":[{"text":"hi"}]},"finishReason":"STOP"}],
+		"usageMetadata":{"promptTokenCount":50,"candidatesTokenCount":8,"totalTokenCount":58}
+	}`
+
+	a := &GeminiAdapter{}
+	out, err := a.TransformResponse([]byte(input))
+	if err != nil {
+		t.Fatalf("TransformResponse() error = %v", err)
+	}
+
+	var resp openAIResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		t.Fatalf("output is not valid openAIResponse JSON: %v", err)
+	}
+	if resp.Usage.PromptTokensDetails != nil {
+		t.Errorf("usage.prompt_tokens_details = %+v, want nil when no cached tokens reported", resp.Usage.PromptTokensDetails)
+	}
+}
+
+// ---- Gemini: streaming accumulation ----------------------------------------
+
+// TestGeminiStreamUsage_CachedTokens verifies that cachedContentTokenCount is
+// accumulated across stream chunks the same way promptTokens/completionTokens
+// are, and that it remains a SUBSET of PromptTokens (not added into it).
+func TestGeminiStreamUsage_CachedTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		lines          []string
+		wantPrompt     int
+		wantCompletion int
+		wantCachedRead int
+	}{
+		{
+			name:           "zero cache usage before any stream lines",
+			lines:          nil,
+			wantPrompt:     0,
+			wantCompletion: 0,
+			wantCachedRead: 0,
+		},
+		{
+			name: "cached tokens accumulated from final chunk",
+			lines: []string{
+				`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"a"}]},"finishReason":""}],"usageMetadata":{}}`,
+				`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"b"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":40,"cachedContentTokenCount":25,"candidatesTokenCount":6,"totalTokenCount":46}}`,
+			},
+			wantPrompt:     40,
+			wantCompletion: 6,
+			wantCachedRead: 25,
+		},
+		{
+			name: "mid-stream chunk with cache info updates before the terminal chunk",
+			lines: []string{
+				`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"a"}]},"finishReason":""}],"usageMetadata":{"promptTokenCount":40,"cachedContentTokenCount":25,"candidatesTokenCount":0,"totalTokenCount":40}}`,
+				`data: {"candidates":[{"content":{"role":"model","parts":[{"text":"b"}]},"finishReason":"STOP"}],"usageMetadata":{"promptTokenCount":40,"cachedContentTokenCount":25,"candidatesTokenCount":6,"totalTokenCount":46}}`,
+			},
+			wantPrompt:     40,
+			wantCompletion: 6,
+			wantCachedRead: 25,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &GeminiAdapter{}
+			for _, line := range tc.lines {
+				transformLineIgnore(a, []byte(line))
+			}
+
+			got := a.StreamUsage()
+			if got.PromptTokens != tc.wantPrompt {
+				t.Errorf("PromptTokens = %d, want %d", got.PromptTokens, tc.wantPrompt)
+			}
+			if got.CompletionTokens != tc.wantCompletion {
+				t.Errorf("CompletionTokens = %d, want %d", got.CompletionTokens, tc.wantCompletion)
+			}
+			if got.CachedReadTokens != tc.wantCachedRead {
+				t.Errorf("CachedReadTokens = %d, want %d", got.CachedReadTokens, tc.wantCachedRead)
+			}
+			if got.CacheWriteTokens != 0 {
+				t.Errorf("CacheWriteTokens = %d, want 0 (Gemini has no cache-write concept)", got.CacheWriteTokens)
+			}
+		})
+	}
+}
+
+// ---- Anthropic: buffered TransformResponse ---------------------------------
+
+// TestAnthropicTransformResponse_CachedTokens verifies that
+// cache_read_input_tokens and cache_creation_input_tokens are ADDED into
+// promptTokens/totalTokens (Anthropic reports them in addition to
+// input_tokens, not as a subset), that the individual buckets still surface
+// via prompt_tokens_details, and that the round trip through extractUsage
+// (the buffered path's actual input) recovers all four figures correctly.
+// This is the under-reporting fix for #179: before it, an Anthropic request
+// with heavy cache reads had its prompt/total tokens under-counted by exactly
+// the cached amount.
+func TestAnthropicTransformResponse_CachedTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		inputJSON         string
+		wantPrompt        int
+		wantCompletion    int
+		wantTotal         int
+		wantCachedRead    int
+		wantCacheWrite    int
+		wantDetailsAbsent bool
+	}{
+		{
+			name: "cache_read_input_tokens added into prompt/total tokens",
+			inputJSON: `{"id":"msg_1","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn",` +
+				`"usage":{"input_tokens":10,"cache_read_input_tokens":40,"output_tokens":5}}`,
+			wantPrompt:     50, // 10 + 40, NOT the raw 10 Anthropic reported
+			wantCompletion: 5,
+			wantTotal:      55, // 50 + 5
+			wantCachedRead: 40,
+			wantCacheWrite: 0,
+		},
+		{
+			name: "cache_creation_input_tokens (cache write) also added",
+			inputJSON: `{"id":"msg_2","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn",` +
+				`"usage":{"input_tokens":10,"cache_creation_input_tokens":25,"output_tokens":5}}`,
+			wantPrompt:     35, // 10 + 25
+			wantCompletion: 5,
+			wantTotal:      40,
+			wantCachedRead: 0,
+			wantCacheWrite: 25,
+		},
+		{
+			name: "both cache_read and cache_creation added simultaneously",
+			inputJSON: `{"id":"msg_3","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn",` +
+				`"usage":{"input_tokens":10,"cache_read_input_tokens":40,"cache_creation_input_tokens":25,"output_tokens":5}}`,
+			wantPrompt:     75, // 10 + 40 + 25
+			wantCompletion: 5,
+			wantTotal:      80,
+			wantCachedRead: 40,
+			wantCacheWrite: 25,
+		},
+		{
+			name: "no cache fields reported: prompt_tokens_details omitted, prompt unchanged",
+			inputJSON: `{"id":"msg_4","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn",` +
+				`"usage":{"input_tokens":10,"output_tokens":5}}`,
+			wantPrompt:        10,
+			wantCompletion:    5,
+			wantTotal:         15,
+			wantCachedRead:    0,
+			wantCacheWrite:    0,
+			wantDetailsAbsent: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &AnthropicAdapter{}
+			out, err := a.TransformResponse([]byte(tc.inputJSON))
+			if err != nil {
+				t.Fatalf("TransformResponse() error = %v", err)
+			}
+
+			var resp openAIResponse
+			if err := json.Unmarshal(out, &resp); err != nil {
+				t.Fatalf("output is not valid openAIResponse JSON: %v", err)
+			}
+
+			if resp.Usage.PromptTokens != tc.wantPrompt {
+				t.Errorf("usage.prompt_tokens = %d, want %d", resp.Usage.PromptTokens, tc.wantPrompt)
+			}
+			if resp.Usage.CompletionTokens != tc.wantCompletion {
+				t.Errorf("usage.completion_tokens = %d, want %d", resp.Usage.CompletionTokens, tc.wantCompletion)
+			}
+			if resp.Usage.TotalTokens != tc.wantTotal {
+				t.Errorf("usage.total_tokens = %d, want %d", resp.Usage.TotalTokens, tc.wantTotal)
+			}
+
+			if tc.wantDetailsAbsent {
+				if resp.Usage.PromptTokensDetails != nil {
+					t.Errorf("usage.prompt_tokens_details = %+v, want nil", resp.Usage.PromptTokensDetails)
+				}
+			} else {
+				if resp.Usage.PromptTokensDetails == nil {
+					t.Fatal("usage.prompt_tokens_details is nil, want non-nil")
+				}
+				if resp.Usage.PromptTokensDetails.CachedTokens != tc.wantCachedRead {
+					t.Errorf("prompt_tokens_details.cached_tokens = %d, want %d", resp.Usage.PromptTokensDetails.CachedTokens, tc.wantCachedRead)
+				}
+				if resp.Usage.PromptTokensDetails.CacheCreationTokens != tc.wantCacheWrite {
+					t.Errorf("prompt_tokens_details.cache_creation_tokens = %d, want %d", resp.Usage.PromptTokensDetails.CacheCreationTokens, tc.wantCacheWrite)
+				}
+			}
+
+			// Round trip: this is what extractUsage actually receives on the
+			// buffered path (handleBufferedResponse feeds it the adapter's
+			// TransformResponse output, not the raw Anthropic body).
+			ui := extractUsage(out)
+			if ui.PromptTokens != tc.wantPrompt {
+				t.Errorf("extractUsage: PromptTokens = %d, want %d", ui.PromptTokens, tc.wantPrompt)
+			}
+			if ui.TotalTokens != tc.wantTotal {
+				t.Errorf("extractUsage: TotalTokens = %d, want %d", ui.TotalTokens, tc.wantTotal)
+			}
+			if ui.CachedReadTokens != tc.wantCachedRead {
+				t.Errorf("extractUsage: CachedReadTokens = %d, want %d", ui.CachedReadTokens, tc.wantCachedRead)
+			}
+			if ui.CacheWriteTokens != tc.wantCacheWrite {
+				t.Errorf("extractUsage: CacheWriteTokens = %d, want %d", ui.CacheWriteTokens, tc.wantCacheWrite)
+			}
+		})
+	}
+}
+
+// ---- Anthropic: StreamUsage (never previously tested) ----------------------
+
+// TestAnthropicStreamUsage verifies AnthropicAdapter.StreamUsage(), which had
+// no test coverage anywhere in the repo before #179. It exercises the full
+// accumulation path: message_start carries input_tokens plus both cache
+// counters, message_delta carries output_tokens, and StreamUsage() must fold
+// the cache counters additively into PromptTokens/TotalTokens exactly as
+// TransformResponse does for the buffered path.
+func TestAnthropicStreamUsage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		events         []string
+		wantPrompt     int
+		wantCompletion int
+		wantTotal      int
+		wantCachedRead int
+		wantCacheWrite int
+	}{
+		{
+			name:           "zero usage before any stream events",
+			events:         nil,
+			wantPrompt:     0,
+			wantCompletion: 0,
+			wantTotal:      0,
+			wantCachedRead: 0,
+			wantCacheWrite: 0,
+		},
+		{
+			name: "input_tokens only, no cache activity",
+			events: []string{
+				`data: {"type":"message_start","message":{"id":"msg_a","usage":{"input_tokens":12}}}`,
+				`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":8}}`,
+			},
+			wantPrompt:     12,
+			wantCompletion: 8,
+			wantTotal:      20,
+			wantCachedRead: 0,
+			wantCacheWrite: 0,
+		},
+		{
+			name: "cache_read_input_tokens added into PromptTokens/TotalTokens",
+			events: []string{
+				`data: {"type":"message_start","message":{"id":"msg_b","usage":{"input_tokens":10,"cache_read_input_tokens":40}}}`,
+				`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`,
+			},
+			wantPrompt:     50, // 10 + 40, not the raw 10
+			wantCompletion: 5,
+			wantTotal:      55,
+			wantCachedRead: 40,
+			wantCacheWrite: 0,
+		},
+		{
+			name: "cache_creation_input_tokens (cache write) added into PromptTokens/TotalTokens",
+			events: []string{
+				`data: {"type":"message_start","message":{"id":"msg_c","usage":{"input_tokens":10,"cache_creation_input_tokens":25}}}`,
+				`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`,
+			},
+			wantPrompt:     35,
+			wantCompletion: 5,
+			wantTotal:      40,
+			wantCachedRead: 0,
+			wantCacheWrite: 25,
+		},
+		{
+			name: "both cache_read and cache_creation added simultaneously",
+			events: []string{
+				`data: {"type":"message_start","message":{"id":"msg_d","usage":{"input_tokens":10,"cache_read_input_tokens":40,"cache_creation_input_tokens":25}}}`,
+				`data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}`,
+			},
+			wantPrompt:     75,
+			wantCompletion: 5,
+			wantTotal:      80,
+			wantCachedRead: 40,
+			wantCacheWrite: 25,
+		},
+		{
+			name: "only message_start seen (no message_delta yet): output remains zero",
+			events: []string{
+				`data: {"type":"message_start","message":{"id":"msg_e","usage":{"input_tokens":10,"cache_read_input_tokens":40}}}`,
+			},
+			wantPrompt:     50,
+			wantCompletion: 0,
+			wantTotal:      50,
+			wantCachedRead: 40,
+			wantCacheWrite: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &AnthropicAdapter{}
+			for _, ev := range tc.events {
+				transformLineIgnore(a, []byte(ev))
+			}
+
+			got := a.StreamUsage()
+			if got.PromptTokens != tc.wantPrompt {
+				t.Errorf("PromptTokens = %d, want %d", got.PromptTokens, tc.wantPrompt)
+			}
+			if got.CompletionTokens != tc.wantCompletion {
+				t.Errorf("CompletionTokens = %d, want %d", got.CompletionTokens, tc.wantCompletion)
+			}
+			if got.TotalTokens != tc.wantTotal {
+				t.Errorf("TotalTokens = %d, want %d", got.TotalTokens, tc.wantTotal)
+			}
+			if got.CachedReadTokens != tc.wantCachedRead {
+				t.Errorf("CachedReadTokens = %d, want %d", got.CachedReadTokens, tc.wantCachedRead)
+			}
+			if got.CacheWriteTokens != tc.wantCacheWrite {
+				t.Errorf("CacheWriteTokens = %d, want %d", got.CacheWriteTokens, tc.wantCacheWrite)
+			}
+		})
+	}
+}
+
+// ---- The provider comparison: subset vs. additive, side by side -----------
+
+// TestCachedTokenAccounting_SubsetVsAdditive is the single most important test
+// in this file. All three scenarios below represent the identical logical
+// event: an upstream served 15 total prompt tokens, of which 5 came from its
+// prompt cache. OpenAI and Gemini report that on the wire as prompt/prompt
+// tokens already totalling 15 with a "5 of those were cached" annotation
+// (cached_tokens/cachedContentTokenCount is a SUBSET). Anthropic instead
+// reports a 10-token input_tokens count and a *separate* 5-token
+// cache_read_input_tokens count that is NOT included in the 10 (ADDITIVE).
+//
+// If the proxy naively used each provider's raw prompt-token field, Anthropic
+// would silently under-report by exactly the cached amount (10 instead of 15)
+// while OpenAI and Gemini would be correct — this test proves the proxy
+// normalizes all three to the same PromptTokens=15, CachedReadTokens=5,
+// regardless of how the upstream chose to represent it on the wire.
+func TestCachedTokenAccounting_SubsetVsAdditive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		wireJSON       string
+		adapter        Adapter // nil for OpenAI passthrough (no adapter transform)
+		wantPrompt     int
+		wantCachedRead int
+	}{
+		{
+			name: "OpenAI: cached_tokens is a SUBSET of prompt_tokens",
+			wireJSON: `{"id":"x","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"hi"},"finish_reason":"stop"}],` +
+				`"usage":{"prompt_tokens":15,"completion_tokens":1,"total_tokens":16,"prompt_tokens_details":{"cached_tokens":5}}}`,
+			adapter:        nil,
+			wantPrompt:     15,
+			wantCachedRead: 5,
+		},
+		{
+			name: "Gemini: cachedContentTokenCount is a SUBSET of promptTokenCount",
+			wireJSON: `{"candidates":[{"content":{"role":"model","parts":[{"text":"hi"}]},"finishReason":"STOP"}],` +
+				`"usageMetadata":{"promptTokenCount":15,"cachedContentTokenCount":5,"candidatesTokenCount":1,"totalTokenCount":16}}`,
+			adapter:        &GeminiAdapter{},
+			wantPrompt:     15,
+			wantCachedRead: 5,
+		},
+		{
+			name: "Anthropic: cache_read_input_tokens is ADDITIVE to input_tokens",
+			wireJSON: `{"id":"msg_1","content":[{"type":"text","text":"hi"}],"stop_reason":"end_turn",` +
+				`"usage":{"input_tokens":10,"cache_read_input_tokens":5,"output_tokens":1}}`,
+			adapter:        &AnthropicAdapter{},
+			wantPrompt:     15, // 10 + 5 — NOT the raw 10 Anthropic reported on the wire
+			wantCachedRead: 5,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			body := []byte(tc.wireJSON)
+			if tc.adapter != nil {
+				out, err := tc.adapter.TransformResponse(body)
+				if err != nil {
+					t.Fatalf("TransformResponse() error = %v", err)
+				}
+				body = out
+			}
+
+			ui := extractUsage(body)
+			if ui.PromptTokens != tc.wantPrompt {
+				t.Errorf("PromptTokens = %d, want %d (normalized across providers)", ui.PromptTokens, tc.wantPrompt)
+			}
+			if ui.CachedReadTokens != tc.wantCachedRead {
+				t.Errorf("CachedReadTokens = %d, want %d", ui.CachedReadTokens, tc.wantCachedRead)
+			}
+		})
+	}
+}

--- a/internal/proxy/cost_formula_test.go
+++ b/internal/proxy/cost_formula_test.go
@@ -1,0 +1,266 @@
+package proxy
+
+// cost_formula_test.go tests the cost-estimate formula inside logUsageEvent
+// (handler.go). Before #179 this formula had NO test coverage at all — it
+// only priced PromptTokens and CompletionTokens; cached-read and cache-write
+// buckets did not exist. This file exercises the four-term formula:
+//
+//	cost = fresh*InputPer1M + cachedRead*cachedRate + cacheWrite*writeRate + completion*OutputPer1M
+//
+// where fresh = PromptTokens - CachedReadTokens - CacheWriteTokens (clamped
+// at zero), and each cache rate falls back to InputPer1M when its dedicated
+// price is left at its zero-value "unconfigured" sentinel.
+//
+// logUsageEvent is unexported but this file lives in package proxy (white-box
+// testing), so it is called directly — no HTTP round trip is required. The
+// resulting cost_estimate is read back from a real in-memory SQLite DB via a
+// real *usage.Logger, matching the project's "no storage mocks" convention.
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/voidmind-io/voidllm/internal/auth"
+	"github.com/voidmind-io/voidllm/internal/config"
+	"github.com/voidmind-io/voidllm/internal/db"
+	"github.com/voidmind-io/voidllm/internal/usage"
+)
+
+// openCostFormulaDB opens an isolated in-memory SQLite DB with all migrations
+// applied, uniquely named per call so parallel subtests never collide.
+func openCostFormulaDB(t *testing.T) *db.DB {
+	t.Helper()
+	cfg := config.DatabaseConfig{
+		Driver:          "sqlite",
+		DSN:             fmt.Sprintf("file:costformula_%d?mode=memory&cache=private", time.Now().UnixNano()),
+		MaxOpenConns:    1,
+		MaxIdleConns:    1,
+		ConnMaxLifetime: time.Minute,
+	}
+	ctx := context.Background()
+	d, err := db.Open(ctx, cfg)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+	if err := db.RunMigrations(ctx, d.SQL(), db.SQLiteDialect{},
+		slog.New(slog.NewTextHandler(io.Discard, nil))); err != nil {
+		t.Fatalf("db.RunMigrations: %v", err)
+	}
+	return d
+}
+
+// loggedCostEstimate calls logUsageEvent directly with the given model
+// pricing and usage figures, flushes the logger synchronously, and returns
+// the cost_estimate column written to usage_events (nil when the column is
+// SQL NULL).
+func loggedCostEstimate(t *testing.T, pricing config.PricingConfig, ui UsageInfo) *float64 {
+	t.Helper()
+
+	d := openCostFormulaDB(t)
+	usageCfg := config.UsageConfig{BufferSize: 8, FlushInterval: time.Hour}
+	ul := usage.NewLogger(d, usageCfg, slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	ul.Start()
+
+	h := NewProxyHandler(nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.UsageLogger = ul
+
+	keyInfo := &auth.KeyInfo{ID: "cost-key", KeyType: "user_key", OrgID: "cost-org"}
+	model := Model{Name: "cost-model", Pricing: pricing}
+
+	h.logUsageEvent(keyInfo, model, ui, 100, nil, 200, "req-cost", model.Name)
+
+	// Stop() drains and flushes synchronously before returning.
+	ul.Stop()
+
+	var cost sql.NullFloat64
+	row := d.SQL().QueryRowContext(context.Background(),
+		"SELECT cost_estimate FROM usage_events LIMIT 1")
+	if err := row.Scan(&cost); err != nil {
+		t.Fatalf("scan cost_estimate: %v", err)
+	}
+	if !cost.Valid {
+		return nil
+	}
+	c := cost.Float64
+	return &c
+}
+
+// TestLogUsageEvent_CostFormula is table-driven over the four-term cost
+// formula in logUsageEvent.
+func TestLogUsageEvent_CostFormula(t *testing.T) {
+	t.Parallel()
+
+	const tolerance = 1e-9
+
+	tests := []struct {
+		name     string
+		pricing  config.PricingConfig
+		ui       UsageInfo
+		wantNil  bool
+		wantCost float64
+	}{
+		{
+			name: "fresh, cached-read, and cache-write each priced at their own configured rate",
+			pricing: config.PricingConfig{
+				InputPer1M:       10,
+				OutputPer1M:      30,
+				CachedInputPer1M: 2,
+				CacheWritePer1M:  15,
+			},
+			ui: UsageInfo{
+				PromptTokens:     1_000_000, // fresh(500k) + cachedRead(300k) + cacheWrite(200k)
+				CachedReadTokens: 300_000,
+				CacheWriteTokens: 200_000,
+				CompletionTokens: 100_000,
+				TotalTokens:      1_100_000,
+			},
+			// 0.5*10 + 0.3*2 + 0.2*15 + 0.1*30 = 5 + 0.6 + 3 + 3 = 11.6
+			wantCost: 11.6,
+		},
+		{
+			name: "unset cached-read rate falls back to the base input rate",
+			pricing: config.PricingConfig{
+				InputPer1M:      10,
+				OutputPer1M:     0,
+				CacheWritePer1M: 15,
+				// CachedInputPer1M intentionally left unset (0).
+			},
+			ui: UsageInfo{
+				PromptTokens:     1_000_000, // fresh(700k) + cachedRead(300k)
+				CachedReadTokens: 300_000,
+				CompletionTokens: 0,
+				TotalTokens:      1_000_000,
+			},
+			// 0.7*10 + 0.3*10(fallback) = 7 + 3 = 10.
+			// If the fallback did not apply, cached tokens would price at 0
+			// and the result would be 7 instead.
+			wantCost: 10,
+		},
+		{
+			name: "unset cache-write rate falls back to the base input rate",
+			pricing: config.PricingConfig{
+				InputPer1M:       10,
+				OutputPer1M:      0,
+				CachedInputPer1M: 2,
+				// CacheWritePer1M intentionally left unset (0).
+			},
+			ui: UsageInfo{
+				PromptTokens:     1_000_000, // fresh(700k) + cacheWrite(300k)
+				CacheWriteTokens: 300_000,
+				CompletionTokens: 0,
+				TotalTokens:      1_000_000,
+			},
+			// 0.7*10 + 0.3*10(fallback) = 7 + 3 = 10.
+			wantCost: 10,
+		},
+		{
+			name: "all four prices zero yields a nil cost",
+			pricing: config.PricingConfig{
+				InputPer1M:       0,
+				OutputPer1M:      0,
+				CachedInputPer1M: 0,
+				CacheWritePer1M:  0,
+			},
+			ui: UsageInfo{
+				PromptTokens:     1_000_000,
+				CachedReadTokens: 300_000,
+				CacheWriteTokens: 200_000,
+				CompletionTokens: 100_000,
+				TotalTokens:      1_100_000,
+			},
+			wantNil: true,
+		},
+		{
+			name: "cache buckets summing to more than PromptTokens clamp fresh at zero",
+			pricing: config.PricingConfig{
+				InputPer1M:       10,
+				OutputPer1M:      0,
+				CachedInputPer1M: 5,
+				CacheWritePer1M:  8,
+			},
+			ui: UsageInfo{
+				PromptTokens:     100,
+				CachedReadTokens: 80,
+				CacheWriteTokens: 50, // 80 + 50 = 130 > PromptTokens(100)
+				CompletionTokens: 0,
+				TotalTokens:      100,
+			},
+			// fresh = max(100-80-50, 0) = 0.
+			// (80/1e6)*5 + (50/1e6)*8 = 0.0004 + 0.0004 = 0.0008.
+			// A naive (unclamped) fresh of -30 would instead subtract
+			// (30/1e6)*10 = 0.0003, producing 0.0005 — the clamp is what
+			// this test actually distinguishes.
+			wantCost: 0.0008,
+		},
+		{
+			name: "only the base input/output rates configured (no cache activity) matches the pre-#179 formula",
+			pricing: config.PricingConfig{
+				InputPer1M:  10,
+				OutputPer1M: 30,
+			},
+			ui: UsageInfo{
+				PromptTokens:     1_000_000,
+				CompletionTokens: 500_000,
+				TotalTokens:      1_500_000,
+			},
+			// 1*10 + 0.5*30 = 10 + 15 = 25.
+			wantCost: 25,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := loggedCostEstimate(t, tc.pricing, tc.ui)
+
+			if tc.wantNil {
+				if got != nil {
+					t.Fatalf("cost_estimate = %v, want nil", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("cost_estimate = nil, want non-nil")
+			}
+			if math.Abs(*got-tc.wantCost) > tolerance {
+				t.Errorf("cost_estimate = %v, want %v", *got, tc.wantCost)
+			}
+		})
+	}
+}
+
+// TestLogUsageEvent_NilKeyInfoNoOp verifies that logUsageEvent is a safe no-op
+// when keyInfo is nil (unauthenticated request / auth middleware not wired),
+// so it never dereferences a nil pointer or writes a spurious usage row.
+func TestLogUsageEvent_NilKeyInfoNoOp(t *testing.T) {
+	t.Parallel()
+
+	d := openCostFormulaDB(t)
+	usageCfg := config.UsageConfig{BufferSize: 8, FlushInterval: time.Hour}
+	ul := usage.NewLogger(d, usageCfg, slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	ul.Start()
+
+	h := NewProxyHandler(nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	h.UsageLogger = ul
+
+	model := Model{Name: "cost-model", Pricing: config.PricingConfig{InputPer1M: 10, OutputPer1M: 30}}
+	h.logUsageEvent(nil, model, UsageInfo{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150}, 10, nil, 200, "req-nil", model.Name)
+
+	ul.Stop()
+
+	var n int
+	if err := d.SQL().QueryRowContext(context.Background(), "SELECT COUNT(*) FROM usage_events").Scan(&n); err != nil {
+		t.Fatalf("count usage_events: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("usage_events row count = %d, want 0 (nil keyInfo must be a no-op)", n)
+	}
+}

--- a/internal/proxy/gemini.go
+++ b/internal/proxy/gemini.go
@@ -28,6 +28,10 @@ type GeminiAdapter struct {
 	modelName        string // stored from TransformRequest for use in TransformResponse
 	promptTokens     int    // accumulated from usageMetadata during streaming
 	completionTokens int    // accumulated from usageMetadata during streaming
+	// cachedReadTokens is accumulated from usageMetadata.cachedContentTokenCount
+	// during streaming. Gemini reports this as a SUBSET of promptTokens (unlike
+	// Anthropic) — see UsageInfo's doc for the cross-provider reconciliation.
+	cachedReadTokens int
 	// doneSent is true after a terminal chunk (finishReason present) has been
 	// written. The blank SSE delimiter that follows is then converted to
 	// data: [DONE] and this flag is cleared.
@@ -136,9 +140,12 @@ type geminiResponse struct {
 		FinishReason string `json:"finishReason"`
 	} `json:"candidates"`
 	UsageMetadata struct {
-		PromptTokenCount     int `json:"promptTokenCount"`
-		CandidatesTokenCount int `json:"candidatesTokenCount"`
-		TotalTokenCount      int `json:"totalTokenCount"`
+		PromptTokenCount int `json:"promptTokenCount"`
+		// CachedContentTokenCount is a SUBSET of PromptTokenCount — see
+		// UsageInfo's doc for the cross-provider reconciliation.
+		CachedContentTokenCount int `json:"cachedContentTokenCount"`
+		CandidatesTokenCount    int `json:"candidatesTokenCount"`
+		TotalTokenCount         int `json:"totalTokenCount"`
 	} `json:"usageMetadata"`
 }
 
@@ -700,9 +707,10 @@ func (a *GeminiAdapter) TransformResponse(body []byte) ([]byte, error) {
 			},
 		},
 		Usage: openAIUsage{
-			PromptTokens:     gr.UsageMetadata.PromptTokenCount,
-			CompletionTokens: gr.UsageMetadata.CandidatesTokenCount,
-			TotalTokens:      gr.UsageMetadata.TotalTokenCount,
+			PromptTokens:        gr.UsageMetadata.PromptTokenCount,
+			CompletionTokens:    gr.UsageMetadata.CandidatesTokenCount,
+			TotalTokens:         gr.UsageMetadata.TotalTokenCount,
+			PromptTokensDetails: cacheUsageDetails(gr.UsageMetadata.CachedContentTokenCount, 0),
 		},
 	}
 
@@ -818,6 +826,9 @@ func (a *GeminiAdapter) TransformStreamLine(line []byte) ([][]byte, error) {
 	}
 	if gr.UsageMetadata.CandidatesTokenCount > 0 || hasFinish {
 		a.completionTokens = gr.UsageMetadata.CandidatesTokenCount
+	}
+	if gr.UsageMetadata.CachedContentTokenCount > 0 || hasFinish {
+		a.cachedReadTokens = gr.UsageMetadata.CachedContentTokenCount
 	}
 
 	// Drop content-free intermediate chunks that carry no delta text, no tool
@@ -967,13 +978,15 @@ func (a *GeminiAdapter) TransformStreamLine(line []byte) ([][]byte, error) {
 }
 
 // StreamUsage returns the token counts accumulated during the Gemini stream.
-// Both fields are zero until the final stream chunk (carrying usageMetadata)
-// has been processed by TransformStreamLine.
+// All fields are zero until the final stream chunk (carrying usageMetadata)
+// has been processed by TransformStreamLine. CachedReadTokens is a subset of
+// PromptTokens, not additive — see UsageInfo's doc.
 func (a *GeminiAdapter) StreamUsage() UsageInfo {
 	return UsageInfo{
 		PromptTokens:     a.promptTokens,
 		CompletionTokens: a.completionTokens,
 		TotalTokens:      a.promptTokens + a.completionTokens,
+		CachedReadTokens: a.cachedReadTokens,
 	}
 }
 

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -183,17 +183,23 @@ func (s *streamUsageExtractor) observe(line []byte) {
 	data := line[len("data: "):]
 	var chunk struct {
 		Usage *struct {
-			PromptTokens     int `json:"prompt_tokens"`
-			CompletionTokens int `json:"completion_tokens"`
-			TotalTokens      int `json:"total_tokens"`
+			PromptTokens        int               `json:"prompt_tokens"`
+			CompletionTokens    int               `json:"completion_tokens"`
+			TotalTokens         int               `json:"total_tokens"`
+			PromptTokensDetails *wireUsageDetails `json:"prompt_tokens_details"`
 		} `json:"usage"`
 	}
 	if jsonx.Unmarshal(data, &chunk) == nil && chunk.Usage != nil {
-		s.lastUsage = UsageInfo{
+		ui := UsageInfo{
 			PromptTokens:     chunk.Usage.PromptTokens,
 			CompletionTokens: chunk.Usage.CompletionTokens,
 			TotalTokens:      chunk.Usage.TotalTokens,
 		}
+		if chunk.Usage.PromptTokensDetails != nil {
+			ui.CachedReadTokens = chunk.Usage.PromptTokensDetails.CachedTokens
+			ui.CacheWriteTokens = chunk.Usage.PromptTokensDetails.CacheCreationTokens
+		}
+		s.lastUsage = ui
 	}
 }
 
@@ -1896,9 +1902,32 @@ func (p *ProxyHandler) logUsageEvent(keyInfo *auth.KeyInfo, model Model, ui Usag
 	}
 
 	var cost *float64
-	if model.Pricing.InputPer1M > 0 || model.Pricing.OutputPer1M > 0 {
-		c := float64(ui.PromptTokens)/1_000_000*model.Pricing.InputPer1M +
-			float64(ui.CompletionTokens)/1_000_000*model.Pricing.OutputPer1M
+	pricing := model.Pricing
+	if pricing.InputPer1M > 0 || pricing.OutputPer1M > 0 || pricing.CachedInputPer1M > 0 || pricing.CacheWritePer1M > 0 {
+		// Fall back to the base input rate for either cache bucket when its
+		// dedicated price is unconfigured (zero). Pricing a configured bucket
+		// at zero just because the rate was never set would silently
+		// under-report cost, so the base input rate is the safe default
+		// rather than free.
+		cachedReadRate := pricing.CachedInputPer1M
+		if cachedReadRate == 0 {
+			cachedReadRate = pricing.InputPer1M
+		}
+		cacheWriteRate := pricing.CacheWritePer1M
+		if cacheWriteRate == 0 {
+			cacheWriteRate = pricing.InputPer1M
+		}
+		// fresh is the portion of PromptTokens that is neither a cache read
+		// nor a cache write. Clamped at zero in case an upstream reports
+		// cache buckets that add up to more than PromptTokens.
+		fresh := ui.PromptTokens - ui.CachedReadTokens - ui.CacheWriteTokens
+		if fresh < 0 {
+			fresh = 0
+		}
+		c := float64(fresh)/1_000_000*pricing.InputPer1M +
+			float64(ui.CachedReadTokens)/1_000_000*cachedReadRate +
+			float64(ui.CacheWriteTokens)/1_000_000*cacheWriteRate +
+			float64(ui.CompletionTokens)/1_000_000*pricing.OutputPer1M
 		cost = &c
 	}
 
@@ -1920,6 +1949,8 @@ func (p *ProxyHandler) logUsageEvent(keyInfo *auth.KeyInfo, model Model, ui Usag
 		PromptTokens:       ui.PromptTokens,
 		CompletionTokens:   ui.CompletionTokens,
 		TotalTokens:        ui.TotalTokens,
+		CachedReadTokens:   ui.CachedReadTokens,
+		CacheWriteTokens:   ui.CacheWriteTokens,
 		CostEstimate:       cost,
 		DurationMS:         durationMS,
 		TTFT_MS:            ttftMS,
@@ -1930,6 +1961,8 @@ func (p *ProxyHandler) logUsageEvent(keyInfo *auth.KeyInfo, model Model, ui Usag
 
 	metrics.TokensTotal.WithLabelValues(model.Name, "prompt").Add(float64(ui.PromptTokens))
 	metrics.TokensTotal.WithLabelValues(model.Name, "completion").Add(float64(ui.CompletionTokens))
+	metrics.TokensTotal.WithLabelValues(model.Name, "cached_read").Add(float64(ui.CachedReadTokens))
+	metrics.TokensTotal.WithLabelValues(model.Name, "cache_write").Add(float64(ui.CacheWriteTokens))
 }
 
 // deploymentKey returns the circuit breaker / health-checker lookup key for a
@@ -2102,25 +2135,47 @@ func clampCooldown(d time.Duration) time.Duration {
 	return d
 }
 
+// wireUsageDetails is the JSON shape of usage.prompt_tokens_details as
+// emitted by extractUsage's callers (the raw upstream body for passthrough
+// providers, or the adapter's OpenAI-shaped TransformResponse output for
+// Anthropic/Gemini). CachedTokens follows the real OpenAI/Gemini field
+// (usage.prompt_tokens_details.cached_tokens): a subset of prompt_tokens
+// served from cache. CacheCreationTokens is a proxy-internal extension with
+// no OpenAI equivalent, added alongside it so that Anthropic's cache-write
+// count (cache_creation_input_tokens) survives the adapter's response
+// transform and can be recovered here without inventing a second top-level
+// object.
+type wireUsageDetails struct {
+	CachedTokens        int `json:"cached_tokens"`
+	CacheCreationTokens int `json:"cache_creation_tokens"`
+}
+
 // extractUsage parses token counts from a non-streaming OpenAI-format response
 // body. Returns a zero UsageInfo when the body cannot be parsed or carries no
-// usage field.
+// usage field. See wireUsageDetails for how cached/cache-write counts are
+// recovered from the wire format.
 func extractUsage(body []byte) UsageInfo {
 	var resp struct {
 		Usage *struct {
-			PromptTokens     int `json:"prompt_tokens"`
-			CompletionTokens int `json:"completion_tokens"`
-			TotalTokens      int `json:"total_tokens"`
+			PromptTokens        int               `json:"prompt_tokens"`
+			CompletionTokens    int               `json:"completion_tokens"`
+			TotalTokens         int               `json:"total_tokens"`
+			PromptTokensDetails *wireUsageDetails `json:"prompt_tokens_details"`
 		} `json:"usage"`
 	}
 	if jsonx.Unmarshal(body, &resp) != nil || resp.Usage == nil {
 		return UsageInfo{}
 	}
-	return UsageInfo{
+	ui := UsageInfo{
 		PromptTokens:     resp.Usage.PromptTokens,
 		CompletionTokens: resp.Usage.CompletionTokens,
 		TotalTokens:      resp.Usage.TotalTokens,
 	}
+	if resp.Usage.PromptTokensDetails != nil {
+		ui.CachedReadTokens = resp.Usage.PromptTokensDetails.CachedTokens
+		ui.CacheWriteTokens = resp.Usage.PromptTokensDetails.CacheCreationTokens
+	}
+	return ui
 }
 
 // mutateRequestBody applies model name replacement and optional stream_options

--- a/internal/usage/event.go
+++ b/internal/usage/event.go
@@ -31,6 +31,14 @@ type Event struct {
 	CompletionTokens int
 	// TotalTokens is the sum of prompt and completion tokens.
 	TotalTokens int
+	// CachedReadTokens is the subset of PromptTokens served from an upstream
+	// prompt cache, billed below the normal input rate. Zero when the
+	// provider reports no cache read.
+	CachedReadTokens int
+	// CacheWriteTokens is the subset of PromptTokens written to an upstream
+	// prompt cache (Anthropic only), billed above the normal input rate.
+	// Zero for providers without a cache-write concept.
+	CacheWriteTokens int
 	// CostEstimate is the estimated cost in USD, or nil if pricing is not configured.
 	CostEstimate *float64
 	// DurationMS is the total request duration in milliseconds.

--- a/internal/usage/logger.go
+++ b/internal/usage/logger.go
@@ -193,14 +193,16 @@ func (l *Logger) flush(events []Event) error {
 	query := "INSERT INTO usage_events " +
 		"(id, key_id, key_type, org_id, team_id, user_id, service_account_id, " +
 		"model_name, prompt_tokens, completion_tokens, total_tokens, " +
+		"cached_read_tokens, cache_write_tokens, " +
 		"cost_estimate, request_duration_ms, ttft_ms, tokens_per_second, status_code, request_id, " +
 		"requested_model_name) " +
 		"VALUES (" +
 		p(1) + ", " + p(2) + ", " + p(3) + ", " + p(4) + ", " +
 		p(5) + ", " + p(6) + ", " + p(7) + ", " + p(8) + ", " +
 		p(9) + ", " + p(10) + ", " + p(11) + ", " +
-		p(12) + ", " + p(13) + ", " + p(14) + ", " + p(15) + ", " + p(16) + ", " + p(17) + ", " +
-		p(18) + ")"
+		p(12) + ", " + p(13) + ", " +
+		p(14) + ", " + p(15) + ", " + p(16) + ", " + p(17) + ", " + p(18) + ", " + p(19) + ", " +
+		p(20) + ")"
 
 	ctx := context.Background()
 
@@ -227,6 +229,8 @@ func (l *Logger) flush(events []Event) error {
 				ev.PromptTokens,
 				ev.CompletionTokens,
 				ev.TotalTokens,
+				ev.CachedReadTokens,
+				ev.CacheWriteTokens,
 				ev.CostEstimate,
 				ev.DurationMS,
 				ev.TTFT_MS,
@@ -270,6 +274,8 @@ func (l *Logger) flush(events []Event) error {
 		r.PromptTokens += ev.PromptTokens
 		r.CompletionTokens += ev.CompletionTokens
 		r.TotalTokens += ev.TotalTokens
+		r.CachedReadTokens += ev.CachedReadTokens
+		r.CacheWriteTokens += ev.CacheWriteTokens
 		if ev.CostEstimate != nil {
 			r.CostSum += *ev.CostEstimate
 		}

--- a/internal/usage/logger_test.go
+++ b/internal/usage/logger_test.go
@@ -262,6 +262,86 @@ func TestLog_AllFieldsStored(t *testing.T) {
 	}
 }
 
+// TestLog_CachedTokensStored verifies that CachedReadTokens and
+// CacheWriteTokens round-trip through flush() into the cached_read_tokens and
+// cache_write_tokens columns, extending the TestLog_AllFieldsStored precedent
+// (see also TestLog_RequestedModelNameStored) to the two columns added by
+// migration 0016 for #179.
+func TestLog_CachedTokensStored(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		cachedRead     int
+		cacheWrite     int
+		wantCachedRead int
+		wantCacheWrite int
+	}{
+		{
+			name:           "both zero (no cache activity) stored as zero, not NULL",
+			cachedRead:     0,
+			cacheWrite:     0,
+			wantCachedRead: 0,
+			wantCacheWrite: 0,
+		},
+		{
+			name:           "cached-read only (OpenAI/Gemini shape)",
+			cachedRead:     40,
+			cacheWrite:     0,
+			wantCachedRead: 40,
+			wantCacheWrite: 0,
+		},
+		{
+			name:           "cache-write only (Anthropic cache-creation shape)",
+			cachedRead:     0,
+			cacheWrite:     25,
+			wantCachedRead: 0,
+			wantCacheWrite: 25,
+		},
+		{
+			name:           "both cached-read and cache-write (Anthropic mixed shape)",
+			cachedRead:     40,
+			cacheWrite:     25,
+			wantCachedRead: 40,
+			wantCacheWrite: 25,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dsn := "file:TestLog_CachedTokensStored_" + sanitizeDSNName(tc.name) + "?mode=memory&cache=private"
+			d := openTestDB(t, dsn)
+			l := newTestLogger(d, defaultCfg())
+			l.Start()
+
+			ev := makeEvent()
+			ev.CachedReadTokens = tc.cachedRead
+			ev.CacheWriteTokens = tc.cacheWrite
+
+			l.Log(ev)
+			stopAndWait(t, l, d, 1)
+
+			ctx := context.Background()
+			row := d.SQL().QueryRowContext(ctx,
+				"SELECT cached_read_tokens, cache_write_tokens FROM usage_events LIMIT 1")
+
+			var cachedRead, cacheWrite int
+			if err := row.Scan(&cachedRead, &cacheWrite); err != nil {
+				t.Fatalf("Scan: %v", err)
+			}
+
+			if cachedRead != tc.wantCachedRead {
+				t.Errorf("cached_read_tokens = %d, want %d", cachedRead, tc.wantCachedRead)
+			}
+			if cacheWrite != tc.wantCacheWrite {
+				t.Errorf("cache_write_tokens = %d, want %d", cacheWrite, tc.wantCacheWrite)
+			}
+		})
+	}
+}
+
 // TestLog_NullableFields verifies NULL vs. non-NULL storage for the six
 // optional columns: team_id, user_id, service_account_id, cost_estimate,
 // ttft_ms, and tokens_per_second.
@@ -692,5 +772,62 @@ func TestLog_TokenCounterUpdatedBeforeFlush(t *testing.T) {
 	// Confirm the DB row is not yet written (flush has not fired).
 	if got := countRows(t, d); got != 0 {
 		t.Errorf("usage_events row count before flush = %d, want 0 (counter updated before DB write)", got)
+	}
+}
+
+// TestLog_TokenCounterConsumesFullAnthropicShapedTotal verifies that an
+// Anthropic-shaped event — where PromptTokens already includes the cache-read
+// tokens the adapter folded in (see AnthropicAdapter.TransformResponse /
+// StreamUsage) — is counted against the token budget by its full TotalTokens,
+// not just the "fresh" portion. Before the #179 fix, an Anthropic response
+// with heavy cache reads would have under-reported PromptTokens/TotalTokens
+// by exactly the cached amount, which would have under-consumed the budget
+// here (a caller could exceed their real token spend before CheckTokens
+// blocked them). This test uses realistic Anthropic-shaped numbers: 10 fresh
+// input tokens + 50 cache-read tokens + 40 completion tokens = 100 total.
+func TestLog_TokenCounterConsumesFullAnthropicShapedTotal(t *testing.T) {
+	t.Parallel()
+
+	d := openTestDB(t, "file:TestLog_TokenCounterConsumesFullAnthropicShapedTotal?mode=memory&cache=private")
+
+	counter := ratelimit.NewTokenCounter()
+	cfg := defaultCfg()
+	l := NewLogger(d, cfg, slog.New(slog.NewTextHandler(io.Discard, nil)), counter)
+	l.Start()
+	defer l.Stop()
+
+	// Mirrors what logUsageEvent builds for an Anthropic response with cache
+	// reads: PromptTokens (10 + 50 = 60) already has the cache tokens folded
+	// in, CachedReadTokens carries the individual bucket for pricing, and
+	// TotalTokens is PromptTokens + CompletionTokens.
+	ev := Event{
+		KeyID:            "anthropic-cache-key",
+		KeyType:          "user_key",
+		OrgID:            "anthropic-cache-org",
+		ModelName:        "claude-3-5-sonnet",
+		PromptTokens:     60,
+		CompletionTokens: 40,
+		TotalTokens:      100,
+		CachedReadTokens: 50,
+		StatusCode:       200,
+	}
+
+	l.Log(ev)
+
+	// A 99-token budget must already be considered exceeded: if the counter
+	// only tracked the "fresh" 10 input tokens (the pre-fix, under-reported
+	// figure) plus 40 completion tokens = 50, this budget would incorrectly
+	// still have headroom.
+	keyLimitsExceeded := ratelimit.Limits{DailyTokenLimit: 99}
+	noLimits := ratelimit.Limits{}
+	if err := counter.CheckTokens("anthropic-cache-key", "", "anthropic-cache-org", keyLimitsExceeded, noLimits, noLimits); err == nil {
+		t.Error("CheckTokens() = nil, want ErrTokenBudgetExceeded (full 100-token total, including cache reads, must be counted)")
+	}
+
+	// A budget of exactly 100 (the correct, fully-inclusive total) must not
+	// yet be exceeded — this distinguishes "counts the full total" from "over-counts".
+	keyLimitsExact := ratelimit.Limits{DailyTokenLimit: 101}
+	if err := counter.CheckTokens("anthropic-cache-key", "", "anthropic-cache-org", keyLimitsExact, noLimits, noLimits); err != nil {
+		t.Errorf("CheckTokens() with limit 101 = %v, want nil (100 tokens < limit 101)", err)
 	}
 }


### PR DESCRIPTION
Closes #179.

`cost_estimate` priced every prompt token at the full input rate, so it drifted from the real provider bill - and drifted **more** the better a customer's cache hit rate was. Agentic and long-system-prompt workloads are exactly the cache-heavy case. Nothing in the codebase parsed cached token counts at all: every extraction site was a closed struct, so the fields were silently dropped.

## The hard part: the providers count in opposite directions

| Provider | Field | Relation to the prompt total |
|---|---|---|
| OpenAI | `prompt_tokens_details.cached_tokens` | subset of `prompt_tokens` |
| Gemini | `usageMetadata.cachedContentTokenCount` | subset of `promptTokenCount` |
| Anthropic | `cache_read_input_tokens`, `cache_creation_input_tokens` | **in addition to** `input_tokens` |

Because Anthropic's buckets were discarded, prompt and total tokens were **under-reported** for every cached Anthropic request. That was not only a cost error: `total_tokens` feeds the token budgets, so those requests also under-consumed their quota. Anthropic's counts are now folded into the prompt total, so the field finally means the same thing for every provider. OpenAI and Gemini totals are deliberately left untouched - inflating them would silently raise existing customers' budget consumption.

## What is stored and how it is priced

Two counters rather than one, because they are priced in opposite directions: cache **reads** are billed below the normal input rate, Anthropic's cache **writes** above it. Fresh tokens are derived (`prompt - read - write`, clamped at zero), never stored.

Cost is computed per bucket. When a cache rate is unconfigured it falls back to the base input rate rather than to free - pricing a bucket at nothing because nobody set its rate would silently under-report. With no cache prices configured the formula degenerates exactly to the previous one, so existing deployments see no change.

## Notes

`internal/db/usage_aggregation.go` had **no tests at all**, despite being the layer every new usage column has to thread through. It now has coverage.

Swagger under `internal/docs` is deliberately not regenerated here: it has been stale since the initial commit, so regenerating would drag six months of unrelated API drift into this diff. Tracked separately.

One pre-existing robustness gap surfaced during review and is filed as #187 rather than fixed here - it needs a protocol-violating upstream stream and its proper fix touches the adapter interface, not cached-token accounting.

## Verification

Per-provider extraction tests buffered and streaming, including `AnthropicAdapter.StreamUsage()` which had never been asserted anywhere. The keystone test puts all three providers side by side and proves they normalise to the same numbers for the same logical event. Cost formula, budget consumption, storage round trip, the hourly rollup and all six query branches are covered. Both central claims were mutation-checked: removing Anthropic's addition, and removing the cached rate from the cost formula, each turn tests red.

Full suite and `-race` on proxy, usage, db and ratelimit are green.