### PR TITLE
fix(health): build probes the way each provider actually expects

### DIFF
--- a/internal/api/admin/dashboard.go
+++ b/internal/api/admin/dashboard.go
@@ -43,6 +43,10 @@ type dashboardStatsResponse struct {
 	// ModelsDegraded is the count of registered models whose current health
 	// status is "degraded". Zero when health monitoring is not enabled.
 	ModelsDegraded int `json:"models_degraded"`
+	// ModelsUnknown is the count of registered models whose current health
+	// status is "unknown" (e.g. no applicable probe ran yet for that
+	// provider/model type). Zero when health monitoring is not enabled.
+	ModelsUnknown int `json:"models_unknown"`
 }
 
 // DashboardStats handles GET /api/v1/dashboard/stats.
@@ -242,6 +246,8 @@ func (h *Handler) DashboardStats(c fiber.Ctx) error {
 				resp.ModelsUnhealthy++
 			case "degraded":
 				resp.ModelsDegraded++
+			case "unknown":
+				resp.ModelsUnknown++
 			}
 		}
 	}

--- a/internal/api/admin/dashboard_test.go
+++ b/internal/api/admin/dashboard_test.go
@@ -1,0 +1,164 @@
+package admin_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	"github.com/voidmind-io/voidllm/internal/api/admin"
+	"github.com/voidmind-io/voidllm/internal/auth"
+	"github.com/voidmind-io/voidllm/internal/cache"
+	"github.com/voidmind-io/voidllm/internal/config"
+	"github.com/voidmind-io/voidllm/internal/db"
+	"github.com/voidmind-io/voidllm/internal/health"
+	"github.com/voidmind-io/voidllm/internal/license"
+)
+
+// fakeHealthProvider implements admin.ModelHealthProvider by returning a
+// fixed set of results, letting dashboard tests control the health-status
+// mix without standing up a real Checker or upstream HTTP servers.
+type fakeHealthProvider struct {
+	results []health.ModelHealth
+}
+
+// GetAllHealth returns the fixed results configured on f.
+func (f fakeHealthProvider) GetAllHealth() []health.ModelHealth {
+	return f.results
+}
+
+// setupDashboardTestApp creates a Fiber app wired with a fresh in-memory
+// SQLite database, admin routes, and the given health provider (nil is
+// valid — it mirrors health monitoring being disabled).
+func setupDashboardTestApp(t *testing.T, dsn string, healthProvider admin.ModelHealthProvider) (*fiber.App, *db.DB, *cache.Cache[string, auth.KeyInfo]) {
+	t.Helper()
+
+	ctx := context.Background()
+	database, err := db.Open(ctx, config.DatabaseConfig{
+		Driver:          "sqlite",
+		DSN:             dsn,
+		MaxOpenConns:    1,
+		MaxIdleConns:    1,
+		ConnMaxLifetime: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("open test DB: %v", err)
+	}
+	t.Cleanup(func() { _ = database.Close() })
+
+	if err := db.RunMigrations(ctx, database.SQL(), db.SQLiteDialect{}, slog.Default()); err != nil {
+		t.Fatalf("run migrations: %v", err)
+	}
+
+	keyCache := cache.New[string, auth.KeyInfo]()
+
+	handler := &admin.Handler{
+		DB:            database,
+		HMACSecret:    testHMACSecret,
+		KeyCache:      keyCache,
+		HealthChecker: healthProvider,
+		License:       license.NewHolder(license.Verify("", true)),
+		Log:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	app := fiber.New()
+	admin.RegisterRoutes(app, handler, keyCache, testHMACSecret, nil)
+
+	return app, database, keyCache
+}
+
+// dashboardStatsURL returns the dashboard stats endpoint URL.
+func dashboardStatsURL() string {
+	return "/api/v1/dashboard/stats"
+}
+
+// TestDashboardStats_ModelsUnknown verifies that DashboardStats counts a
+// model whose current health status is "unknown" into the models_unknown
+// field, alongside the pre-existing healthy/degraded/unhealthy counts.
+func TestDashboardStats_ModelsUnknown(t *testing.T) {
+	t.Parallel()
+
+	provider := fakeHealthProvider{results: []health.ModelHealth{
+		{ModelName: "healthy-model", Status: "healthy"},
+		{ModelName: "degraded-model", Status: "degraded"},
+		{ModelName: "unhealthy-model", Status: "unhealthy"},
+		{ModelName: "unknown-model-1", Status: "unknown"},
+		{ModelName: "unknown-model-2", Status: "unknown"},
+	}}
+
+	app, database, keyCache := setupDashboardTestApp(t, "file:TestDashboardStats_ModelsUnknown?mode=memory&cache=private", provider)
+	org := mustCreateOrg(t, database, "Dashboard Org", "dashboard-org-unknown")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	req := httptest.NewRequest("GET", dashboardStatsURL(), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var got struct {
+		ModelsHealthy   int `json:"models_healthy"`
+		ModelsUnhealthy int `json:"models_unhealthy"`
+		ModelsDegraded  int `json:"models_degraded"`
+		ModelsUnknown   int `json:"models_unknown"`
+	}
+	decodeBody(t, resp.Body, &got)
+
+	if got.ModelsHealthy != 1 {
+		t.Errorf("models_healthy = %d, want 1", got.ModelsHealthy)
+	}
+	if got.ModelsDegraded != 1 {
+		t.Errorf("models_degraded = %d, want 1", got.ModelsDegraded)
+	}
+	if got.ModelsUnhealthy != 1 {
+		t.Errorf("models_unhealthy = %d, want 1", got.ModelsUnhealthy)
+	}
+	if got.ModelsUnknown != 2 {
+		t.Errorf("models_unknown = %d, want 2", got.ModelsUnknown)
+	}
+}
+
+// TestDashboardStats_NoHealthChecker_ModelsUnknownZero verifies that when
+// health monitoring is disabled (HealthChecker is nil), models_unknown is
+// zero rather than omitted or erroring.
+func TestDashboardStats_NoHealthChecker_ModelsUnknownZero(t *testing.T) {
+	t.Parallel()
+
+	app, database, keyCache := setupDashboardTestApp(t, "file:TestDashboardStats_NoHealthChecker?mode=memory&cache=private", nil)
+	org := mustCreateOrg(t, database, "Dashboard Org", "dashboard-org-nohealth")
+	testKey := addTestKey(t, keyCache, auth.RoleOrgAdmin, org.ID)
+
+	req := httptest.NewRequest("GET", dashboardStatsURL(), nil)
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	var got struct {
+		ModelsUnknown int `json:"models_unknown"`
+	}
+	decodeBody(t, resp.Body, &got)
+
+	if got.ModelsUnknown != 0 {
+		t.Errorf("models_unknown = %d, want 0 when health monitoring is disabled", got.ModelsUnknown)
+	}
+}

--- a/internal/api/admin/models.go
+++ b/internal/api/admin/models.go
@@ -1217,6 +1217,40 @@ type testConnectionResponse struct {
 	Message string `json:"message"`
 }
 
+// validateProviderIdentity checks that req carries the identity fields required
+// to build a meaningful probe request for req.Provider. Vertex, Gemini, and
+// Azure each embed an identifier (project/location, model name, or deployment
+// name) directly in the probe URL; if that identifier is missing the request
+// still gets built and sent, producing an unhelpful 404 from a URL with an
+// empty path segment instead of a clear explanation. It returns an empty
+// message and ok=true when req.Provider requires no additional identity
+// fields or all required fields are present; otherwise it returns a specific,
+// actionable message and ok=false.
+func validateProviderIdentity(req testConnectionRequest) (message string, ok bool) {
+	switch req.Provider {
+	case "vertex":
+		switch {
+		case req.GCPProject == "" && req.GCPLocation == "":
+			return "gcp_project and gcp_location are required for vertex", false
+		case req.GCPProject == "":
+			return "gcp_project is required for vertex", false
+		case req.GCPLocation == "":
+			return "gcp_location is required for vertex", false
+		case req.ModelName == "":
+			return "model_name is required for vertex", false
+		}
+	case "gemini":
+		if req.ModelName == "" {
+			return "model_name is required for gemini", false
+		}
+	case "azure":
+		if req.AzureDeployment == "" {
+			return "azure_deployment is required for azure", false
+		}
+	}
+	return "", true
+}
+
 // TestModelConnection handles POST /api/v1/models/test-connection.
 // It probes the upstream provider's GET /models endpoint to verify connectivity
 // and authentication without persisting any data.
@@ -1261,6 +1295,16 @@ func (h *Handler) TestModelConnection(c fiber.Ctx) error {
 		})
 	}
 
+	// Reject providers whose probe URL requires an identity field (project,
+	// location, model name, or deployment name) that was not supplied, before
+	// issuing a doomed upstream call built from empty path segments.
+	if msg, ok := validateProviderIdentity(req); !ok {
+		return c.JSON(testConnectionResponse{
+			Success: false,
+			Message: msg,
+		})
+	}
+
 	// Use a background context with an explicit timeout so the outbound request
 	// is not cancelled if the Fiber request context is recycled.
 	reqCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -1281,9 +1325,16 @@ func (h *Handler) TestModelConnection(c fiber.Ctx) error {
 	// to it. A models-list probe is preferred (it needs no model identity and
 	// mirrors the historical behaviour for OpenAI-compatible providers and
 	// Anthropic); providers with no meaningful models-list equivalent (azure,
-	// vertex, gemini) fall back to a minimal chat probe.
+	// vertex, gemini) fall back to a minimal chat probe. isModelsListProbe
+	// records which intent actually built the request, explicitly, at the
+	// point the choice is made — the response is later parsed for a model
+	// count only when this is true, rather than inferring probe intent from
+	// httpReq.Method (an implementation detail of BuildProbeRequest that a
+	// future GET-based intent could misparse).
+	isModelsListProbe := true
 	httpReq, err := health.BuildProbeRequest(reqCtx, health.IntentModelsList, target)
 	if errors.Is(err, health.ErrProbeNotApplicable) {
+		isModelsListProbe = false
 		httpReq, err = health.BuildProbeRequest(reqCtx, health.IntentChat, target)
 	}
 	if err != nil {
@@ -1329,7 +1380,7 @@ func (h *Handler) TestModelConnection(c fiber.Ctx) error {
 	// Only a models-list probe response has the OpenAI models-list envelope;
 	// a chat-probe fallback response (issued for azure/vertex/gemini) has a
 	// different shape and is not parsed for a model count.
-	if httpReq.Method == http.MethodGet {
+	if isModelsListProbe {
 		var modelsResp struct {
 			Data []struct {
 				ID string `json:"id"`

--- a/internal/api/admin/models.go
+++ b/internal/api/admin/models.go
@@ -17,6 +17,7 @@ import (
 	"github.com/voidmind-io/voidllm/internal/auth"
 	"github.com/voidmind-io/voidllm/internal/config"
 	"github.com/voidmind-io/voidllm/internal/db"
+	"github.com/voidmind-io/voidllm/internal/health"
 	"github.com/voidmind-io/voidllm/internal/jsonx"
 	"github.com/voidmind-io/voidllm/internal/license"
 	"github.com/voidmind-io/voidllm/internal/provider"
@@ -1190,6 +1191,24 @@ type testConnectionRequest struct {
 	Provider string `json:"provider"`
 	BaseURL  string `json:"base_url"`
 	APIKey   string `json:"api_key"`
+	// ModelName is the model identifier the probe request references. It is
+	// required to build a meaningful request for providers whose synthetic
+	// probe must name a model in the URL or body (anthropic, gemini,
+	// vertex); providers tested via a models-list probe (openai, vllm,
+	// ollama, custom) ignore it.
+	ModelName string `json:"model_name,omitempty"`
+	// AzureDeployment is the Azure OpenAI deployment name. Required to build
+	// a working probe URL when Provider is "azure".
+	AzureDeployment string `json:"azure_deployment,omitempty"`
+	// AzureAPIVersion overrides the default Azure OpenAI API version used by
+	// the probe. Only meaningful when Provider is "azure".
+	AzureAPIVersion string `json:"azure_api_version,omitempty"`
+	// GCPProject is the Google Cloud project ID. Required to build a working
+	// probe URL when Provider is "vertex".
+	GCPProject string `json:"gcp_project,omitempty"`
+	// GCPLocation is the Google Cloud region (e.g. "us-central1"). Required
+	// to build a working probe URL when Provider is "vertex".
+	GCPLocation string `json:"gcp_location,omitempty"`
 }
 
 // testConnectionResponse is the JSON response returned by TestModelConnection.
@@ -1242,14 +1261,31 @@ func (h *Handler) TestModelConnection(c fiber.Ctx) error {
 		})
 	}
 
-	testURL := strings.TrimRight(req.BaseURL, "/") + "/models"
-
 	// Use a background context with an explicit timeout so the outbound request
 	// is not cancelled if the Fiber request context is recycled.
 	reqCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	httpReq, err := http.NewRequestWithContext(reqCtx, http.MethodGet, testURL, nil)
+	target := health.ProbeTarget{
+		ModelName:       req.ModelName,
+		Provider:        req.Provider,
+		BaseURL:         req.BaseURL,
+		APIKey:          req.APIKey,
+		AzureDeployment: req.AzureDeployment,
+		AzureAPIVersion: req.AzureAPIVersion,
+		GCPProject:      req.GCPProject,
+		GCPLocation:     req.GCPLocation,
+	}
+
+	// Probe the provider the same way the proxy hot path would actually talk
+	// to it. A models-list probe is preferred (it needs no model identity and
+	// mirrors the historical behaviour for OpenAI-compatible providers and
+	// Anthropic); providers with no meaningful models-list equivalent (azure,
+	// vertex, gemini) fall back to a minimal chat probe.
+	httpReq, err := health.BuildProbeRequest(reqCtx, health.IntentModelsList, target)
+	if errors.Is(err, health.ErrProbeNotApplicable) {
+		httpReq, err = health.BuildProbeRequest(reqCtx, health.IntentChat, target)
+	}
 	if err != nil {
 		h.Log.WarnContext(ctx, "test-connection: build request failed",
 			slog.String("url", req.BaseURL),
@@ -1259,16 +1295,6 @@ func (h *Handler) TestModelConnection(c fiber.Ctx) error {
 			Success: false,
 			Message: "Invalid base URL format",
 		})
-	}
-
-	if req.APIKey != "" {
-		switch req.Provider {
-		case "anthropic":
-			httpReq.Header.Set("x-api-key", req.APIKey)
-			httpReq.Header.Set("anthropic-version", "2023-06-01")
-		default:
-			httpReq.Header.Set("Authorization", "Bearer "+req.APIKey)
-		}
 	}
 
 	resp, err := testClient.Do(httpReq)
@@ -1300,17 +1326,22 @@ func (h *Handler) TestModelConnection(c fiber.Ctx) error {
 
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
 
-	var modelsResp struct {
-		Data []struct {
-			ID string `json:"id"`
-		} `json:"data"`
-	}
+	// Only a models-list probe response has the OpenAI models-list envelope;
+	// a chat-probe fallback response (issued for azure/vertex/gemini) has a
+	// different shape and is not parsed for a model count.
+	if httpReq.Method == http.MethodGet {
+		var modelsResp struct {
+			Data []struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		}
 
-	if err := jsonx.Unmarshal(body, &modelsResp); err == nil && len(modelsResp.Data) > 0 {
-		return c.JSON(testConnectionResponse{
-			Success: true,
-			Message: fmt.Sprintf("connected successfully. %d models available.", len(modelsResp.Data)),
-		})
+		if err := jsonx.Unmarshal(body, &modelsResp); err == nil && len(modelsResp.Data) > 0 {
+			return c.JSON(testConnectionResponse{
+				Success: true,
+				Message: fmt.Sprintf("connected successfully. %d models available.", len(modelsResp.Data)),
+			})
+		}
 	}
 
 	return c.JSON(testConnectionResponse{

--- a/internal/api/admin/models_test.go
+++ b/internal/api/admin/models_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1826,6 +1827,217 @@ func TestTestConnection_VertexFallsBackToChatProbe(t *testing.T) {
 	decodeBody(t, resp.Body, &got)
 	if got["success"] != true {
 		t.Errorf("success = %v, want true", got["success"])
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Server-side identity validation tests (validateProviderIdentity)
+// ──────────────────────────────────────────────────────────────────────────────
+
+// TestTestConnection_MissingProviderIdentity verifies that TestModelConnection
+// rejects vertex/gemini/azure requests missing a required identity field
+// (gcp_project, gcp_location, model_name, azure_deployment) with the normal
+// testConnectionResponse{Success:false} shape, a message naming the missing
+// field, and — critically — WITHOUT issuing any upstream request at all.
+func TestTestConnection_MissingProviderIdentity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		body       map[string]any
+		wantMsgHas string
+	}{
+		{
+			name: "vertex missing gcp_project and gcp_location",
+			body: map[string]any{
+				"provider":   "vertex",
+				"model_name": "gemini-1.5-pro",
+			},
+			wantMsgHas: "gcp_project and gcp_location",
+		},
+		{
+			name: "vertex missing gcp_project only",
+			body: map[string]any{
+				"provider":     "vertex",
+				"gcp_location": "us-central1",
+				"model_name":   "gemini-1.5-pro",
+			},
+			wantMsgHas: "gcp_project",
+		},
+		{
+			name: "vertex missing gcp_location only",
+			body: map[string]any{
+				"provider":    "vertex",
+				"gcp_project": "proj-123",
+				"model_name":  "gemini-1.5-pro",
+			},
+			wantMsgHas: "gcp_location",
+		},
+		{
+			name: "vertex missing model_name",
+			body: map[string]any{
+				"provider":     "vertex",
+				"gcp_project":  "proj-123",
+				"gcp_location": "us-central1",
+			},
+			wantMsgHas: "model_name",
+		},
+		{
+			name: "gemini missing model_name",
+			body: map[string]any{
+				"provider": "gemini",
+			},
+			wantMsgHas: "model_name",
+		},
+		{
+			name: "azure missing azure_deployment",
+			body: map[string]any{
+				"provider":   "azure",
+				"model_name": "gpt-4o",
+			},
+			wantMsgHas: "azure_deployment",
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var hits int32
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt32(&hits, 1)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			t.Cleanup(upstream.Close)
+
+			dsn := fmt.Sprintf("file:TestTestConnection_MissingIdentity_%d?mode=memory&cache=private", i)
+			app, _, keyCache := setupModelTestApp(t, dsn)
+			testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+			reqBody := map[string]any{"base_url": upstream.URL, "api_key": "test-key"}
+			for k, v := range tc.body {
+				reqBody[k] = v
+			}
+
+			req := httptest.NewRequest("POST", modelTestConnectionURL(), bodyJSON(t, reqBody))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testKey)
+
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+			if err != nil {
+				t.Fatalf("app.Test: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != fiber.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+			}
+
+			var got map[string]any
+			decodeBody(t, resp.Body, &got)
+			if got["success"] != false {
+				t.Errorf("success = %v, want false", got["success"])
+			}
+			msg, _ := got["message"].(string)
+			if !strings.Contains(msg, tc.wantMsgHas) {
+				t.Errorf("message = %q, want to contain %q", msg, tc.wantMsgHas)
+			}
+
+			if n := atomic.LoadInt32(&hits); n != 0 {
+				t.Errorf("upstream hit count = %d, want 0 (no upstream call must be made when identity validation fails)", n)
+			}
+		})
+	}
+}
+
+// TestTestConnection_ProviderIdentitySuppliedReachesUpstream is the
+// complement of TestTestConnection_MissingProviderIdentity: when all
+// required identity fields ARE supplied, validateProviderIdentity must not
+// block the request and the upstream probe must still be issued and succeed.
+// This is a light-touch confirmation alongside the fuller happy-path coverage
+// in TestTestConnection_AzureFallsBackToChatProbe, _GeminiFallsBackToChatProbe,
+// and _VertexFallsBackToChatProbe.
+func TestTestConnection_ProviderIdentitySuppliedReachesUpstream(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body map[string]any
+	}{
+		{
+			name: "vertex with all identity fields",
+			body: map[string]any{
+				"provider":     "vertex",
+				"model_name":   "gemini-1.5-pro",
+				"gcp_project":  "proj-123",
+				"gcp_location": "us-central1",
+			},
+		},
+		{
+			name: "gemini with model_name",
+			body: map[string]any{
+				"provider":   "gemini",
+				"model_name": "gemini-1.5-pro",
+			},
+		},
+		{
+			name: "azure with azure_deployment",
+			body: map[string]any{
+				"provider":         "azure",
+				"model_name":       "gpt-4o",
+				"azure_deployment": "gpt4-deployment",
+			},
+		},
+	}
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var hits int32
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				atomic.AddInt32(&hits, 1)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"hi"}}],"candidates":[{"content":{"parts":[{"text":"hi"}]}}]}`))
+			}))
+			t.Cleanup(upstream.Close)
+
+			dsn := fmt.Sprintf("file:TestTestConnection_IdentitySupplied_%d?mode=memory&cache=private", i)
+			app, _, keyCache := setupModelTestApp(t, dsn)
+			testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+			reqBody := map[string]any{"base_url": upstream.URL, "api_key": "test-key"}
+			for k, v := range tc.body {
+				reqBody[k] = v
+			}
+
+			req := httptest.NewRequest("POST", modelTestConnectionURL(), bodyJSON(t, reqBody))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+testKey)
+
+			resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+			if err != nil {
+				t.Fatalf("app.Test: %v", err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != fiber.StatusOK {
+				body, _ := io.ReadAll(resp.Body)
+				t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+			}
+
+			var got map[string]any
+			decodeBody(t, resp.Body, &got)
+			if got["success"] != true {
+				t.Errorf("success = %v, want true; message = %v", got["success"], got["message"])
+			}
+
+			if n := atomic.LoadInt32(&hits); n != 1 {
+				t.Errorf("upstream hit count = %d, want 1 (upstream call must be made when identity is supplied)", n)
+			}
+		})
 	}
 }
 

--- a/internal/api/admin/models_test.go
+++ b/internal/api/admin/models_test.go
@@ -1578,6 +1578,258 @@ func TestTestConnection_NonAnthropicUsesBearerAuth(t *testing.T) {
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
+// Provider-aware probe tests (issue #182)
+// ──────────────────────────────────────────────────────────────────────────────
+
+// TestTestConnection_AnthropicUsesModelsListIntent verifies that anthropic —
+// like openai — is probed via the models-list intent: a GET request to a
+// path ending "/models", authenticated with x-api-key.
+func TestTestConnection_AnthropicUsesModelsListIntent(t *testing.T) {
+	t.Parallel()
+
+	var capturedMethod, capturedPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	dsn := "file:TestTestConnection_AnthropicModelsList?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("POST", modelTestConnectionURL(), bodyJSON(t, map[string]any{
+		"provider": "anthropic",
+		"base_url": upstream.URL,
+		"api_key":  "sk-ant-test-key",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if capturedMethod != http.MethodGet {
+		t.Errorf("upstream method = %q, want GET", capturedMethod)
+	}
+	if !strings.HasSuffix(capturedPath, "/models") {
+		t.Errorf("upstream path = %q, want suffix %q", capturedPath, "/models")
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+	if got["success"] != true {
+		t.Errorf("success = %v, want true", got["success"])
+	}
+}
+
+// TestTestConnection_AzureFallsBackToChatProbe verifies that azure — which
+// has no meaningful models-list probe — falls back to a chat probe: a POST
+// to a deployment-scoped URL carrying api-version, authenticated with
+// api-key (not Authorization).
+func TestTestConnection_AzureFallsBackToChatProbe(t *testing.T) {
+	t.Parallel()
+
+	var capturedMethod, capturedPath, capturedQuery string
+	var capturedHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		capturedQuery = r.URL.RawQuery
+		capturedHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"hi"}}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	dsn := "file:TestTestConnection_AzureChatFallback?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("POST", modelTestConnectionURL(), bodyJSON(t, map[string]any{
+		"provider":         "azure",
+		"base_url":         upstream.URL,
+		"api_key":          "azure-test-key",
+		"model_name":       "gpt-4o",
+		"azure_deployment": "gpt4-deployment",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	if capturedMethod != http.MethodPost {
+		t.Errorf("upstream method = %q, want POST", capturedMethod)
+	}
+	if !strings.Contains(capturedPath, "/openai/deployments/gpt4-deployment/") {
+		t.Errorf("upstream path = %q, want to contain %q", capturedPath, "/openai/deployments/gpt4-deployment/")
+	}
+	if !strings.Contains(capturedQuery, "api-version=") {
+		t.Errorf("upstream query = %q, want to contain %q", capturedQuery, "api-version=")
+	}
+	if capturedHeaders.Get("api-key") != "azure-test-key" {
+		t.Errorf("api-key header = %q, want %q", capturedHeaders.Get("api-key"), "azure-test-key")
+	}
+	if capturedHeaders.Get("Authorization") != "" {
+		t.Error("Authorization header must not be set for azure provider")
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+	if got["success"] != true {
+		t.Errorf("success = %v, want true", got["success"])
+	}
+	// The chat-probe fallback response has no models-list envelope, so the
+	// message must not report a model count.
+	msg, _ := got["message"].(string)
+	if strings.Contains(msg, "models available") {
+		t.Errorf("message = %q, must not report a model count for a chat-probe fallback", msg)
+	}
+}
+
+// TestTestConnection_GeminiFallsBackToChatProbe verifies that gemini — which
+// has no meaningful models-list probe — falls back to a chat probe: a POST
+// to a v1beta generateContent URL, authenticated with x-goog-api-key.
+func TestTestConnection_GeminiFallsBackToChatProbe(t *testing.T) {
+	t.Parallel()
+
+	var capturedMethod, capturedPath string
+	var capturedHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		capturedHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"hi"}]}}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	dsn := "file:TestTestConnection_GeminiChatFallback?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("POST", modelTestConnectionURL(), bodyJSON(t, map[string]any{
+		"provider":   "gemini",
+		"base_url":   upstream.URL,
+		"api_key":    "goog-test-key",
+		"model_name": "gemini-1.5-pro",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	if capturedMethod != http.MethodPost {
+		t.Errorf("upstream method = %q, want POST", capturedMethod)
+	}
+	if !strings.Contains(capturedPath, "/v1beta/models/") || !strings.HasSuffix(capturedPath, ":generateContent") {
+		t.Errorf("upstream path = %q, want to contain /v1beta/models/ and end with :generateContent", capturedPath)
+	}
+	if capturedHeaders.Get("x-goog-api-key") != "goog-test-key" {
+		t.Errorf("x-goog-api-key header = %q, want %q", capturedHeaders.Get("x-goog-api-key"), "goog-test-key")
+	}
+	if capturedHeaders.Get("Authorization") != "" {
+		t.Error("Authorization header must not be set for gemini provider")
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+	if got["success"] != true {
+		t.Errorf("success = %v, want true", got["success"])
+	}
+}
+
+// TestTestConnection_VertexFallsBackToChatProbe verifies that vertex — which
+// has no meaningful models-list probe — falls back to a chat probe against a
+// project/location-scoped URL, and that the default Bearer Authorization
+// header IS present (GeminiAdapter.SetHeaders deliberately leaves it
+// untouched for provider "vertex").
+func TestTestConnection_VertexFallsBackToChatProbe(t *testing.T) {
+	t.Parallel()
+
+	var capturedMethod, capturedPath string
+	var capturedHeaders http.Header
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		capturedHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"text":"hi"}]}}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	dsn := "file:TestTestConnection_VertexChatFallback?mode=memory&cache=private"
+	app, _, keyCache := setupModelTestApp(t, dsn)
+	testKey := addTestKey(t, keyCache, auth.RoleSystemAdmin, "")
+
+	req := httptest.NewRequest("POST", modelTestConnectionURL(), bodyJSON(t, map[string]any{
+		"provider":     "vertex",
+		"base_url":     upstream.URL,
+		"api_key":      "vertex-bearer-token",
+		"model_name":   "gemini-1.5-pro",
+		"gcp_project":  "proj-123",
+		"gcp_location": "us-central1",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+testKey)
+
+	resp, err := app.Test(req, fiber.TestConfig{Timeout: testTimeout})
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != fiber.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body: %s", resp.StatusCode, body)
+	}
+
+	if capturedMethod != http.MethodPost {
+		t.Errorf("upstream method = %q, want POST", capturedMethod)
+	}
+	wantPathParts := []string{"/v1/projects/proj-123/locations/us-central1/publishers/google/models/gemini-1.5-pro:generateContent"}
+	for _, want := range wantPathParts {
+		if capturedPath != want {
+			t.Errorf("upstream path = %q, want %q", capturedPath, want)
+		}
+	}
+	// The trap: vertex authenticates via the default Bearer header, not a
+	// provider-specific header.
+	if capturedHeaders.Get("Authorization") != "Bearer vertex-bearer-token" {
+		t.Errorf("Authorization header = %q, want %q", capturedHeaders.Get("Authorization"), "Bearer vertex-bearer-token")
+	}
+
+	var got map[string]any
+	decodeBody(t, resp.Body, &got)
+	if got["success"] != true {
+		t.Errorf("success = %v, want true", got["success"])
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
 // Fallback model name tests
 // ──────────────────────────────────────────────────────────────────────────────
 

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -271,9 +271,11 @@ func (c *Checker) runOne(t probeTarget, level probeLevel) {
 		// nil — deriveStatus already treats nil as "not checked" — rather
 		// than recording a success that never actually ran, or a failure
 		// that would wrongly drag the status to degraded/unhealthy.
+		//
+		// levelHealth never appears here: probeHealth pings the bare server
+		// root directly and never routes through BuildProbeRequest, so it
+		// can never return ErrProbeNotApplicable.
 		switch level {
-		case levelHealth:
-			updated.HealthOK = nil
 		case levelModels:
 			updated.ModelsOK = nil
 		case levelFunctional:

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -126,8 +126,9 @@ type ModelHealth struct {
 // serialization one level's Store can silently overwrite a concurrent
 // update from another level (a lost update, not a data race — copying the
 // struct before mutating already prevents the latter). Readers never take
-// mu; they only ever observe a fully-formed *ModelHealth that runOne
-// published after releasing it.
+// mu: runOne stores a value only once it is fully populated, so whether a
+// reader loads before or after a concurrent write it always observes a
+// complete, internally consistent *ModelHealth.
 type Checker struct {
 	registry *proxy.Registry
 	results  sync.Map // map[string]*ModelHealth — keyed by probeTarget.key, replaced atomically

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -118,12 +118,27 @@ type ModelHealth struct {
 // Checker periodically probes all models registered in the proxy.Registry at
 // up to three configurable levels and stores the results in memory. All methods
 // are safe for concurrent use.
+//
+// results is a sync.Map so that GetHealth and GetAllHealth stay lock-free on
+// the request hot path. mu protects only the load-copy-mutate-store sequence
+// in runOne: up to three probe levels (health, models, functional) run on
+// independent tickers and can race to update the same key, and without
+// serialization one level's Store can silently overwrite a concurrent
+// update from another level (a lost update, not a data race — copying the
+// struct before mutating already prevents the latter). Readers never take
+// mu; they only ever observe a fully-formed *ModelHealth that runOne
+// published after releasing it.
 type Checker struct {
 	registry *proxy.Registry
 	results  sync.Map // map[string]*ModelHealth — keyed by probeTarget.key, replaced atomically
-	cfg      config.HealthCheckConfig
-	client   *http.Client
-	log      *slog.Logger
+	// mu serializes the read-modify-write sequence in runOne across
+	// concurrently running probe levels. It is never held during network
+	// I/O (execProbe) and is never taken by readers (GetHealth,
+	// GetAllHealth) — see the Checker doc comment.
+	mu     sync.Mutex
+	cfg    config.HealthCheckConfig
+	client *http.Client
+	log    *slog.Logger
 }
 
 // NewChecker constructs a Checker that will probe the models in registry
@@ -151,7 +166,9 @@ func NewChecker(registry *proxy.Registry, cfg config.HealthCheckConfig, log *slo
 // within a multi-deployment model key is "modelName/deploymentName". It
 // returns nil and false when the target has not yet been probed.
 // The returned pointer is safe to read without further synchronization —
-// stored values are never mutated after being placed in the map.
+// stored values are never mutated after being placed in the map. This holds
+// even though writers serialize on Checker.mu: GetHealth intentionally does
+// not acquire it, since the map only ever holds fully-formed snapshots.
 func (c *Checker) GetHealth(key string) (*ModelHealth, bool) {
 	v, ok := c.results.Load(key)
 	if !ok {
@@ -263,21 +280,31 @@ func (c *Checker) runAll(level probeLevel) {
 }
 
 // runOne executes a single probe for the given target at the given level and
-// atomically replaces the stored ModelHealth using copy-on-write to avoid data
-// races.
+// atomically replaces the stored ModelHealth using copy-on-write.
 func (c *Checker) runOne(t probeTarget, level probeLevel) {
 	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
 	defer cancel()
 
 	latencyMs, err := execProbe(ctx, c.client, t, level)
 
+	// From here on we only touch in-memory state — no network I/O — so hold
+	// mu for the remainder of the function. Health, models, and functional
+	// probes run on independent tickers and can reach this point for the
+	// same key concurrently; without the lock, two levels could both load
+	// the same old snapshot and the second Store would silently discard the
+	// first level's update (a lost update). Copy-on-write alone prevents a
+	// data race on the struct fields, but not this lost-update race between
+	// levels — mu is what serializes the load-copy-mutate-store sequence.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	// Load existing or create a zero value to copy from.
 	existing, _ := c.results.LoadOrStore(t.key, &ModelHealth{ModelName: t.key, Status: "unknown"})
 	old := existing.(*ModelHealth)
 
-	// Copy-on-write: mutate the copy, then store atomically. This eliminates
-	// the data race that would occur if multiple probe-level goroutines
-	// mutated the same *ModelHealth in place.
+	// Copy-on-write: mutate the copy, then store atomically, so a concurrent
+	// reader that already holds the old pointer (see GetHealth) never
+	// observes a partially-updated struct.
 	updated := *old
 	updated.LastCheck = time.Now().UTC()
 

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -80,8 +80,12 @@ type ModelHealth struct {
 	Status string `json:"status"`
 	// LastCheck is the UTC timestamp of the most recent probe cycle.
 	LastCheck time.Time `json:"last_check"`
-	// LastError holds the error message from the most recently failed probe,
-	// or is empty when all probes passed.
+	// LastError is derived from HealthError, ModelsError, and FunctionalError
+	// using the same health > models > functional priority as Status, for
+	// consumers that display a single error value. It is empty when every
+	// enabled and applicable probe is currently passing. Prefer HealthError,
+	// ModelsError, and FunctionalError when it matters which probe produced
+	// the message.
 	LastError string `json:"last_error,omitempty"`
 	// LatencyMs is the round-trip time of the most recent successful probe
 	// in milliseconds. Zero when no probe has succeeded yet.
@@ -96,6 +100,19 @@ type ModelHealth struct {
 	// reflects whether the last POST /chat/completions probe returned a 2xx
 	// response.
 	FunctionalOK *bool `json:"functional_ok"`
+	// HealthError holds the sanitized error from the most recent health
+	// probe. It is empty when the probe is disabled, has not yet run, or
+	// last succeeded.
+	HealthError string `json:"health_error,omitempty"`
+	// ModelsError holds the sanitized error from the most recent models
+	// probe. It is empty when the probe is disabled, not applicable to the
+	// target's provider, has not yet run, or last succeeded.
+	ModelsError string `json:"models_error,omitempty"`
+	// FunctionalError holds the sanitized error from the most recent
+	// functional probe. It is empty when the probe is disabled, not
+	// applicable to the target's model type, has not yet run, or last
+	// succeeded.
+	FunctionalError string `json:"functional_error,omitempty"`
 }
 
 // Checker periodically probes all models registered in the proxy.Registry at
@@ -270,7 +287,10 @@ func (c *Checker) runOne(t probeTarget, level probeLevel) {
 		// functional probe against an image model). Leave the level's field
 		// nil — deriveStatus already treats nil as "not checked" — rather
 		// than recording a success that never actually ran, or a failure
-		// that would wrongly drag the status to degraded/unhealthy.
+		// that would wrongly drag the status to degraded/unhealthy. Also
+		// clear the level's own error field: a probe that just became
+		// not-applicable (e.g. after a model type edit) must not keep
+		// displaying a stale failure from when it was still applicable.
 		//
 		// levelHealth never appears here: probeHealth pings the bare server
 		// root directly and never routes through BuildProbeRequest, so it
@@ -278,9 +298,12 @@ func (c *Checker) runOne(t probeTarget, level probeLevel) {
 		switch level {
 		case levelModels:
 			updated.ModelsOK = nil
+			updated.ModelsError = ""
 		case levelFunctional:
 			updated.FunctionalOK = nil
+			updated.FunctionalError = ""
 		}
+		updated.LastError = deriveLastError(&updated)
 		updated.Status = deriveStatus(&updated)
 		c.results.Store(t.key, &updated)
 		updateMetrics(t.key, &updated)
@@ -288,29 +311,34 @@ func (c *Checker) runOne(t probeTarget, level probeLevel) {
 	}
 
 	ok := err == nil
+	var sanitized string
 	if ok {
 		updated.LatencyMs = latencyMs
-		updated.LastError = ""
 	} else {
-		updated.LastError = sanitizeError(err)
+		sanitized = sanitizeError(err)
 		c.log.LogAttrs(ctx, slog.LevelDebug, "health probe failed",
 			slog.String("key", t.key),
-			slog.String("error", updated.LastError),
+			slog.String("error", sanitized),
 		)
 	}
 
+	// Each level owns its own error field. Assigning sanitized (empty on
+	// success) here, rather than sharing one field across levels, ensures a
+	// successful run of one probe never wipes a genuine failure recorded by
+	// another.
 	switch level {
 	case levelHealth:
 		updated.HealthOK = &ok
-		if ok {
-			updated.LatencyMs = latencyMs
-		}
+		updated.HealthError = sanitized
 	case levelModels:
 		updated.ModelsOK = &ok
+		updated.ModelsError = sanitized
 	case levelFunctional:
 		updated.FunctionalOK = &ok
+		updated.FunctionalError = sanitized
 	}
 
+	updated.LastError = deriveLastError(&updated)
 	updated.Status = deriveStatus(&updated)
 	c.results.Store(t.key, &updated)
 
@@ -474,6 +502,22 @@ func setAuthHeaders(req *http.Request, t probeTarget) {
 	} else {
 		req.Header.Set("Authorization", "Bearer "+t.apiKey)
 	}
+}
+
+// deriveLastError picks the single error message to expose as LastError for
+// consumers that show one value. It follows the same precedence as
+// deriveStatus: a failed reachability probe outranks a failed models probe,
+// which outranks a failed functional probe, so the reported message always
+// describes the most severe current failure. It returns an empty string when
+// every enabled and applicable probe is passing.
+func deriveLastError(h *ModelHealth) string {
+	if h.HealthError != "" {
+		return h.HealthError
+	}
+	if h.ModelsError != "" {
+		return h.ModelsError
+	}
+	return h.FunctionalError
 }
 
 // deriveStatus computes the overall status from the individual probe results.

--- a/internal/health/checker.go
+++ b/internal/health/checker.go
@@ -4,8 +4,8 @@
 package health
 
 import (
-	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/voidmind-io/voidllm/internal/config"
-	"github.com/voidmind-io/voidllm/internal/jsonx"
 	"github.com/voidmind-io/voidllm/internal/metrics"
 	"github.com/voidmind-io/voidllm/internal/proxy"
 )
@@ -53,6 +52,23 @@ type probeTarget struct {
 	gcpProject string
 	// gcpLocation is the Google Cloud region. Non-empty only for provider "vertex".
 	gcpLocation string
+}
+
+// asProbeTarget converts t to the exported ProbeTarget shape that
+// BuildProbeRequest accepts. key and modelType are Checker-internal
+// dispatch/labelling fields with no bearing on request construction and are
+// intentionally not carried over.
+func (t probeTarget) asProbeTarget() ProbeTarget {
+	return ProbeTarget{
+		ModelName:       t.modelName,
+		Provider:        t.provider,
+		BaseURL:         t.baseURL,
+		APIKey:          t.apiKey,
+		AzureDeployment: t.azureDeployment,
+		AzureAPIVersion: t.azureAPIVersion,
+		GCPProject:      t.gcpProject,
+		GCPLocation:     t.gcpLocation,
+	}
 }
 
 // ModelHealth holds the most recent health state for a single upstream model.
@@ -248,6 +264,27 @@ func (c *Checker) runOne(t probeTarget, level probeLevel) {
 	updated := *old
 	updated.LastCheck = time.Now().UTC()
 
+	if errors.Is(err, ErrProbeNotApplicable) {
+		// This probe has no meaningful equivalent for the target's provider
+		// or model type (e.g. a models-list probe against Gemini, or a
+		// functional probe against an image model). Leave the level's field
+		// nil — deriveStatus already treats nil as "not checked" — rather
+		// than recording a success that never actually ran, or a failure
+		// that would wrongly drag the status to degraded/unhealthy.
+		switch level {
+		case levelHealth:
+			updated.HealthOK = nil
+		case levelModels:
+			updated.ModelsOK = nil
+		case levelFunctional:
+			updated.FunctionalOK = nil
+		}
+		updated.Status = deriveStatus(&updated)
+		c.results.Store(t.key, &updated)
+		updateMetrics(t.key, &updated)
+		return
+	}
+
 	ok := err == nil
 	if ok {
 		updated.LatencyMs = latencyMs
@@ -357,115 +394,50 @@ func probeHealth(ctx context.Context, client *http.Client, t probeTarget) (int64
 	return latencyMs, nil
 }
 
-// probeModels performs a GET to <base_url>/models and returns success on any
-// 2xx HTTP response.
+// probeModels performs a GET to the provider's model-listing endpoint (built
+// by BuildProbeRequest, provider-aware) and returns success on any 2xx HTTP
+// response. It returns ErrProbeNotApplicable for providers whose adapter has
+// no meaningful model-listing endpoint (azure, vertex, gemini) — see
+// BuildProbeRequest's doc for the full rationale.
 func probeModels(ctx context.Context, client *http.Client, t probeTarget) (int64, error) {
-	rawURL := strings.TrimRight(t.baseURL, "/") + "/models"
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
-	if err != nil {
-		return 0, fmt.Errorf("build request: %w", err)
-	}
-
-	setAuthHeaders(req, t)
-
-	start := time.Now()
-	resp, err := client.Do(req)
-	latencyMs := time.Since(start).Milliseconds()
-	if err != nil {
-		return 0, fmt.Errorf("do request: %w", err)
-	}
-	defer resp.Body.Close()
-	_, _ = io.Copy(io.Discard, resp.Body)
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return 0, fmt.Errorf("http %d", resp.StatusCode)
-	}
-	return latencyMs, nil
+	return probeWithIntent(ctx, client, IntentModelsList, t)
 }
 
 // probeFunctional dispatches to the appropriate functional probe based on the
 // target's model type. Image, audio_transcription, and tts models are skipped
-// because they are too expensive or require special binary input to probe
-// meaningfully.
+// (ErrProbeNotApplicable) because they are too expensive or require special
+// binary input to probe meaningfully.
 func probeFunctional(ctx context.Context, client *http.Client, t probeTarget) (int64, error) {
 	switch t.modelType {
 	case "embedding":
-		return probeEmbedding(ctx, client, t)
+		return probeWithIntent(ctx, client, IntentEmbeddings, t)
 	case "reranking", "image", "audio_transcription", "tts":
 		// Skip — incompatible endpoint or too expensive to probe.
-		return 0, nil
+		return 0, ErrProbeNotApplicable
 	default: // "chat", "completion", ""
-		return probeFunctionalChat(ctx, client, t)
+		return probeWithIntent(ctx, client, IntentChat, t)
 	}
 }
 
-// probeFunctionalChat performs a minimal POST /chat/completions request with a
-// single-token max to verify end-to-end functionality of the upstream model.
-// For Azure targets the deployment name is used as the model identifier.
-func probeFunctionalChat(ctx context.Context, client *http.Client, t probeTarget) (int64, error) {
-	rawURL := strings.TrimRight(t.baseURL, "/") + "/chat/completions"
-
-	upstreamModel := t.modelName
-	if t.provider == "azure" && t.azureDeployment != "" {
-		upstreamModel = t.azureDeployment
-	}
-
-	payload := map[string]any{
-		"model":      upstreamModel,
-		"messages":   []map[string]string{{"role": "user", "content": "hi"}},
-		"max_tokens": 1,
-	}
-	body, err := jsonx.Marshal(payload)
+// probeWithIntent builds a provider-aware probe request for intent via
+// BuildProbeRequest and executes it, returning ErrProbeNotApplicable
+// unchanged so callers (probeFunctional, runOne) can distinguish "skipped"
+// from "failed".
+func probeWithIntent(ctx context.Context, client *http.Client, intent ProbeIntent, t probeTarget) (int64, error) {
+	req, err := BuildProbeRequest(ctx, intent, t.asProbeTarget())
 	if err != nil {
-		return 0, fmt.Errorf("marshal request: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
-	if err != nil {
+		if errors.Is(err, ErrProbeNotApplicable) {
+			return 0, err
+		}
 		return 0, fmt.Errorf("build request: %w", err)
 	}
-	req.Header.Set("Content-Type", "application/json")
-
-	setAuthHeaders(req, t)
-
-	start := time.Now()
-	resp, err := client.Do(req)
-	latencyMs := time.Since(start).Milliseconds()
-	if err != nil {
-		return 0, fmt.Errorf("do request: %w", err)
-	}
-	defer resp.Body.Close()
-	_, _ = io.Copy(io.Discard, resp.Body)
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return 0, fmt.Errorf("http %d", resp.StatusCode)
-	}
-	return latencyMs, nil
+	return doProbeRequest(client, req)
 }
 
-// probeEmbedding performs a minimal POST /embeddings request with a single
-// short input string to verify end-to-end functionality of an embedding model.
-func probeEmbedding(ctx context.Context, client *http.Client, t probeTarget) (int64, error) {
-	rawURL := strings.TrimRight(t.baseURL, "/") + "/embeddings"
-
-	payload := map[string]any{
-		"model": t.modelName,
-		"input": "test",
-	}
-	body, err := jsonx.Marshal(payload)
-	if err != nil {
-		return 0, fmt.Errorf("marshal request: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
-	if err != nil {
-		return 0, fmt.Errorf("build request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	setAuthHeaders(req, t)
-
+// doProbeRequest executes req and returns success on any 2xx HTTP response.
+// It is shared by every probe that treats "2xx" as the pass/fail boundary
+// (models-list, functional chat, functional embeddings).
+func doProbeRequest(client *http.Client, req *http.Request) (int64, error) {
 	start := time.Now()
 	resp, err := client.Do(req)
 	latencyMs := time.Since(start).Milliseconds()
@@ -482,8 +454,14 @@ func probeEmbedding(ctx context.Context, client *http.Client, t probeTarget) (in
 }
 
 // setAuthHeaders adds the appropriate authentication headers to req based on
-// the target's provider. Anthropic uses the x-api-key header scheme; all other
-// providers use Bearer token authorization.
+// the target's provider. It is used only by probeHealth: probeModels and
+// probeFunctional build their requests via BuildProbeRequest, which sets
+// provider-correct headers through the same proxy.Adapter.SetHeaders logic
+// the real proxy hot path uses. probeHealth intentionally stays independent
+// of BuildProbeRequest because it hits the bare server root, not a
+// provider-shaped endpoint, and treats any HTTP response as success — the
+// exact header scheme used barely matters for that check, but Anthropic's
+// x-api-key scheme is still applied for parity with a normal request.
 func setAuthHeaders(req *http.Request, t probeTarget) {
 	if t.apiKey == "" {
 		return

--- a/internal/health/checker_internal_test.go
+++ b/internal/health/checker_internal_test.go
@@ -1,10 +1,12 @@
 package health
 
 import (
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/voidmind-io/voidllm/internal/config"
@@ -150,5 +152,86 @@ func TestRunOne_NotApplicable_ClearsOnlyOwnError(t *testing.T) {
 	}
 	if mh.FunctionalError != wantFunctionalError {
 		t.Errorf("FunctionalError = %q, want %q (must be unchanged by the models-level transition)", mh.FunctionalError, wantFunctionalError)
+	}
+}
+
+// TestRunOne_ConcurrentLevels_NoLostUpdate drives all three probe levels for
+// the SAME key concurrently, many times, and asserts that every level's
+// result survives in the final stored ModelHealth.
+//
+// runOne's sequence — Load the existing snapshot, copy it, mutate only the
+// calling level's field, then Store — is safe against concurrent mutation of
+// the same struct (copy-on-write), but without Checker.mu it is not safe
+// against a lost update: two levels can both Load the same old snapshot
+// before either has Stored, and whichever Store lands second silently
+// discards the field the other level just wrote, because it was built from a
+// copy that predates that write. That is a lost update, not a data race, so
+// -race alone cannot catch it — only asserting on the resulting state can.
+//
+// A single httptest.Server gives each level a distinct, deterministic
+// outcome by request path: the health probe hits the server root and always
+// succeeds (any response counts as reachable), "/models" returns 500 so the
+// models-list probe fails, and "/chat/completions" returns 200 so the
+// functional probe succeeds. That lets the assertions check not merely that
+// each field is non-nil but that it holds the *correct* per-level outcome —
+// ruling out a bug where one level's result leaks into another's field, not
+// just a bug where a field goes missing.
+func TestRunOne_ConcurrentLevels_NoLostUpdate(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/models" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	reg, err := proxy.NewRegistry(nil)
+	if err != nil {
+		t.Fatalf("proxy.NewRegistry: %v", err)
+	}
+	c := NewChecker(reg, config.HealthCheckConfig{}, newDiscardLogger())
+
+	const iterations = 300
+	for i := 0; i < iterations; i++ {
+		key := fmt.Sprintf("concurrent-model-%d", i)
+		target := probeTarget{
+			key:       key,
+			modelName: key,
+			provider:  "openai",
+			baseURL:   srv.URL,
+			modelType: "chat",
+		}
+
+		// Start all three levels as close to simultaneously as possible so
+		// their runOne calls race to update the same key.
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		for _, lvl := range []probeLevel{levelHealth, levelModels, levelFunctional} {
+			wg.Add(1)
+			go func(lvl probeLevel) {
+				defer wg.Done()
+				<-start
+				c.runOne(target, lvl)
+			}(lvl)
+		}
+		close(start)
+		wg.Wait()
+
+		mh, ok := c.GetHealth(key)
+		if !ok {
+			t.Fatalf("iteration %d: GetHealth(%q) returned false after all three levels ran", i, key)
+		}
+		if mh.HealthOK == nil || !*mh.HealthOK {
+			t.Errorf("iteration %d: HealthOK = %v, want non-nil true (lost update clobbered the health level's result)", i, mh.HealthOK)
+		}
+		if mh.ModelsOK == nil || *mh.ModelsOK {
+			t.Errorf("iteration %d: ModelsOK = %v, want non-nil false (lost update clobbered the models level's result)", i, mh.ModelsOK)
+		}
+		if mh.FunctionalOK == nil || !*mh.FunctionalOK {
+			t.Errorf("iteration %d: FunctionalOK = %v, want non-nil true (lost update clobbered the functional level's result)", i, mh.FunctionalOK)
+		}
 	}
 }

--- a/internal/health/checker_internal_test.go
+++ b/internal/health/checker_internal_test.go
@@ -1,0 +1,154 @@
+package health
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/voidmind-io/voidllm/internal/config"
+	"github.com/voidmind-io/voidllm/internal/proxy"
+)
+
+// newDiscardLogger returns a discard slog.Logger so probe debug lines don't
+// clutter test output. It duplicates checker_test.go's newLogger because this
+// file lives in package health (white-box) rather than health_test, and the
+// two test binaries do not share unexported helpers.
+func newDiscardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestDeriveLastError_Precedence verifies deriveLastError's priority order —
+// health error outranks models error outranks functional error — matching
+// deriveStatus's precedence, and that it returns empty when nothing is set.
+func TestDeriveLastError_Precedence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		h    *ModelHealth
+		want string
+	}{
+		{
+			name: "health error wins over models and functional",
+			h: &ModelHealth{
+				HealthError:     "health failed",
+				ModelsError:     "models failed",
+				FunctionalError: "functional failed",
+			},
+			want: "health failed",
+		},
+		{
+			name: "models error wins over functional when health is empty",
+			h: &ModelHealth{
+				ModelsError:     "models failed",
+				FunctionalError: "functional failed",
+			},
+			want: "models failed",
+		},
+		{
+			name: "functional error surfaces when health and models are empty",
+			h: &ModelHealth{
+				FunctionalError: "functional failed",
+			},
+			want: "functional failed",
+		},
+		{
+			name: "empty when nothing is set",
+			h:    &ModelHealth{},
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := deriveLastError(tc.h)
+			if got != tc.want {
+				t.Errorf("deriveLastError() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRunOne_NotApplicable_ClearsOnlyOwnError drives the Checker's unexported
+// runOne directly (rather than through the registry/Start path) so it can
+// express a provider transition for the *same* probe-target key within a
+// single test — the registry has no live-update path that would let a
+// black-box test change a target's provider between two probe cycles for the
+// same key, but runOne itself has no such restriction: it is keyed purely by
+// probeTarget.key, exactly as it would be if a model were edited from one
+// provider to another between health-check cycles.
+//
+// It records genuine failures on both the models and functional levels, then
+// re-probes the models level with a target whose provider makes the
+// models-list probe not-applicable (azure). It asserts that only the models
+// level's error is cleared and that the functional level's independently
+// recorded failure is left untouched.
+func TestRunOne_NotApplicable_ClearsOnlyOwnError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	reg, err := proxy.NewRegistry(nil)
+	if err != nil {
+		t.Fatalf("proxy.NewRegistry: %v", err)
+	}
+	c := NewChecker(reg, config.HealthCheckConfig{}, newDiscardLogger())
+
+	const key = "transition-model"
+	openaiTarget := probeTarget{
+		key:       key,
+		modelName: key,
+		provider:  "openai",
+		baseURL:   srv.URL,
+		modelType: "chat",
+	}
+
+	// Record genuine failures on both levels: the server returns 500 for
+	// every path, so both the models-list and functional-chat probes fail.
+	c.runOne(openaiTarget, levelModels)
+	c.runOne(openaiTarget, levelFunctional)
+
+	mh, ok := c.GetHealth(key)
+	if !ok {
+		t.Fatal("GetHealth returned false after the initial probes")
+	}
+	if mh.ModelsError == "" {
+		t.Fatal("precondition failed: ModelsError must be non-empty before the transition")
+	}
+	if mh.FunctionalError == "" {
+		t.Fatal("precondition failed: FunctionalError must be non-empty before the transition")
+	}
+	wantFunctionalOK := mh.FunctionalOK
+	wantFunctionalError := mh.FunctionalError
+
+	// Simulate the model being edited from openai to azure: the models-list
+	// probe has no meaningful equivalent for azure and becomes not-applicable
+	// for this same-keyed target on the next cycle.
+	azureTarget := openaiTarget
+	azureTarget.provider = "azure"
+	c.runOne(azureTarget, levelModels)
+
+	mh, ok = c.GetHealth(key)
+	if !ok {
+		t.Fatal("GetHealth returned false after the transition")
+	}
+	if mh.ModelsOK != nil {
+		t.Errorf("ModelsOK = %v, want nil once the probe becomes not-applicable", mh.ModelsOK)
+	}
+	if mh.ModelsError != "" {
+		t.Errorf("ModelsError = %q, want empty once the probe becomes not-applicable (must not linger)", mh.ModelsError)
+	}
+	if (mh.FunctionalOK == nil) != (wantFunctionalOK == nil) || (mh.FunctionalOK != nil && *mh.FunctionalOK != *wantFunctionalOK) {
+		t.Errorf("FunctionalOK = %v, want %v (must be undisturbed by the models-level transition)", mh.FunctionalOK, wantFunctionalOK)
+	}
+	if mh.FunctionalError != wantFunctionalError {
+		t.Errorf("FunctionalError = %q, want %q (must be unchanged by the models-level transition)", mh.FunctionalError, wantFunctionalError)
+	}
+}

--- a/internal/health/checker_test.go
+++ b/internal/health/checker_test.go
@@ -704,6 +704,101 @@ func TestChecker_NotApplicableProbe_DoesNotBlockGenuineDegradation(t *testing.T)
 	}
 }
 
+// TestChecker_CrossLevelIsolation_SuccessDoesNotWipeFailure drives a real
+// Checker with the models and functional probes enabled against a server
+// where the models-list probe genuinely fails and the functional probe
+// genuinely succeeds. Start() runs levelModels before levelFunctional, so
+// this reproduces the exact ordering that triggered the old shared-LastError
+// bug: a later successful probe (functional) must not erase an earlier
+// genuine failure (models). Each level now owns its own error field, so the
+// failing level's error must survive and the passing level's error field
+// must be empty.
+func TestChecker_CrossLevelIsolation_SuccessDoesNotWipeFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/models" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if r.URL.Path == "/chat/completions" && r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"hi"}}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	reg := newRegistry(t, srv.URL)
+	// Models is enabled and fails; Functional is enabled and succeeds; Health
+	// is disabled so it cannot mask the scenario.
+	c := health.NewChecker(reg, cfg(false, true, true), newLogger())
+	stop := c.Start()
+	t.Cleanup(stop)
+
+	mh, ok := c.GetHealth("test-model")
+	if !ok {
+		t.Fatal("GetHealth returned false; probe cycle did not run")
+	}
+	if mh.ModelsOK == nil || *mh.ModelsOK {
+		t.Errorf("ModelsOK = %v, want false", mh.ModelsOK)
+	}
+	if mh.ModelsError == "" {
+		t.Error("ModelsError is empty, want the genuine models-probe failure to be recorded")
+	}
+	if mh.FunctionalOK == nil || !*mh.FunctionalOK {
+		t.Errorf("FunctionalOK = %v, want true", mh.FunctionalOK)
+	}
+	if mh.FunctionalError != "" {
+		t.Errorf("FunctionalError = %q, want empty — a later successful probe must not report an error", mh.FunctionalError)
+	}
+	// The models failure must still be the one surfaced by LastError, since
+	// FunctionalError being empty must not have wiped it.
+	if mh.LastError != mh.ModelsError {
+		t.Errorf("LastError = %q, want it to equal ModelsError (%q)", mh.LastError, mh.ModelsError)
+	}
+	if mh.LastError == "" {
+		t.Error("LastError is empty, want the surviving models-probe failure")
+	}
+}
+
+// TestChecker_LastError_PrecedenceEndToEnd drives a real Checker with all
+// three probes enabled against an unreachable host, so health, models, and
+// functional all genuinely fail at once. It verifies that LastError — the
+// single-value field kept for existing consumers — surfaces the
+// highest-priority failure (health) rather than whichever probe happened to
+// run last, confirming the JSON contract (LastError) still behaves as
+// existing consumers expect.
+func TestChecker_LastError_PrecedenceEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	allEnabled := config.HealthCheckConfig{
+		Health:     config.HealthProbeConfig{Enabled: true, Interval: 24 * time.Hour},
+		Models:     config.HealthProbeConfig{Enabled: true, Interval: 24 * time.Hour},
+		Functional: config.HealthProbeConfig{Enabled: true, Interval: 24 * time.Hour},
+	}
+	reg := newRegistry(t, "http://127.0.0.1:1")
+	c := health.NewChecker(reg, allEnabled, newLogger())
+	stop := c.Start()
+	t.Cleanup(stop)
+
+	mh, ok := c.GetHealth("test-model")
+	if !ok {
+		t.Fatal("GetHealth returned false; probe cycle did not run")
+	}
+	if mh.HealthError == "" {
+		t.Fatal("precondition failed: HealthError must be non-empty (unreachable host)")
+	}
+	if mh.LastError != mh.HealthError {
+		t.Errorf("LastError = %q, want it to equal HealthError (%q) — health outranks models and functional", mh.LastError, mh.HealthError)
+	}
+	if mh.Status != "unhealthy" {
+		t.Errorf("Status = %q, want %q", mh.Status, "unhealthy")
+	}
+}
+
 // TestChecker_MultiDeployment_KeepsPerDeploymentKey verifies that a
 // multi-deployment model produces one health result per deployment, each
 // keyed as "modelName/deploymentName".

--- a/internal/health/checker_test.go
+++ b/internal/health/checker_test.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,6 +26,22 @@ func newRegistry(t *testing.T, baseURL string) *proxy.Registry {
 			BaseURL:  baseURL,
 		},
 	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	return reg
+}
+
+// newRegistryWithConfig builds a one-model Registry from mc, defaulting Name
+// to "test-model" when unset. Unlike newRegistry (hardcoded to provider
+// "openai" with no deployments), this lets tests set Provider, Type, and the
+// Azure/GCP fields needed for provider-specific probe-applicability tests.
+func newRegistryWithConfig(t *testing.T, mc config.ModelConfig) *proxy.Registry {
+	t.Helper()
+	if mc.Name == "" {
+		mc.Name = "test-model"
+	}
+	reg, err := proxy.NewRegistry([]config.ModelConfig{mc})
 	if err != nil {
 		t.Fatalf("NewRegistry: %v", err)
 	}
@@ -479,5 +497,254 @@ func TestSanitizeError_ConnectionRefused(t *testing.T) {
 	}
 	if mh.LastError != "connection refused" {
 		t.Errorf("LastError = %q, want %q", mh.LastError, "connection refused")
+	}
+}
+
+// TestChecker_ModelsProbe_NotApplicable_LeavesNilNotDegraded verifies that
+// when the models-list probe has no meaningful equivalent for the target's
+// provider (azure, vertex, gemini), the Checker leaves ModelsOK nil and
+// derives status "unknown" rather than contacting the upstream at all or
+// recording a false failure.
+func TestChecker_ModelsProbe_NotApplicable_LeavesNilNotDegraded(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		provider string
+	}{
+		{name: "azure", provider: "azure"},
+		{name: "vertex", provider: "vertex"},
+		{name: "gemini", provider: "gemini"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var hits int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				atomic.AddInt32(&hits, 1)
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(srv.Close)
+
+			reg := newRegistryWithConfig(t, config.ModelConfig{
+				Provider:        tc.provider,
+				BaseURL:         srv.URL,
+				AzureDeployment: "dep",
+				GCPProject:      "proj",
+				GCPLocation:     "us-central1",
+			})
+			// Only the models probe is enabled.
+			c := health.NewChecker(reg, cfg(false, true, false), newLogger())
+			stop := c.Start()
+			t.Cleanup(stop)
+
+			mh, ok := c.GetHealth("test-model")
+			if !ok {
+				t.Fatal("GetHealth returned false; probe cycle did not run")
+			}
+			if mh.ModelsOK != nil {
+				t.Errorf("ModelsOK = %v, want nil (not applicable for provider %s)", mh.ModelsOK, tc.provider)
+			}
+			if mh.Status != "unknown" {
+				t.Errorf("Status = %q, want %q (not-applicable must not degrade)", mh.Status, "unknown")
+			}
+			if got := atomic.LoadInt32(&hits); got != 0 {
+				t.Errorf("upstream received %d requests, want 0 (models-list is not applicable for %s)", got, tc.provider)
+			}
+		})
+	}
+}
+
+// TestChecker_EmbeddingsProbe_NotApplicable_LeavesNilNotDegraded verifies
+// that a functional probe against an embedding model whose provider has no
+// OpenAI-compatible embeddings endpoint (anthropic, gemini, vertex) leaves
+// FunctionalOK nil and derives status "unknown".
+func TestChecker_EmbeddingsProbe_NotApplicable_LeavesNilNotDegraded(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		provider string
+	}{
+		{name: "anthropic", provider: "anthropic"},
+		{name: "gemini", provider: "gemini"},
+		{name: "vertex", provider: "vertex"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var hits int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				atomic.AddInt32(&hits, 1)
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(srv.Close)
+
+			reg := newRegistryWithConfig(t, config.ModelConfig{
+				Provider:    tc.provider,
+				BaseURL:     srv.URL,
+				Type:        "embedding",
+				GCPProject:  "proj",
+				GCPLocation: "us-central1",
+			})
+			c := health.NewChecker(reg, cfg(false, false, true), newLogger())
+			stop := c.Start()
+			t.Cleanup(stop)
+
+			mh, ok := c.GetHealth("test-model")
+			if !ok {
+				t.Fatal("GetHealth returned false; probe cycle did not run")
+			}
+			if mh.FunctionalOK != nil {
+				t.Errorf("FunctionalOK = %v, want nil (embeddings not applicable for provider %s)", mh.FunctionalOK, tc.provider)
+			}
+			if mh.Status != "unknown" {
+				t.Errorf("Status = %q, want %q (not-applicable must not degrade)", mh.Status, "unknown")
+			}
+			if got := atomic.LoadInt32(&hits); got != 0 {
+				t.Errorf("upstream received %d requests, want 0 (embeddings is not applicable for %s)", got, tc.provider)
+			}
+		})
+	}
+}
+
+// TestChecker_FunctionalProbe_ModelTypeSkip_LeavesNilNotSuccess verifies
+// that model types with no meaningful functional probe (reranking, image,
+// audio_transcription, tts) leave FunctionalOK nil rather than recording a
+// success that never actually ran. This is a behaviour change: previously
+// these types were skipped by recording an implicit success.
+func TestChecker_FunctionalProbe_ModelTypeSkip_LeavesNilNotSuccess(t *testing.T) {
+	t.Parallel()
+
+	types := []string{"reranking", "image", "audio_transcription", "tts"}
+
+	for _, mt := range types {
+		t.Run(mt, func(t *testing.T) {
+			t.Parallel()
+
+			var hits int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				atomic.AddInt32(&hits, 1)
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(srv.Close)
+
+			reg := newRegistryWithConfig(t, config.ModelConfig{
+				Provider: "openai",
+				BaseURL:  srv.URL,
+				Type:     mt,
+			})
+			c := health.NewChecker(reg, cfg(false, false, true), newLogger())
+			stop := c.Start()
+			t.Cleanup(stop)
+
+			mh, ok := c.GetHealth("test-model")
+			if !ok {
+				t.Fatal("GetHealth returned false; probe cycle did not run")
+			}
+			if mh.FunctionalOK != nil {
+				t.Errorf("FunctionalOK = %v, want nil (model type %q is skipped)", mh.FunctionalOK, mt)
+			}
+			if mh.Status != "unknown" {
+				t.Errorf("Status = %q, want %q (a skipped probe must not be recorded as healthy)", mh.Status, "unknown")
+			}
+			if got := atomic.LoadInt32(&hits); got != 0 {
+				t.Errorf("upstream received %d requests, want 0 (type %q must be skipped before any request is sent)", got, mt)
+			}
+		})
+	}
+}
+
+// TestChecker_NotApplicableProbe_DoesNotBlockGenuineDegradation drives a
+// combined scenario through the real Checker: the models probe is not
+// applicable for azure (stays nil, "not checked"), while the functional
+// probe is applicable and genuinely fails. The not-applicable probe must
+// not mask the genuine failure — status must still be "degraded".
+func TestChecker_NotApplicableProbe_DoesNotBlockGenuineDegradation(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Azure's chat probe path always contains "/chat/completions"; fail
+		// it so the functional probe genuinely degrades the status.
+		if strings.Contains(r.URL.Path, "/chat/completions") {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	reg := newRegistryWithConfig(t, config.ModelConfig{
+		Provider:        "azure",
+		BaseURL:         srv.URL,
+		AzureDeployment: "dep",
+	})
+	// Models probe (not applicable for azure, stays nil) and functional
+	// probe (applicable, fails) are both enabled; health is off.
+	c := health.NewChecker(reg, cfg(false, true, true), newLogger())
+	stop := c.Start()
+	t.Cleanup(stop)
+
+	mh, ok := c.GetHealth("test-model")
+	if !ok {
+		t.Fatal("GetHealth returned false; probe cycle did not run")
+	}
+	if mh.ModelsOK != nil {
+		t.Errorf("ModelsOK = %v, want nil (not applicable for azure)", mh.ModelsOK)
+	}
+	if mh.FunctionalOK == nil || *mh.FunctionalOK {
+		t.Errorf("FunctionalOK = %v, want false (upstream returned 500)", mh.FunctionalOK)
+	}
+	if mh.Status != "degraded" {
+		t.Errorf("Status = %q, want %q — a not-applicable probe must not prevent a genuine failure from degrading status", mh.Status, "degraded")
+	}
+}
+
+// TestChecker_MultiDeployment_KeepsPerDeploymentKey verifies that a
+// multi-deployment model produces one health result per deployment, each
+// keyed as "modelName/deploymentName".
+func TestChecker_MultiDeployment_KeepsPerDeploymentKey(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	reg, err := proxy.NewRegistry([]config.ModelConfig{
+		{
+			Name:     "multi-model",
+			Strategy: "round-robin",
+			Deployments: []config.DeploymentConfig{
+				{Name: "dep-a", Provider: "openai", BaseURL: srv.URL},
+				{Name: "dep-b", Provider: "openai", BaseURL: srv.URL},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	c := health.NewChecker(reg, cfg(true, false, false), newLogger())
+	stop := c.Start()
+	t.Cleanup(stop)
+
+	for _, key := range []string{"multi-model/dep-a", "multi-model/dep-b"} {
+		mh, ok := c.GetHealth(key)
+		if !ok {
+			t.Fatalf("GetHealth(%q) returned false; probe did not run", key)
+		}
+		if mh.HealthOK == nil || !*mh.HealthOK {
+			t.Errorf("key %q: HealthOK = %v, want true", key, mh.HealthOK)
+		}
+	}
+
+	all := c.GetAllHealth()
+	if len(all) != 2 {
+		t.Fatalf("GetAllHealth() len = %d, want 2", len(all))
 	}
 }

--- a/internal/health/probe_request.go
+++ b/internal/health/probe_request.go
@@ -1,0 +1,253 @@
+package health
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/voidmind-io/voidllm/internal/jsonx"
+	"github.com/voidmind-io/voidllm/internal/proxy"
+)
+
+// ErrProbeNotApplicable is returned by BuildProbeRequest when intent has no
+// meaningful upstream equivalent for the target provider — for example a
+// models-list probe against Azure, Vertex, or Gemini, or an embeddings probe
+// against Anthropic or Gemini. Callers must treat this as "skip", not as a
+// failed probe: it must never be recorded as a successful check.
+var ErrProbeNotApplicable = errors.New("probe not applicable for this provider")
+
+// ProbeIntent identifies which kind of synthetic upstream request
+// BuildProbeRequest should construct.
+type ProbeIntent int
+
+const (
+	// IntentChat requests a minimal chat/completion-shaped call.
+	IntentChat ProbeIntent = iota
+	// IntentEmbeddings requests a minimal embeddings-shaped call.
+	IntentEmbeddings
+	// IntentModelsList requests the provider's model-listing endpoint.
+	IntentModelsList
+)
+
+// ProbeTarget carries the provider and model identity needed to build a
+// synthetic probe request via BuildProbeRequest. It is exported so that both
+// the periodic Checker (internal/health) and the on-demand connection tester
+// (internal/api/admin) can construct probe requests through the same
+// provider-aware logic; neither package re-implements provider URL, body, or
+// header rules.
+type ProbeTarget struct {
+	// ModelName is the canonical model name. Required for providers whose
+	// synthetic request must reference a model by name in the URL or body
+	// (anthropic, gemini, vertex); ignored by IntentModelsList.
+	ModelName string
+	// Provider selects the adapter: "" (or an OpenAI-compatible value such as
+	// "openai", "vllm", "ollama", "custom"), "anthropic", "azure", "gemini",
+	// or "vertex".
+	Provider string
+	// BaseURL is the upstream provider's base URL.
+	BaseURL string
+	// APIKey is the upstream provider's plaintext API key. Empty means no
+	// authentication header is set (aside from whatever the adapter itself
+	// always sets, e.g. anthropic-version).
+	APIKey string
+	// AzureDeployment is the Azure OpenAI deployment name. Required when
+	// Provider is "azure".
+	AzureDeployment string
+	// AzureAPIVersion overrides the default Azure OpenAI API version. Only
+	// meaningful when Provider is "azure".
+	AzureAPIVersion string
+	// GCPProject is the Google Cloud project ID. Required when Provider is
+	// "vertex".
+	GCPProject string
+	// GCPLocation is the Google Cloud region (e.g. "us-central1"). Required
+	// when Provider is "vertex".
+	GCPLocation string
+}
+
+// intentApplicable reports whether a probe of the given intent has a
+// meaningful upstream equivalent for provider. IntentChat always applies:
+// every provider adapter accepts a chat-shaped request.
+func intentApplicable(intent ProbeIntent, provider string) bool {
+	switch intent {
+	case IntentModelsList:
+		// Azure requires a per-deployment URL, Gemini/Vertex's TransformURL
+		// unconditionally builds a generateContent URL — neither has a
+		// generic model-listing endpoint reachable this way.
+		switch provider {
+		case "azure", "vertex", "gemini":
+			return false
+		}
+		return true
+	case IntentEmbeddings:
+		// Anthropic and Gemini/Vertex have no OpenAI-compatible embeddings
+		// endpoint. Azure does (it is OpenAI-compatible per deployment).
+		switch provider {
+		case "anthropic", "gemini", "vertex":
+			return false
+		}
+		return true
+	case IntentChat:
+		return true
+	default:
+		return false
+	}
+}
+
+// upstreamPathForIntent returns the OpenAI-shaped path passed to
+// Adapter.TransformURL (and used directly for nil-adapter providers).
+func upstreamPathForIntent(intent ProbeIntent) string {
+	switch intent {
+	case IntentChat:
+		return "chat/completions"
+	case IntentEmbeddings:
+		return "embeddings"
+	case IntentModelsList:
+		return "models"
+	default:
+		return ""
+	}
+}
+
+// probeModel builds the proxy.Model literal that adapters need for URL,
+// body, and header construction from a ProbeTarget.
+func probeModel(target ProbeTarget) proxy.Model {
+	return proxy.Model{
+		Name:            target.ModelName,
+		Provider:        target.Provider,
+		BaseURL:         target.BaseURL,
+		APIKey:          target.APIKey,
+		AzureDeployment: target.AzureDeployment,
+		AzureAPIVersion: target.AzureAPIVersion,
+		GCPProject:      target.GCPProject,
+		GCPLocation:     target.GCPLocation,
+	}
+}
+
+// probeRequestBody builds the fixed, synthetic OpenAI-shaped payload for
+// intent and runs it through adapter.TransformRequest when an adapter is
+// present. The payload never carries caller-supplied content — only static
+// placeholder text — so no prompt or response content is ever part of a
+// probe (zero-knowledge).
+//
+// For IntentChat against Azure, the deployment name is sent as the body's
+// model field rather than the canonical model name. This mirrors the
+// deployment-name substitution the real proxy path performs for Azure
+// requests and predates this function; it is preserved here unchanged.
+func probeRequestBody(intent ProbeIntent, target ProbeTarget, adapter proxy.Adapter, model proxy.Model) ([]byte, error) {
+	var payload map[string]any
+	switch intent {
+	case IntentChat:
+		upstreamModel := target.ModelName
+		if target.Provider == "azure" && target.AzureDeployment != "" {
+			upstreamModel = target.AzureDeployment
+		}
+		payload = map[string]any{
+			"model":      upstreamModel,
+			"messages":   []map[string]string{{"role": "user", "content": "hi"}},
+			"max_tokens": 1,
+		}
+	case IntentEmbeddings:
+		payload = map[string]any{
+			"model": target.ModelName,
+			"input": "test",
+		}
+	default:
+		return nil, fmt.Errorf("probe request body: intent %d has no synthetic payload", intent)
+	}
+
+	body, err := jsonx.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("marshal probe payload: %w", err)
+	}
+
+	if adapter == nil {
+		return body, nil
+	}
+
+	transformed, err := adapter.TransformRequest(body, model)
+	if err != nil {
+		return nil, fmt.Errorf("adapter transform request: %w", err)
+	}
+	return transformed, nil
+}
+
+// BuildProbeRequest constructs the *http.Request for probing target
+// according to intent, reusing the exact same provider adapters
+// (proxy.GetAdapter, Adapter.TransformURL, Adapter.TransformRequest,
+// Adapter.SetHeaders) that the proxy hot path uses for real traffic. This
+// guarantees a probe talks to each provider the same way a real request
+// would: Anthropic gets a Messages-API request at /v1/messages, Gemini gets
+// a generateContent request with x-goog-api-key, Azure gets a
+// deployment-scoped URL with api-key, and Vertex gets a project/location-
+// scoped URL with a Bearer token.
+//
+// It returns ErrProbeNotApplicable when intent has no meaningful upstream
+// equivalent for target.Provider; callers must treat that as "skip this
+// probe", never as a failed or successful check.
+//
+// The request body, when present, is a fixed synthetic payload (a one-word
+// user message, or a one-word embeddings input) — it never carries caller
+// content, and BuildProbeRequest never logs the body it constructs.
+func BuildProbeRequest(ctx context.Context, intent ProbeIntent, target ProbeTarget) (*http.Request, error) {
+	if !intentApplicable(intent, target.Provider) {
+		return nil, ErrProbeNotApplicable
+	}
+
+	adapter := proxy.GetAdapter(target.Provider)
+	model := probeModel(target)
+	upstreamPath := upstreamPathForIntent(intent)
+
+	var method string
+	var body []byte
+	if intent == IntentModelsList {
+		method = http.MethodGet
+	} else {
+		method = http.MethodPost
+		var err error
+		body, err = probeRequestBody(intent, target, adapter, model)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var rawURL string
+	if adapter != nil {
+		rawURL = adapter.TransformURL(target.BaseURL, upstreamPath, model)
+	} else {
+		rawURL = strings.TrimRight(target.BaseURL, "/") + "/" + upstreamPath
+	}
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, rawURL, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build probe request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	// Mirror setUpstreamHeaders' default: set a Bearer Authorization header
+	// before the adapter gets a chance to adjust it. This matters most for
+	// Vertex, whose GeminiAdapter.SetHeaders intentionally leaves the
+	// Authorization header untouched — the real (non-probe) request path
+	// relies on this default having already been set upstream of the
+	// adapter. Every other adapter that needs a different scheme removes
+	// this header itself in SetHeaders.
+	if target.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+target.APIKey)
+	}
+
+	if adapter != nil {
+		adapter.SetHeaders(req, model)
+	}
+
+	return req, nil
+}

--- a/internal/health/probe_request_test.go
+++ b/internal/health/probe_request_test.go
@@ -1,0 +1,451 @@
+package health_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/voidmind-io/voidllm/internal/health"
+)
+
+// readBody reads and JSON-decodes req.Body into a map. It fails the test if
+// the request has no body or the body is not valid JSON.
+func readBody(t *testing.T, req *http.Request) map[string]any {
+	t.Helper()
+	if req.Body == nil {
+		t.Fatal("request has no body")
+	}
+	raw, err := io.ReadAll(req.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal body %q: %v", raw, err)
+	}
+	return doc
+}
+
+// TestBuildProbeRequest_ChatByProvider verifies that BuildProbeRequest builds
+// a provider-correct URL, headers, and body for a chat probe against every
+// supported provider. This is the core assertion the provider-aware probe
+// work (issue #182) exists to guarantee: each provider is probed the same
+// way the real proxy hot path would talk to it.
+func TestBuildProbeRequest_ChatByProvider(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		// target is the ProbeTarget under test.
+		target health.ProbeTarget
+		// wantURL is the exact expected request URL.
+		wantURL string
+		// wantMethod is the exact expected HTTP method.
+		wantMethod string
+		// wantHeaders lists header/value pairs that must be present exactly.
+		wantHeaders map[string]string
+		// wantHeadersAbsent lists headers that must NOT be set (empty value).
+		wantHeadersAbsent []string
+		// checkBody, when non-nil, receives the JSON-decoded request body.
+		checkBody func(t *testing.T, body map[string]any)
+	}{
+		{
+			name: "anthropic",
+			target: health.ProbeTarget{
+				ModelName: "claude-3-opus",
+				Provider:  "anthropic",
+				BaseURL:   "https://api.anthropic.com",
+				APIKey:    "sk-ant-test-key",
+			},
+			wantURL:    "https://api.anthropic.com/v1/messages",
+			wantMethod: http.MethodPost,
+			wantHeaders: map[string]string{
+				"x-api-key":         "sk-ant-test-key",
+				"anthropic-version": "2023-06-01",
+			},
+			wantHeadersAbsent: []string{"Authorization"},
+			checkBody: func(t *testing.T, body map[string]any) {
+				t.Helper()
+				if _, ok := body["messages"]; !ok {
+					t.Error("body missing \"messages\"")
+				}
+				if _, ok := body["max_tokens"]; !ok {
+					t.Error("body missing \"max_tokens\" (Anthropic requires it)")
+				}
+				msgs, ok := body["messages"].([]any)
+				if !ok || len(msgs) != 1 {
+					t.Fatalf("messages = %#v, want a single-element array", body["messages"])
+				}
+				msg, ok := msgs[0].(map[string]any)
+				if !ok {
+					t.Fatalf("messages[0] = %#v, want an object", msgs[0])
+				}
+				if msg["role"] != "user" {
+					t.Errorf("messages[0].role = %v, want %q", msg["role"], "user")
+				}
+				// Anthropic's Messages API represents content as an array of
+				// typed blocks, not a bare string — this is the concrete
+				// structural difference from an OpenAI chat body.
+				if _, ok := msg["content"].([]any); !ok {
+					t.Errorf("messages[0].content = %#v (%T), want a content-block array (Messages-shaped, not OpenAI-shaped)", msg["content"], msg["content"])
+				}
+			},
+		},
+		{
+			name: "gemini",
+			target: health.ProbeTarget{
+				ModelName: "gemini-1.5-pro",
+				Provider:  "gemini",
+				BaseURL:   "https://generativelanguage.googleapis.com",
+				APIKey:    "goog-test-key",
+			},
+			wantURL:    "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent",
+			wantMethod: http.MethodPost,
+			wantHeaders: map[string]string{
+				"x-goog-api-key": "goog-test-key",
+			},
+			wantHeadersAbsent: []string{"Authorization"},
+			checkBody: func(t *testing.T, body map[string]any) {
+				t.Helper()
+				if _, ok := body["messages"]; ok {
+					t.Error("body has OpenAI-shaped \"messages\" field; want Gemini-shaped \"contents\"")
+				}
+				contents, ok := body["contents"].([]any)
+				if !ok || len(contents) == 0 {
+					t.Fatalf("contents = %#v, want a non-empty array", body["contents"])
+				}
+			},
+		},
+		{
+			name: "azure",
+			target: health.ProbeTarget{
+				ModelName:       "gpt-4o",
+				Provider:        "azure",
+				BaseURL:         "https://myres.openai.azure.com",
+				APIKey:          "azure-test-key",
+				AzureDeployment: "gpt4-deployment",
+			},
+			wantURL:    "https://myres.openai.azure.com/openai/deployments/gpt4-deployment/chat/completions?api-version=2024-10-21",
+			wantMethod: http.MethodPost,
+			wantHeaders: map[string]string{
+				"api-key": "azure-test-key",
+			},
+			wantHeadersAbsent: []string{"Authorization"},
+			checkBody: func(t *testing.T, body map[string]any) {
+				t.Helper()
+				// The probe body's model field carries the Azure deployment
+				// name, mirroring the real proxy path's substitution.
+				if body["model"] != "gpt4-deployment" {
+					t.Errorf("body.model = %v, want %q", body["model"], "gpt4-deployment")
+				}
+			},
+		},
+		{
+			name: "azure with explicit api version",
+			target: health.ProbeTarget{
+				ModelName:       "gpt-4o",
+				Provider:        "azure",
+				BaseURL:         "https://myres.openai.azure.com",
+				APIKey:          "azure-test-key",
+				AzureDeployment: "gpt4-deployment",
+				AzureAPIVersion: "2023-05-15",
+			},
+			wantURL:    "https://myres.openai.azure.com/openai/deployments/gpt4-deployment/chat/completions?api-version=2023-05-15",
+			wantMethod: http.MethodPost,
+			wantHeaders: map[string]string{
+				"api-key": "azure-test-key",
+			},
+			wantHeadersAbsent: []string{"Authorization"},
+		},
+		{
+			name: "vertex",
+			target: health.ProbeTarget{
+				ModelName:   "gemini-1.5-pro",
+				Provider:    "vertex",
+				BaseURL:     "https://us-central1-aiplatform.googleapis.com",
+				APIKey:      "vertex-bearer-token",
+				GCPProject:  "proj-123",
+				GCPLocation: "us-central1",
+			},
+			wantURL:    "https://us-central1-aiplatform.googleapis.com/v1/projects/proj-123/locations/us-central1/publishers/google/models/gemini-1.5-pro:generateContent",
+			wantMethod: http.MethodPost,
+			// The trap: unlike every other provider, Vertex authenticates
+			// with the default Bearer Authorization header that is set
+			// BEFORE the adapter runs — GeminiAdapter.SetHeaders
+			// deliberately leaves it untouched for provider "vertex".
+			wantHeaders: map[string]string{
+				"Authorization": "Bearer vertex-bearer-token",
+			},
+			checkBody: func(t *testing.T, body map[string]any) {
+				t.Helper()
+				if _, ok := body["contents"].([]any); !ok {
+					t.Errorf("contents = %#v, want a non-empty array", body["contents"])
+				}
+			},
+		},
+		{
+			name: "openai",
+			target: health.ProbeTarget{
+				ModelName: "gpt-4",
+				Provider:  "openai",
+				BaseURL:   "https://api.openai.com/v1",
+				APIKey:    "sk-openai-test-key",
+			},
+			wantURL:    "https://api.openai.com/v1/chat/completions",
+			wantMethod: http.MethodPost,
+			wantHeaders: map[string]string{
+				"Authorization": "Bearer sk-openai-test-key",
+			},
+			checkBody: func(t *testing.T, body map[string]any) {
+				t.Helper()
+				if body["model"] != "gpt-4" {
+					t.Errorf("body.model = %v, want %q", body["model"], "gpt-4")
+				}
+				if _, ok := body["messages"]; !ok {
+					t.Error("body missing \"messages\"")
+				}
+			},
+		},
+		{
+			name: "vllm",
+			target: health.ProbeTarget{
+				ModelName: "llama-3-70b",
+				Provider:  "vllm",
+				BaseURL:   "http://localhost:8000/v1",
+			},
+			wantURL:           "http://localhost:8000/v1/chat/completions",
+			wantMethod:        http.MethodPost,
+			wantHeadersAbsent: []string{"Authorization"},
+		},
+		{
+			name: "custom (unknown provider treated as passthrough)",
+			target: health.ProbeTarget{
+				ModelName: "custom-model",
+				Provider:  "custom",
+				BaseURL:   "http://localhost:9000",
+				APIKey:    "custom-key",
+			},
+			wantURL:    "http://localhost:9000/chat/completions",
+			wantMethod: http.MethodPost,
+			wantHeaders: map[string]string{
+				"Authorization": "Bearer custom-key",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := health.BuildProbeRequest(context.Background(), health.IntentChat, tc.target)
+			if err != nil {
+				t.Fatalf("BuildProbeRequest: %v", err)
+			}
+
+			if req.URL.String() != tc.wantURL {
+				t.Errorf("URL = %q, want %q", req.URL.String(), tc.wantURL)
+			}
+			if req.Method != tc.wantMethod {
+				t.Errorf("Method = %q, want %q", req.Method, tc.wantMethod)
+			}
+			for header, want := range tc.wantHeaders {
+				if got := req.Header.Get(header); got != want {
+					t.Errorf("header %q = %q, want %q", header, got, want)
+				}
+			}
+			for _, header := range tc.wantHeadersAbsent {
+				if got := req.Header.Get(header); got != "" {
+					t.Errorf("header %q = %q, want absent", header, got)
+				}
+			}
+			if tc.checkBody != nil {
+				tc.checkBody(t, readBody(t, req))
+			}
+		})
+	}
+}
+
+// TestBuildProbeRequest_Vertex_UsesBearerAuthorization is a focused,
+// standalone assertion of the Vertex authentication trap: SetHeaders for
+// provider "vertex" is a deliberate no-op, so BuildProbeRequest's own
+// default Bearer Authorization header (set before the adapter runs) is what
+// actually authenticates the probe. This must never be assumed away by a
+// future refactor.
+func TestBuildProbeRequest_Vertex_UsesBearerAuthorization(t *testing.T) {
+	t.Parallel()
+
+	req, err := health.BuildProbeRequest(context.Background(), health.IntentChat, health.ProbeTarget{
+		ModelName:   "gemini-1.5-flash",
+		Provider:    "vertex",
+		BaseURL:     "https://us-central1-aiplatform.googleapis.com",
+		APIKey:      "vertex-token",
+		GCPProject:  "proj-xyz",
+		GCPLocation: "us-central1",
+	})
+	if err != nil {
+		t.Fatalf("BuildProbeRequest: %v", err)
+	}
+
+	got := req.Header.Get("Authorization")
+	want := "Bearer vertex-token"
+	if got != want {
+		t.Errorf("Authorization = %q, want %q", got, want)
+	}
+}
+
+// TestBuildProbeRequest_ModelsList_Applicability verifies which providers
+// have a meaningful models-list probe and, where applicable, that the built
+// request targets the right endpoint.
+func TestBuildProbeRequest_ModelsList_Applicability(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		provider    string
+		wantErr     error
+		wantURLHas  string
+		wantURLTail string
+	}{
+		{name: "azure not applicable", provider: "azure", wantErr: health.ErrProbeNotApplicable},
+		{name: "vertex not applicable", provider: "vertex", wantErr: health.ErrProbeNotApplicable},
+		{name: "gemini not applicable", provider: "gemini", wantErr: health.ErrProbeNotApplicable},
+		{name: "anthropic applicable", provider: "anthropic", wantURLTail: "/models"},
+		{name: "openai applicable", provider: "openai", wantURLTail: "/models"},
+		{name: "vllm applicable", provider: "vllm", wantURLTail: "/models"},
+		{name: "custom applicable", provider: "custom", wantURLTail: "/models"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			target := health.ProbeTarget{
+				ModelName:   "some-model",
+				Provider:    tc.provider,
+				BaseURL:     "https://upstream.example.com",
+				APIKey:      "key",
+				GCPProject:  "proj",
+				GCPLocation: "us-central1",
+			}
+			req, err := health.BuildProbeRequest(context.Background(), health.IntentModelsList, target)
+
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("err = %v, want %v", err, tc.wantErr)
+				}
+				if req != nil {
+					t.Error("request must be nil when ErrProbeNotApplicable is returned")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("BuildProbeRequest: %v", err)
+			}
+			if req.Method != http.MethodGet {
+				t.Errorf("Method = %q, want GET", req.Method)
+			}
+			if !strings.HasSuffix(req.URL.String(), tc.wantURLTail) {
+				t.Errorf("URL = %q, want suffix %q", req.URL.String(), tc.wantURLTail)
+			}
+			if req.Body != nil {
+				t.Error("models-list probe must not have a request body")
+			}
+		})
+	}
+}
+
+// TestBuildProbeRequest_Embeddings_Applicability verifies which providers
+// have a meaningful embeddings probe and, where applicable, that the built
+// request carries an embeddings-shaped body.
+func TestBuildProbeRequest_Embeddings_Applicability(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		provider string
+		wantErr  error
+	}{
+		{name: "anthropic not applicable", provider: "anthropic", wantErr: health.ErrProbeNotApplicable},
+		{name: "gemini not applicable", provider: "gemini", wantErr: health.ErrProbeNotApplicable},
+		{name: "vertex not applicable", provider: "vertex", wantErr: health.ErrProbeNotApplicable},
+		{name: "azure applicable", provider: "azure"},
+		{name: "openai applicable", provider: "openai"},
+		{name: "vllm applicable", provider: "vllm"},
+		{name: "custom applicable", provider: "custom"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			target := health.ProbeTarget{
+				ModelName:       "embed-model",
+				Provider:        tc.provider,
+				BaseURL:         "https://upstream.example.com",
+				APIKey:          "key",
+				AzureDeployment: "embed-deployment",
+				GCPProject:      "proj",
+				GCPLocation:     "us-central1",
+			}
+			req, err := health.BuildProbeRequest(context.Background(), health.IntentEmbeddings, target)
+
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("err = %v, want %v", err, tc.wantErr)
+				}
+				if req != nil {
+					t.Error("request must be nil when ErrProbeNotApplicable is returned")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("BuildProbeRequest: %v", err)
+			}
+			if req.Method != http.MethodPost {
+				t.Errorf("Method = %q, want POST", req.Method)
+			}
+			body := readBody(t, req)
+			if _, ok := body["input"]; !ok {
+				t.Error("embeddings body missing \"input\"")
+			}
+			// Unlike the chat probe, the embeddings probe does not
+			// substitute the Azure deployment name for the model field.
+			if body["model"] != "embed-model" {
+				t.Errorf("body.model = %v, want %q", body["model"], "embed-model")
+			}
+		})
+	}
+}
+
+// TestBuildProbeRequest_ChatAlwaysApplicable verifies that IntentChat never
+// returns ErrProbeNotApplicable, for any provider.
+func TestBuildProbeRequest_ChatAlwaysApplicable(t *testing.T) {
+	t.Parallel()
+
+	for _, provider := range []string{"", "openai", "vllm", "ollama", "custom", "anthropic", "azure", "gemini", "vertex"} {
+		provider := provider
+		t.Run(provider, func(t *testing.T) {
+			t.Parallel()
+
+			target := health.ProbeTarget{
+				ModelName:       "some-model",
+				Provider:        provider,
+				BaseURL:         "https://upstream.example.com",
+				APIKey:          "key",
+				AzureDeployment: "dep",
+				GCPProject:      "proj",
+				GCPLocation:     "us-central1",
+			}
+			_, err := health.BuildProbeRequest(context.Background(), health.IntentChat, target)
+			if err != nil {
+				t.Errorf("BuildProbeRequest(IntentChat, provider=%q): %v", provider, err)
+			}
+		})
+	}
+}

--- a/internal/health/probe_request_test.go
+++ b/internal/health/probe_request_test.go
@@ -359,6 +359,30 @@ func TestBuildProbeRequest_ModelsList_Applicability(t *testing.T) {
 	}
 }
 
+// TestBuildProbeRequest_ModelsList_AnthropicUsesV1Prefix verifies that a
+// models-list probe against provider "anthropic" requests the documented
+// Anthropic endpoint /v1/models — not the OpenAI-style /models path that a
+// naive base+"/models" concatenation would produce. The real Anthropic base
+// URL (https://api.anthropic.com) carries no /v1 segment itself, so this
+// prefix only appears in the built request if AnthropicAdapter.TransformURL
+// maps the "models" path explicitly (see internal/proxy/anthropic.go).
+func TestBuildProbeRequest_ModelsList_AnthropicUsesV1Prefix(t *testing.T) {
+	t.Parallel()
+
+	target := health.ProbeTarget{
+		Provider: "anthropic",
+		BaseURL:  "https://api.anthropic.com",
+		APIKey:   "key",
+	}
+	req, err := health.BuildProbeRequest(context.Background(), health.IntentModelsList, target)
+	if err != nil {
+		t.Fatalf("BuildProbeRequest: %v", err)
+	}
+	if !strings.HasSuffix(req.URL.String(), "/v1/models") {
+		t.Errorf("URL = %q, want suffix %q", req.URL.String(), "/v1/models")
+	}
+}
+
 // TestBuildProbeRequest_Embeddings_Applicability verifies which providers
 // have a meaningful embeddings probe and, where applicable, that the built
 // request carries an embeddings-shaped body.

--- a/internal/proxy/anthropic.go
+++ b/internal/proxy/anthropic.go
@@ -590,11 +590,20 @@ func (a *AnthropicAdapter) TransformRequest(body []byte, _ Model) ([]byte, error
 }
 
 // TransformURL maps the OpenAI endpoint path to the equivalent Anthropic path.
-// chat/completions becomes /v1/messages; all other paths are forwarded as-is.
+// chat/completions becomes /v1/messages and models becomes /v1/models — both
+// are real Anthropic API endpoints. The models mapping is exercised by the
+// health-check / connection-test models-list probe (see
+// internal/health.BuildProbeRequest) and by any direct, non-GET /v1/models
+// request that reaches the proxy hot path (GET /v1/models is served locally
+// by ModelsHandler and never reaches this adapter). All other paths are
+// forwarded as-is under the configured base URL.
 func (a *AnthropicAdapter) TransformURL(baseURL, upstreamPath string, _ Model) string {
 	base := strings.TrimRight(baseURL, "/")
-	if upstreamPath == "chat/completions" {
+	switch upstreamPath {
+	case "chat/completions":
 		return base + "/v1/messages"
+	case "models":
+		return base + "/v1/models"
 	}
 	return base + "/" + upstreamPath
 }

--- a/internal/proxy/anthropic_test.go
+++ b/internal/proxy/anthropic_test.go
@@ -2899,7 +2899,7 @@ func TestAnthropicTransformURL(t *testing.T) {
 			}
 
 			// Guard against double slashes in the result (common trailing-slash bug).
-			if strings.Contains(got, "//") && !strings.HasPrefix(got, "https://") {
+			if strings.Contains(got, "//") {
 				// Allow the protocol scheme's "//"; check after stripping it.
 				noScheme := strings.SplitN(got, "://", 2)
 				if len(noScheme) == 2 && strings.Contains(noScheme[1], "//") {

--- a/internal/proxy/anthropic_test.go
+++ b/internal/proxy/anthropic_test.go
@@ -2873,6 +2873,18 @@ func TestAnthropicTransformURL(t *testing.T) {
 			upstreamPath: "embeddings",
 			wantURL:      "https://api.anthropic.com/embeddings",
 		},
+		{
+			name:         "models maps to /v1/models",
+			baseURL:      "https://api.anthropic.com",
+			upstreamPath: "models",
+			wantURL:      "https://api.anthropic.com/v1/models",
+		},
+		{
+			name:         "trailing slash on base with models path does not produce double slash",
+			baseURL:      "https://api.anthropic.com/",
+			upstreamPath: "models",
+			wantURL:      "https://api.anthropic.com/v1/models",
+		},
 	}
 
 	for _, tc := range tests {

--- a/ui/src/hooks/useDashboardStats.ts
+++ b/ui/src/hooks/useDashboardStats.ts
@@ -21,6 +21,7 @@ export interface DashboardStats {
   models_healthy: number
   models_unhealthy: number
   models_degraded: number
+  models_unknown: number
 }
 
 export function useDashboardStats() {

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -281,6 +281,16 @@ function IconXCircle() {
   )
 }
 
+function IconHelpCircle() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="10" />
+      <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  )
+}
+
 // ---------------------------------------------------------------------------
 // DashboardPage
 // ---------------------------------------------------------------------------
@@ -447,12 +457,13 @@ export default function DashboardPage() {
 
         {/* Model Health summary — only shown when at least one model has health data */}
         {!statsLoading &&
-          (stats?.models_healthy ?? 0) + (stats?.models_degraded ?? 0) + (stats?.models_unhealthy ?? 0) > 0 && (
+          (stats?.models_healthy ?? 0) + (stats?.models_degraded ?? 0) + (stats?.models_unhealthy ?? 0) +
+            (stats?.models_unknown ?? 0) > 0 && (
             <div>
               <h2 className="text-sm font-medium text-text-tertiary uppercase tracking-wider mb-3">
                 Model Health
               </h2>
-              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
                 <StatCard
                   label="Healthy"
                   value={stats?.models_healthy ?? 0}
@@ -470,6 +481,12 @@ export default function DashboardPage() {
                   value={stats?.models_unhealthy ?? 0}
                   icon={<IconXCircle />}
                   iconColor="red"
+                />
+                <StatCard
+                  label="Unknown"
+                  value={stats?.models_unknown ?? 0}
+                  icon={<IconHelpCircle />}
+                  iconColor="blue"
                 />
               </div>
             </div>

--- a/ui/src/pages/ModelsPage.tsx
+++ b/ui/src/pages/ModelsPage.tsx
@@ -554,13 +554,19 @@ function CreateModelDialog({ open, onClose }: CreateModelDialogProps) {
     setTesting(true)
     setTestResult(null)
     try {
+      const body: Record<string, string> = {
+        provider,
+        base_url: baseUrl.trim(),
+        api_key: apiKey.trim(),
+      }
+      if (name.trim()) body.model_name = name.trim()
+      if (isAzure) {
+        if (azureDeployment.trim()) body.azure_deployment = azureDeployment.trim()
+        if (azureApiVersion.trim()) body.azure_api_version = azureApiVersion.trim()
+      }
       const res = await apiClient<{ success: boolean; message: string }>('/models/test-connection', {
         method: 'POST',
-        body: JSON.stringify({
-          provider,
-          base_url: baseUrl.trim(),
-          api_key: apiKey.trim(),
-        }),
+        body: JSON.stringify(body),
       })
       setTestResult(res)
     } catch (err) {


### PR DESCRIPTION
Closes #182.

The health checker sent OpenAI-shaped requests to every upstream - a POST to `{base}/chat/completions` with an OpenAI body and a GET to `{base}/models` - regardless of who was on the other end. Anthropic wants `/v1/messages` with a Messages body, Gemini `/v1beta/models/{model}:generateContent` with an `x-goog-api-key`, Azure a deployment-scoped path with an `api-key` header, Vertex a project-scoped path. Probes against those providers therefore failed permanently: a wrong `degraded` badge, a wrong dashboard tile, and a billable upstream call on every interval.

The same assumption existed a second time in the admin connection test, where it was more visible - an operator adding a correctly configured Anthropic or Gemini model clicked "Test connection" and was told it was broken.

## Approach

Rather than adding a third copy of provider knowledge, both callers now build their request through the existing proxy adapters, which already encode it and carry their own table tests. Vertex needed care: `GeminiAdapter.SetHeaders` deliberately leaves `Authorization` alone because the real request path sets it earlier, so the builder has to supply it or vertex probes go out unauthenticated.

Probes with no equivalent for a provider - a models list on Azure, embeddings on Anthropic - now report not-applicable instead of failing. The existing model-type skips reported *success* for a probe that never ran; they leave the field unset now, which the status derivation already treats as unchecked.

## What review turned up along the way

- **The Anthropic models probe was still wrong** after the first pass: the adapter only remapped `chat/completions`, so a models list hit `api.anthropic.com/models` while the real endpoint is `/v1/models`. Only probes are affected - `GET /v1/models` is answered by VoidLLM itself and never reaches an adapter.
- **The connection test accepted vertex and gemini without the identity fields** those providers need in the URL, building a path with empty segments and returning a confusing 404. It now refuses up front, naming the missing field, without any upstream call.
- **`ModelHealth` had one `LastError` shared by three probe levels**, so a passing probe erased a failing one's message, and a probe that became not-applicable kept showing a stale failure. Each level owns its error now; `LastError` stays in the JSON contract, derived with the same precedence as the status.
- **A lost-update race in `runOne`.** Three probe levels run on independent tickers and did an unsynchronized load-copy-mutate-store, so a level finishing second could silently revert a genuine failure recorded by another - reporting healthy with no error. Pre-existing, but it defeated the guarantee the per-level errors were introduced to provide. A mutex now serializes the update; it is never held across network I/O, and reads stay lock-free because the router calls `GetHealth` on the request path.
- **The dashboard hid model health entirely** once statuses became `unknown`, since it counted only healthy/degraded/unhealthy and the UI dropped the section when those summed to zero. Unknown is counted and shown.

## Verification

Per-provider tests assert the actual request URL, auth header and body shape - no health test did either before. The adapters' own table tests are the oracle. Every central claim was mutation-checked: the Anthropic URL, the vertex `Authorization` header, the vertex identity validation, `deriveLastError` precedence, the not-applicable error clearing, and the mutex - removing each one turns the corresponding test red, and the concurrency test fails on every run without the lock.

Full suite and `-race` on health, router, proxy and admin are green; UI typecheck, lint, 359 tests and production build likewise.