### PR TITLE
fix(ui): render the Select menu in a portal so tables stop clipping it

### DIFF
--- a/ui/src/components/ui/Dialog.tsx
+++ b/ui/src/components/ui/Dialog.tsx
@@ -76,6 +76,11 @@ export function Dialog({
 
   const handlePanelKeyDown = (e: React.KeyboardEvent) => {
     if (e.key !== 'Tab') return
+    // A descendant may already have handled Tab and moved focus deliberately -
+    // a portalled Select menu does exactly that, and its events still reach us
+    // by bubbling through the React tree. Re-running the trap afterwards would
+    // undo that focus move. The Escape handler above uses the same guard.
+    if (e.defaultPrevented) return
     const focusable = panelRef.current?.querySelectorAll<HTMLElement>(
       'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
     )

--- a/ui/src/components/ui/Select.test.tsx
+++ b/ui/src/components/ui/Select.test.tsx
@@ -658,18 +658,29 @@ describe('Select', () => {
     // kept the fixed max-h-60 class (240px) regardless, which could
     // overflow a viewport a Dialog's body-scroll-lock made unreachable).
     //
-    // TRIGGER_GAP (4) and VIEWPORT_MARGIN (8) below mirror the
-    // module-private constants of the same name in Select.tsx (not
-    // exported). Expected values are derived from the stubbed rect and
-    // these constants rather than hardcoded, so a future change to the
-    // margins fails these tests loudly instead of leaving them silently
-    // out of sync.
+    // TRIGGER_GAP (4), VIEWPORT_MARGIN (8), MIN_MENU_HEIGHT (96) and
+    // ESTIMATED_MENU_HEIGHT (240) below mirror the module-private
+    // constants of the same names in Select.tsx (not exported). Expected
+    // values are derived from the stubbed rect and these constants rather
+    // than hardcoded, so a future change to the margins or the clamp band
+    // fails these tests loudly instead of leaving them silently out of
+    // sync. The inline maxHeight style is clamped into
+    // [MIN_MENU_HEIGHT, ESTIMATED_MENU_HEIGHT]: it tracks the measured
+    // available space only inside that band, floors at MIN_MENU_HEIGHT
+    // when there is little or no room on either side, and caps at
+    // ESTIMATED_MENU_HEIGHT (matching the max-h-60 class) when there is
+    // far more room than that.
     // -------------------------------------------------------------------
 
     it('clamps the below-placed menu maxHeight to the measured space below, not an unbounded value', async () => {
       const TRIGGER_GAP = 4
       const VIEWPORT_MARGIN = 8
-      const innerHeight = 800
+      const MIN_MENU_HEIGHT = 96
+      const ESTIMATED_MENU_HEIGHT = 240
+      // innerHeight is chosen so spaceBelow lands strictly inside the
+      // clamp band — proving the height tracks the measured space rather
+      // than just hitting the floor or the cap.
+      const innerHeight = 300
       const rect = { left: 40, top: 100, right: 240, bottom: 130, width: 200, height: 30 }
       vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(innerHeight)
       renderSelect()
@@ -679,15 +690,27 @@ describe('Select', () => {
       const listbox = screen.getByRole('listbox')
 
       const spaceBelow = innerHeight - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN
+      // Sanity check on the fixture: this only proves tracking (not just
+      // the floor or the cap) if spaceBelow is strictly inside the band.
+      expect(spaceBelow).toBeGreaterThan(MIN_MENU_HEIGHT)
+      expect(spaceBelow).toBeLessThan(ESTIMATED_MENU_HEIGHT)
       expect(listbox.style.top).toBe(`${rect.bottom + TRIGGER_GAP}px`)
-      expect(listbox.style.maxHeight).toBe(`${spaceBelow}px`)
+      expect(listbox.style.maxHeight).toBe(
+        `${Math.min(Math.max(spaceBelow, MIN_MENU_HEIGHT), ESTIMATED_MENU_HEIGHT)}px`,
+      )
     })
 
-    it('clamps the above-flipped menu maxHeight to the measured space above', async () => {
+    it('caps the maxHeight at ESTIMATED_MENU_HEIGHT when the viewport offers far more room than that', async () => {
+      // The inline maxHeight style would otherwise beat the max-h-60
+      // class in the cascade and let the menu grow past 240px on a tall
+      // viewport — this is what pins the cap back in place after the
+      // move from a class-only cap to an inline style.
       const TRIGGER_GAP = 4
       const VIEWPORT_MARGIN = 8
-      const innerHeight = 400
-      const rect = { left: 40, top: 350, right: 240, bottom: 380, width: 200, height: 30 }
+      const MIN_MENU_HEIGHT = 96
+      const ESTIMATED_MENU_HEIGHT = 240
+      const innerHeight = 1000
+      const rect = { left: 40, top: 100, right: 240, bottom: 130, width: 200, height: 30 }
       vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(innerHeight)
       renderSelect()
       const trigger = screen.getByRole('combobox')
@@ -695,10 +718,48 @@ describe('Select', () => {
       await userEvent.click(trigger)
       const listbox = screen.getByRole('listbox')
 
+      const spaceBelow = innerHeight - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN
+      // Sanity check on the fixture: this only proves the cap survived if
+      // the raw available space genuinely exceeds it.
+      expect(spaceBelow).toBeGreaterThan(ESTIMATED_MENU_HEIGHT)
+      expect(listbox.style.top).toBe(`${rect.bottom + TRIGGER_GAP}px`)
+      expect(listbox.style.maxHeight).toBe(
+        `${Math.min(Math.max(spaceBelow, MIN_MENU_HEIGHT), ESTIMATED_MENU_HEIGHT)}px`,
+      )
+    })
+
+    it('clamps the above-flipped menu maxHeight to the measured space above', async () => {
+      const TRIGGER_GAP = 4
+      const VIEWPORT_MARGIN = 8
+      const MIN_MENU_HEIGHT = 96
+      const ESTIMATED_MENU_HEIGHT = 240
+      // innerHeight/rect are chosen so spaceBelow doesn't fit the
+      // pre-paint estimate (triggering the flip to "above") while
+      // spaceAbove lands strictly inside the clamp band.
+      const innerHeight = 400
+      const rect = { left: 40, top: 200, right: 240, bottom: 230, width: 200, height: 30 }
+      vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(innerHeight)
+      renderSelect()
+      const trigger = screen.getByRole('combobox')
+      stubRect(trigger, rect)
+      await userEvent.click(trigger)
+      const listbox = screen.getByRole('listbox')
+
+      const spaceBelow = innerHeight - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN
       const spaceAbove = rect.top - TRIGGER_GAP - VIEWPORT_MARGIN
+      // Sanity check on the fixture: the flip only happens because below
+      // doesn't fit the pre-paint estimate and above has more room; the
+      // test only proves tracking if spaceAbove is strictly inside the
+      // clamp band.
+      expect(spaceBelow).toBeLessThan(ESTIMATED_MENU_HEIGHT)
+      expect(spaceAbove).toBeGreaterThan(spaceBelow)
+      expect(spaceAbove).toBeGreaterThan(MIN_MENU_HEIGHT)
+      expect(spaceAbove).toBeLessThan(ESTIMATED_MENU_HEIGHT)
       expect(listbox.style.top).toBe('')
       expect(listbox.style.bottom).toBe(`${innerHeight - rect.top + TRIGGER_GAP}px`)
-      expect(listbox.style.maxHeight).toBe(`${spaceAbove}px`)
+      expect(listbox.style.maxHeight).toBe(
+        `${Math.min(Math.max(spaceAbove, MIN_MENU_HEIGHT), ESTIMATED_MENU_HEIGHT)}px`,
+      )
     })
 
     it('flips above and clamps to that side when the menu fits on neither side', async () => {
@@ -706,11 +767,15 @@ describe('Select', () => {
       // under the previous logic ("above" was only chosen when space
       // fit above that estimate) this would have fallen through to
       // "below" with no clamp at all — a fixed max-h-60 (240px) menu
-      // inside a 200px-tall viewport, overflowing it.
+      // inside a short viewport, overflowing it. innerHeight/rect are
+      // chosen so spaceAbove (the side picked) still lands strictly
+      // inside the clamp band, proving it tracks rather than just floors.
       const TRIGGER_GAP = 4
       const VIEWPORT_MARGIN = 8
-      const innerHeight = 200
-      const rect = { left: 40, top: 100, right: 240, bottom: 110, width: 200, height: 10 }
+      const MIN_MENU_HEIGHT = 96
+      const ESTIMATED_MENU_HEIGHT = 240
+      const innerHeight = 300
+      const rect = { left: 40, top: 150, right: 240, bottom: 170, width: 200, height: 20 }
       vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(innerHeight)
       renderSelect()
       const trigger = screen.getByRole('combobox')
@@ -721,21 +786,65 @@ describe('Select', () => {
       const spaceBelow = innerHeight - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN
       const spaceAbove = rect.top - TRIGGER_GAP - VIEWPORT_MARGIN
       // Sanity check on the fixture itself: this test only pins down the
-      // "neither fits, pick the bigger side" branch if above truly has
-      // more room than below.
+      // "neither fits, pick the bigger side" branch if neither side fits
+      // the pre-paint estimate, above truly has more room than below, and
+      // above lands inside the clamp band (not just at its floor).
+      expect(spaceBelow).toBeLessThan(ESTIMATED_MENU_HEIGHT)
+      expect(spaceAbove).toBeLessThan(ESTIMATED_MENU_HEIGHT)
       expect(spaceAbove).toBeGreaterThan(spaceBelow)
+      expect(spaceAbove).toBeGreaterThan(MIN_MENU_HEIGHT)
 
       // Flipped above (bottom set, top unset) ...
       expect(listbox.style.top).toBe('')
       expect(listbox.style.bottom).toBe(`${innerHeight - rect.top + TRIGGER_GAP}px`)
       // ...and clamped to the larger (above) side's space, not left
       // unbounded at the old fixed 240px.
-      expect(listbox.style.maxHeight).toBe(`${spaceAbove}px`)
+      expect(listbox.style.maxHeight).toBe(
+        `${Math.min(Math.max(spaceAbove, MIN_MENU_HEIGHT), ESTIMATED_MENU_HEIGHT)}px`,
+      )
+    })
+
+    it('floors the maxHeight at MIN_MENU_HEIGHT when the available space on both sides is at or below zero', async () => {
+      // A very short viewport (or a trigger scrolled partly toward an
+      // edge but not far enough to count as fully out of view — see the
+      // "closes the dropdown when the trigger scrolls above/below the
+      // viewport" tests above for the fully-out-of-view case) can leave
+      // zero or negative space on both sides. The menu must still get a
+      // usable, visible height rather than staying open with maxHeight: 0.
+      const TRIGGER_GAP = 4
+      const VIEWPORT_MARGIN = 8
+      const MIN_MENU_HEIGHT = 96
+      const ESTIMATED_MENU_HEIGHT = 240
+      const innerHeight = 20
+      const rect = { left: 0, top: 10, right: 100, bottom: 15, width: 100, height: 5 }
+      vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(innerHeight)
+      renderSelect()
+      const trigger = screen.getByRole('combobox')
+      stubRect(trigger, rect)
+      await userEvent.click(trigger)
+      const listbox = screen.getByRole('listbox')
+
+      const spaceBelow = innerHeight - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN
+      const spaceAbove = rect.top - TRIGGER_GAP - VIEWPORT_MARGIN
+      // Sanity check on the fixture: both sides must be at or below zero
+      // for this to actually exercise the floor.
+      expect(spaceBelow).toBeLessThanOrEqual(0)
+      expect(spaceAbove).toBeLessThanOrEqual(0)
+      // Whichever side has (marginally) more room is the one the
+      // component picks and clamps — here that is "above", since
+      // spaceAbove > spaceBelow.
+      expect(listbox.style.top).toBe('')
+      expect(listbox.style.bottom).toBe(`${innerHeight - rect.top + TRIGGER_GAP}px`)
+      expect(listbox.style.maxHeight).toBe(
+        `${Math.min(Math.max(Math.max(spaceAbove, spaceBelow), MIN_MENU_HEIGHT), ESTIMATED_MENU_HEIGHT)}px`,
+      )
     })
 
     it('recomputes the maxHeight clamp on resize and shrinks it when the viewport shrinks', async () => {
       const TRIGGER_GAP = 4
       const VIEWPORT_MARGIN = 8
+      const MIN_MENU_HEIGHT = 96
+      const ESTIMATED_MENU_HEIGHT = 240
       const rect = { left: 40, top: 100, right: 240, bottom: 130, width: 200, height: 30 }
       const innerHeightSpy = vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(800)
       renderSelect()
@@ -743,8 +852,13 @@ describe('Select', () => {
       stubRect(trigger, rect)
       await userEvent.click(trigger)
       const listbox = screen.getByRole('listbox')
+      // At innerHeight 800 the raw available space is far past the cap,
+      // so this leg proves the cap holds at the module boundary rather
+      // than tracking an unbounded value.
+      const spaceBelowTall = 800 - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN
+      expect(spaceBelowTall).toBeGreaterThan(ESTIMATED_MENU_HEIGHT)
       expect(listbox.style.maxHeight).toBe(
-        `${800 - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN}px`,
+        `${Math.min(Math.max(spaceBelowTall, MIN_MENU_HEIGHT), ESTIMATED_MENU_HEIGHT)}px`,
       )
 
       innerHeightSpy.mockReturnValue(300)
@@ -752,9 +866,15 @@ describe('Select', () => {
       // The re-measure reads the menu's real (unstubbed) height from
       // menuRef, which jsdom reports as 0 — still enough to exercise the
       // same "clamp to available space" path, just recomputed against the
-      // shrunk viewport.
+      // shrunk viewport. At innerHeight 300 the raw available space now
+      // lands inside the clamp band, so this leg proves the height
+      // actually follows the shrunk viewport down instead of staying
+      // pinned at the earlier cap.
+      const spaceBelowShrunk = 300 - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN
+      expect(spaceBelowShrunk).toBeGreaterThan(MIN_MENU_HEIGHT)
+      expect(spaceBelowShrunk).toBeLessThan(ESTIMATED_MENU_HEIGHT)
       expect(listbox.style.maxHeight).toBe(
-        `${300 - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN}px`,
+        `${Math.min(Math.max(spaceBelowShrunk, MIN_MENU_HEIGHT), ESTIMATED_MENU_HEIGHT)}px`,
       )
     })
   })
@@ -890,14 +1010,13 @@ describe('Select', () => {
       fireEvent.keyDown(searchInput, { key: 'Tab' })
 
       expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
-      expect(document.activeElement).toBe(trigger)
       // The bug this guards against: without the defaultPrevented check,
       // the Dialog's trap would see the Select's own focus move land on
       // `last` (the trigger — the only Select-related element the panel's
-      // query can see) and wrap it straight back to `first`.
-      expect(document.activeElement).not.toBe(
-        screen.getByRole('button', { name: 'Close' }),
-      )
+      // query can see) and wrap it straight back to `first` (the Close
+      // button). Asserting activeElement is the trigger already proves it
+      // isn't the Close button, since they are distinct elements.
+      expect(document.activeElement).toBe(trigger)
     })
 
     it('Tab still wraps from the last focusable to the first when a Select is present but closed (guard does not disable the trap in general)', async () => {

--- a/ui/src/components/ui/Select.test.tsx
+++ b/ui/src/components/ui/Select.test.tsx
@@ -2,9 +2,12 @@ import { createRef } from 'react'
 import type { ComponentProps } from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { Select } from './Select'
 import type { SelectOption } from './Select'
+import { Table } from './Table'
+import type { Column } from './Table'
+import { Dialog } from './Dialog'
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -23,6 +26,30 @@ function renderSelect(props: Partial<ComponentProps<typeof Select>> = {}) {
     onChange: vi.fn(),
   }
   return render(<Select {...defaults} {...props} />)
+}
+
+// jsdom's getBoundingClientRect always returns an all-zero rect, so any test
+// that asserts a real inline `left`/`top`/`bottom`/`width` value on the
+// portalled menu must stub the trigger's (or menu's) rect explicitly —
+// otherwise the assertion would pass vacuously against a rect that is all
+// zeros regardless of what the positioning code actually does.
+function stubRect(
+  el: Element,
+  rect: {
+    left: number
+    top: number
+    right: number
+    bottom: number
+    width: number
+    height: number
+  },
+) {
+  vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+    ...rect,
+    x: rect.left,
+    y: rect.top,
+    toJSON: () => rect,
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -461,6 +488,267 @@ describe('Select', () => {
     it('additional className merged on wrapper element', () => {
       const { container } = renderSelect({ className: 'my-custom-class' })
       expect(container.firstElementChild?.className).toContain('my-custom-class')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Portal (menu renders into document.body via ReactDOM.createPortal —
+  // GitHub #183). Escape, focus return after selection, arrow-key navigation
+  // and the search box are already exercised through role queries in the
+  // suites above (Open/Close, Focus Management, Keyboard Navigation,
+  // Searchable) and behave identically now that the menu is portalled —
+  // not duplicated here.
+  // ---------------------------------------------------------------------------
+
+  describe('Portal', () => {
+    it('menu is rendered into document.body, not inside the component container', async () => {
+      // Same assertion shape as Dialog.test.tsx's "Portal" describe
+      // (lines ~274-282): absent from the local render container, present
+      // under document.body.
+      const { container } = renderSelect()
+      await userEvent.click(screen.getByRole('combobox'))
+      expect(container.querySelector('[role="listbox"]')).toBeNull()
+      expect(document.body.querySelector('[role="listbox"]')).not.toBeNull()
+    })
+
+    it('mousedown inside the portalled menu does not close it', async () => {
+      // The blocker (#183): a naive outside-click check only looks at
+      // containerRef, which does not contain the portalled menu (it lives
+      // under document.body, not inside the component's own wrapper div).
+      // Without menuRef in the check, this mousedown alone closes the menu.
+      renderSelect()
+      await userEvent.click(screen.getByRole('combobox'))
+      const listbox = screen.getByRole('listbox')
+      fireEvent.mouseDown(listbox)
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
+    })
+
+    it('clicking an option inside the portalled menu calls onChange with the right value and closes the menu', async () => {
+      // The other half of the blocker: a click is mousedown -> mouseup ->
+      // click. If the mousedown half above closed the menu first, the
+      // option node would already be unmounted by the time the click fires,
+      // and onChange would never be called.
+      const onChange = vi.fn()
+      renderSelect({ onChange })
+      await userEvent.click(screen.getByRole('combobox'))
+      await userEvent.click(screen.getByRole('option', { name: /Cherry/ }))
+      expect(onChange).toHaveBeenCalledOnce()
+      expect(onChange).toHaveBeenCalledWith('cherry')
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Positioning (the portalled menu is `position: fixed`, placed from the
+  // trigger's getBoundingClientRect, and re-measured on resize/scroll —
+  // GitHub #183)
+  // ---------------------------------------------------------------------------
+
+  describe('Positioning', () => {
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    it('menu left/width are taken from the trigger rect', async () => {
+      renderSelect()
+      const trigger = screen.getByRole('combobox')
+      stubRect(trigger, { left: 40, top: 100, right: 240, bottom: 130, width: 200, height: 30 })
+      await userEvent.click(trigger)
+      const listbox = screen.getByRole('listbox')
+      expect(listbox.style.left).toBe('40px')
+      expect(listbox.style.width).toBe('200px')
+    })
+
+    it('menu position updates when the window resizes', async () => {
+      renderSelect()
+      const trigger = screen.getByRole('combobox')
+      stubRect(trigger, { left: 40, top: 100, right: 240, bottom: 130, width: 200, height: 30 })
+      await userEvent.click(trigger)
+      const listbox = screen.getByRole('listbox')
+      expect(listbox.style.left).toBe('40px')
+
+      stubRect(trigger, { left: 90, top: 100, right: 290, bottom: 130, width: 200, height: 30 })
+      fireEvent.resize(window)
+      expect(listbox.style.left).toBe('90px')
+    })
+
+    it('menu position updates when a nested scrollable ancestor (not window) scrolls', async () => {
+      // The tracking effect registers its scroll listener on window with
+      // useCapture=true specifically so it also catches scrolling from an
+      // ancestor scroll container (Table's overflow-x-auto, Dialog's
+      // overflow-y-auto). Native `scroll` events do not bubble, so firing
+      // scroll on this nested div (rather than window itself) only reaches
+      // a *capturing* window listener — a bubble-phase listener would never
+      // see it. This is what actually pins the capture-phase requirement
+      // down, as opposed to firing scroll on window directly.
+      const onChange = vi.fn()
+      render(
+        <div style={{ overflowY: 'auto' }} data-testid="scroll-ancestor">
+          <Select options={options} value="" onChange={onChange} />
+        </div>,
+      )
+      const scrollAncestor = screen.getByTestId('scroll-ancestor')
+      const trigger = screen.getByRole('combobox')
+      stubRect(trigger, { left: 40, top: 100, right: 240, bottom: 130, width: 200, height: 30 })
+      await userEvent.click(trigger)
+      const listbox = screen.getByRole('listbox')
+      expect(listbox.style.left).toBe('40px')
+
+      stubRect(trigger, { left: 150, top: 60, right: 350, bottom: 90, width: 200, height: 30 })
+      fireEvent.scroll(scrollAncestor)
+      expect(listbox.style.left).toBe('150px')
+    })
+
+    it('closes the dropdown when the trigger scrolls above the viewport', async () => {
+      renderSelect()
+      const trigger = screen.getByRole('combobox')
+      stubRect(trigger, { left: 40, top: 100, right: 240, bottom: 130, width: 200, height: 30 })
+      await userEvent.click(trigger)
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
+
+      stubRect(trigger, { left: 40, top: -300, right: 240, bottom: -270, width: 200, height: 30 })
+      fireEvent.scroll(window)
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    })
+
+    it('closes the dropdown when the trigger scrolls below the viewport', async () => {
+      renderSelect()
+      const trigger = screen.getByRole('combobox')
+      stubRect(trigger, { left: 40, top: 100, right: 240, bottom: 130, width: 200, height: 30 })
+      await userEvent.click(trigger)
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
+
+      stubRect(trigger, { left: 40, top: 2000, right: 240, bottom: 2030, width: 200, height: 30 })
+      fireEvent.scroll(window)
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    })
+
+    it('places the menu above the trigger when there is not enough room below but room above', async () => {
+      // window.innerHeight is stubbed so the trigger sits close to the
+      // bottom edge: spaceBelow (innerHeight - rect.bottom = 400 - 380 = 20)
+      // is smaller than ESTIMATED_MENU_HEIGHT (used for the initial
+      // synchronous placement, before the menu has painted), and rect.top
+      // (350) leaves enough room above to fit it.
+      vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(400)
+      renderSelect()
+      const trigger = screen.getByRole('combobox')
+      stubRect(trigger, { left: 40, top: 350, right: 240, bottom: 380, width: 200, height: 30 })
+      await userEvent.click(trigger)
+      const listbox = screen.getByRole('listbox')
+      // `bottom` (not `top`) is the style that distinguishes "rendered
+      // above": bottom = innerHeight(400) - rect.top(350) + 4 = 54.
+      expect(listbox.style.bottom).toBe('54px')
+      expect(listbox.style.top).toBe('')
+    })
+
+    it('places the menu below the trigger when there is enough room', async () => {
+      renderSelect()
+      const trigger = screen.getByRole('combobox')
+      stubRect(trigger, { left: 40, top: 100, right: 240, bottom: 130, width: 200, height: 30 })
+      await userEvent.click(trigger)
+      const listbox = screen.getByRole('listbox')
+      // top = rect.bottom(130) + 4 = 134.
+      expect(listbox.style.top).toBe('134px')
+      expect(listbox.style.bottom).toBe('')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Rendered inside other components (Table, Dialog) — the two contexts
+  // that were broken before the menu was portalled: an absolutely
+  // positioned menu inside Table's overflow-x-auto wrapper got clipped, and
+  // inside Dialog's own stacking context it could render behind the
+  // backdrop. GitHub #183.
+  // ---------------------------------------------------------------------------
+
+  describe('Rendered inside other components', () => {
+    it('Select inside a Table opens and its options are clickable', async () => {
+      interface Row {
+        id: string
+        value: string
+      }
+      const onChange = vi.fn()
+      const rows: Row[] = [{ id: '1', value: '' }]
+      const columns: Column<Row>[] = [
+        {
+          key: 'fruit',
+          header: 'Fruit',
+          render: (row) => (
+            <Select options={options} value={row.value} onChange={onChange} />
+          ),
+        },
+      ]
+      render(<Table columns={columns} data={rows} keyExtractor={(r) => r.id} />)
+
+      await userEvent.click(screen.getByRole('combobox'))
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
+      await userEvent.click(screen.getByRole('option', { name: /Cherry/ }))
+      expect(onChange).toHaveBeenCalledWith('cherry')
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    })
+
+    it('Select inside a Dialog opens and its options are clickable', async () => {
+      const onChange = vi.fn()
+      render(
+        <Dialog open onClose={vi.fn()} title="Pick a fruit">
+          <Select options={options} value="" onChange={onChange} />
+        </Dialog>,
+      )
+
+      await userEvent.click(screen.getByRole('combobox'))
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
+      await userEvent.click(screen.getByRole('option', { name: 'Apple' }))
+      expect(onChange).toHaveBeenCalledWith('apple')
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    })
+
+    it('menu and Dialog backdrop are both z-50 siblings under document.body, resolved by DOM order', async () => {
+      // The menu's z-50 only beats the Dialog backdrop's z-50 (and the
+      // fixed Sidebar's z-50, which is structurally the same case — a
+      // fixed z-50 sibling under document.body) because it paints later in
+      // DOM order, not because of a higher z-index.
+      render(
+        <Dialog open onClose={vi.fn()} title="Pick a fruit">
+          <Select options={options} value="" onChange={vi.fn()} />
+        </Dialog>,
+      )
+      await userEvent.click(screen.getByRole('combobox'))
+      const dialogBackdrop = screen.getByRole('dialog').parentElement
+      const listbox = screen.getByRole('listbox')
+      expect(dialogBackdrop).not.toBeNull()
+      const bodyChildren = Array.from(document.body.children)
+      expect(bodyChildren.indexOf(listbox)).toBeGreaterThan(
+        bodyChildren.indexOf(dialogBackdrop as Element),
+      )
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Tab inside the searchable menu (GitHub #183) — the portalled menu lives
+  // outside a Dialog's focusable-elements query, so the Dialog's own Tab
+  // trap cannot wrap focus back into it. Tab must instead close the menu
+  // and hand focus back to the trigger, which the Dialog's trap does track.
+  // ---------------------------------------------------------------------------
+
+  describe('Tab in searchable menu', () => {
+    it('Tab closes the dropdown and returns focus to the trigger', async () => {
+      renderSelect({ searchable: true })
+      const trigger = screen.getByRole('combobox')
+      await userEvent.click(trigger)
+      const searchInput = screen.getByPlaceholderText('Search...')
+      fireEvent.keyDown(searchInput, { key: 'Tab' })
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+      expect(document.activeElement).toBe(trigger)
+    })
+
+    it('Shift+Tab also closes the dropdown and returns focus to the trigger', async () => {
+      renderSelect({ searchable: true })
+      const trigger = screen.getByRole('combobox')
+      await userEvent.click(trigger)
+      const searchInput = screen.getByPlaceholderText('Search...')
+      fireEvent.keyDown(searchInput, { key: 'Tab', shiftKey: true })
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+      expect(document.activeElement).toBe(trigger)
     })
   })
 })

--- a/ui/src/components/ui/Select.test.tsx
+++ b/ui/src/components/ui/Select.test.tsx
@@ -658,28 +658,28 @@ describe('Select', () => {
     // kept the fixed max-h-60 class (240px) regardless, which could
     // overflow a viewport a Dialog's body-scroll-lock made unreachable).
     //
-    // TRIGGER_GAP (4), VIEWPORT_MARGIN (8), MIN_MENU_HEIGHT (96) and
-    // ESTIMATED_MENU_HEIGHT (240) below mirror the module-private
-    // constants of the same names in Select.tsx (not exported). Expected
-    // values are derived from the stubbed rect and these constants rather
-    // than hardcoded, so a future change to the margins or the clamp band
-    // fails these tests loudly instead of leaving them silently out of
-    // sync. The inline maxHeight style is clamped into
-    // [MIN_MENU_HEIGHT, ESTIMATED_MENU_HEIGHT]: it tracks the measured
-    // available space only inside that band, floors at MIN_MENU_HEIGHT
-    // when there is little or no room on either side, and caps at
-    // ESTIMATED_MENU_HEIGHT (matching the max-h-60 class) when there is
-    // far more room than that.
+    // TRIGGER_GAP (4), VIEWPORT_MARGIN (8) and ESTIMATED_MENU_HEIGHT (240)
+    // below mirror the module-private constants of the same names in
+    // Select.tsx (not exported). Expected values are derived from the
+    // stubbed rect and these constants rather than hardcoded, so a future
+    // change to the margins or the clamp cap fails these tests loudly
+    // instead of leaving them silently out of sync. The inline maxHeight
+    // style tracks the measured space available at the anchor's final
+    // (shifted) position, capped at ESTIMATED_MENU_HEIGHT (matching the
+    // max-h-60 class) when there is far more room than that. There is no
+    // floor: the shift stage guarantees the anchor is already pulled back
+    // inside the viewport, so the space it measures there is always >= 0
+    // — see the "keeps the menu fully inside the viewport" test below for
+    // the degenerate case where that space is legitimately 0.
     // -------------------------------------------------------------------
 
     it('clamps the below-placed menu maxHeight to the measured space below, not an unbounded value', async () => {
       const TRIGGER_GAP = 4
       const VIEWPORT_MARGIN = 8
-      const MIN_MENU_HEIGHT = 96
       const ESTIMATED_MENU_HEIGHT = 240
-      // innerHeight is chosen so spaceBelow lands strictly inside the
-      // clamp band — proving the height tracks the measured space rather
-      // than just hitting the floor or the cap.
+      // innerHeight is chosen so spaceBelow lands strictly below the cap
+      // — proving the height tracks the measured space rather than just
+      // hitting the cap.
       const innerHeight = 300
       const rect = { left: 40, top: 100, right: 240, bottom: 130, width: 200, height: 30 }
       vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(innerHeight)
@@ -691,12 +691,12 @@ describe('Select', () => {
 
       const spaceBelow = innerHeight - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN
       // Sanity check on the fixture: this only proves tracking (not just
-      // the floor or the cap) if spaceBelow is strictly inside the band.
-      expect(spaceBelow).toBeGreaterThan(MIN_MENU_HEIGHT)
+      // the cap) if spaceBelow is strictly positive and below the cap.
+      expect(spaceBelow).toBeGreaterThan(0)
       expect(spaceBelow).toBeLessThan(ESTIMATED_MENU_HEIGHT)
       expect(listbox.style.top).toBe(`${rect.bottom + TRIGGER_GAP}px`)
       expect(listbox.style.maxHeight).toBe(
-        `${Math.min(Math.max(spaceBelow, MIN_MENU_HEIGHT), ESTIMATED_MENU_HEIGHT)}px`,
+        `${Math.min(spaceBelow, ESTIMATED_MENU_HEIGHT)}px`,
       )
     })
 
@@ -707,7 +707,6 @@ describe('Select', () => {
       // move from a class-only cap to an inline style.
       const TRIGGER_GAP = 4
       const VIEWPORT_MARGIN = 8
-      const MIN_MENU_HEIGHT = 96
       const ESTIMATED_MENU_HEIGHT = 240
       const innerHeight = 1000
       const rect = { left: 40, top: 100, right: 240, bottom: 130, width: 200, height: 30 }
@@ -724,18 +723,17 @@ describe('Select', () => {
       expect(spaceBelow).toBeGreaterThan(ESTIMATED_MENU_HEIGHT)
       expect(listbox.style.top).toBe(`${rect.bottom + TRIGGER_GAP}px`)
       expect(listbox.style.maxHeight).toBe(
-        `${Math.min(Math.max(spaceBelow, MIN_MENU_HEIGHT), ESTIMATED_MENU_HEIGHT)}px`,
+        `${Math.min(spaceBelow, ESTIMATED_MENU_HEIGHT)}px`,
       )
     })
 
     it('clamps the above-flipped menu maxHeight to the measured space above', async () => {
       const TRIGGER_GAP = 4
       const VIEWPORT_MARGIN = 8
-      const MIN_MENU_HEIGHT = 96
       const ESTIMATED_MENU_HEIGHT = 240
       // innerHeight/rect are chosen so spaceBelow doesn't fit the
       // pre-paint estimate (triggering the flip to "above") while
-      // spaceAbove lands strictly inside the clamp band.
+      // spaceAbove lands strictly below the cap.
       const innerHeight = 400
       const rect = { left: 40, top: 200, right: 240, bottom: 230, width: 200, height: 30 }
       vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(innerHeight)
@@ -749,16 +747,16 @@ describe('Select', () => {
       const spaceAbove = rect.top - TRIGGER_GAP - VIEWPORT_MARGIN
       // Sanity check on the fixture: the flip only happens because below
       // doesn't fit the pre-paint estimate and above has more room; the
-      // test only proves tracking if spaceAbove is strictly inside the
-      // clamp band.
+      // test only proves tracking if spaceAbove is strictly positive and
+      // below the cap.
       expect(spaceBelow).toBeLessThan(ESTIMATED_MENU_HEIGHT)
       expect(spaceAbove).toBeGreaterThan(spaceBelow)
-      expect(spaceAbove).toBeGreaterThan(MIN_MENU_HEIGHT)
+      expect(spaceAbove).toBeGreaterThan(0)
       expect(spaceAbove).toBeLessThan(ESTIMATED_MENU_HEIGHT)
       expect(listbox.style.top).toBe('')
       expect(listbox.style.bottom).toBe(`${innerHeight - rect.top + TRIGGER_GAP}px`)
       expect(listbox.style.maxHeight).toBe(
-        `${Math.min(Math.max(spaceAbove, MIN_MENU_HEIGHT), ESTIMATED_MENU_HEIGHT)}px`,
+        `${Math.min(spaceAbove, ESTIMATED_MENU_HEIGHT)}px`,
       )
     })
 
@@ -769,10 +767,10 @@ describe('Select', () => {
       // "below" with no clamp at all — a fixed max-h-60 (240px) menu
       // inside a short viewport, overflowing it. innerHeight/rect are
       // chosen so spaceAbove (the side picked) still lands strictly
-      // inside the clamp band, proving it tracks rather than just floors.
+      // below the cap, proving it tracks rather than just snapping to
+      // ESTIMATED_MENU_HEIGHT.
       const TRIGGER_GAP = 4
       const VIEWPORT_MARGIN = 8
-      const MIN_MENU_HEIGHT = 96
       const ESTIMATED_MENU_HEIGHT = 240
       const innerHeight = 300
       const rect = { left: 40, top: 150, right: 240, bottom: 170, width: 200, height: 20 }
@@ -787,12 +785,11 @@ describe('Select', () => {
       const spaceAbove = rect.top - TRIGGER_GAP - VIEWPORT_MARGIN
       // Sanity check on the fixture itself: this test only pins down the
       // "neither fits, pick the bigger side" branch if neither side fits
-      // the pre-paint estimate, above truly has more room than below, and
-      // above lands inside the clamp band (not just at its floor).
+      // the pre-paint estimate and above truly has more room than below.
       expect(spaceBelow).toBeLessThan(ESTIMATED_MENU_HEIGHT)
       expect(spaceAbove).toBeLessThan(ESTIMATED_MENU_HEIGHT)
       expect(spaceAbove).toBeGreaterThan(spaceBelow)
-      expect(spaceAbove).toBeGreaterThan(MIN_MENU_HEIGHT)
+      expect(spaceAbove).toBeGreaterThan(0)
 
       // Flipped above (bottom set, top unset) ...
       expect(listbox.style.top).toBe('')
@@ -800,20 +797,24 @@ describe('Select', () => {
       // ...and clamped to the larger (above) side's space, not left
       // unbounded at the old fixed 240px.
       expect(listbox.style.maxHeight).toBe(
-        `${Math.min(Math.max(spaceAbove, MIN_MENU_HEIGHT), ESTIMATED_MENU_HEIGHT)}px`,
+        `${Math.min(spaceAbove, ESTIMATED_MENU_HEIGHT)}px`,
       )
     })
 
-    it('floors the maxHeight at MIN_MENU_HEIGHT when the available space on both sides is at or below zero', async () => {
+    it('keeps the menu fully inside the viewport when the available space on both sides is at or below zero', async () => {
       // A very short viewport (or a trigger scrolled partly toward an
       // edge but not far enough to count as fully out of view — see the
       // "closes the dropdown when the trigger scrolls above/below the
       // viewport" tests above for the fully-out-of-view case) can leave
-      // zero or negative space on both sides. The menu must still get a
-      // usable, visible height rather than staying open with maxHeight: 0.
+      // zero or negative space on both sides. There is no MIN_MENU_HEIGHT
+      // floor any more — that constant is gone, and it was exactly what
+      // used to push the menu's far edge out of the window on a viewport
+      // like this one. What the pipeline guarantees instead is that the
+      // menu box — anchor and height together — never renders partly
+      // off-screen, even when (as asserted below) the honest answer for
+      // how much height is left is 0.
       const TRIGGER_GAP = 4
       const VIEWPORT_MARGIN = 8
-      const MIN_MENU_HEIGHT = 96
       const ESTIMATED_MENU_HEIGHT = 240
       const innerHeight = 20
       const rect = { left: 0, top: 10, right: 100, bottom: 15, width: 100, height: 5 }
@@ -827,23 +828,118 @@ describe('Select', () => {
       const spaceBelow = innerHeight - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN
       const spaceAbove = rect.top - TRIGGER_GAP - VIEWPORT_MARGIN
       // Sanity check on the fixture: both sides must be at or below zero
-      // for this to actually exercise the floor.
+      // for this to exercise the degenerate case.
       expect(spaceBelow).toBeLessThanOrEqual(0)
       expect(spaceAbove).toBeLessThanOrEqual(0)
+
       // Whichever side has (marginally) more room is the one the
-      // component picks and clamps — here that is "above", since
-      // spaceAbove > spaceBelow.
+      // component picks — here that is "above", since spaceAbove(-2) >
+      // spaceBelow(-7).
       expect(listbox.style.top).toBe('')
-      expect(listbox.style.bottom).toBe(`${innerHeight - rect.top + TRIGGER_GAP}px`)
-      expect(listbox.style.maxHeight).toBe(
-        `${Math.min(Math.max(Math.max(spaceAbove, spaceBelow), MIN_MENU_HEIGHT), ESTIMATED_MENU_HEIGHT)}px`,
+
+      // Shift: the raw anchor (innerHeight - rect.top + TRIGGER_GAP = 14)
+      // falls outside [VIEWPORT_MARGIN, innerHeight - VIEWPORT_MARGIN] on
+      // this 20px-tall viewport, so it gets clamped down to the band's
+      // upper bound (12) instead of being used as-is.
+      const expectedBottom = Math.min(
+        Math.max(innerHeight - rect.top + TRIGGER_GAP, VIEWPORT_MARGIN),
+        innerHeight - VIEWPORT_MARGIN,
       )
+      expect(expectedBottom).toBeGreaterThanOrEqual(VIEWPORT_MARGIN)
+      expect(expectedBottom).toBeLessThanOrEqual(innerHeight - VIEWPORT_MARGIN)
+      expect(listbox.style.bottom).toBe(`${expectedBottom}px`)
+
+      // Size: maxHeight is derived from the space between the *shifted*
+      // anchor and the opposite margin. On this fixture that space is
+      // exactly 0 (20 - 8 - 12) — there genuinely is no room left once
+      // the anchor has been pulled back on-screen, so 0 is the correct,
+      // intended height here, not a defect. This is the same outcome
+      // floating-ui's size middleware produces once shift has already
+      // consumed all the slack; asserting anything else would mean
+      // reintroducing an invented floor.
+      const expectedMaxHeight = Math.min(
+        innerHeight - VIEWPORT_MARGIN - expectedBottom,
+        ESTIMATED_MENU_HEIGHT,
+      )
+      expect(expectedMaxHeight).toBe(0)
+      expect(listbox.style.maxHeight).toBe(`${expectedMaxHeight}px`)
+
+      // The whole box — top edge and bottom edge, both measured from the
+      // top of the viewport — must stay inside [VIEWPORT_MARGIN,
+      // innerHeight - VIEWPORT_MARGIN]. The old floor-based test only
+      // checked maxHeight in isolation, so a version that sized the menu
+      // off the *unshifted* anchor (still a small positive number) could
+      // have passed even though the box it described sat outside the
+      // window. This is the assertion that closes that gap.
+      const boxBottomFromTop = innerHeight - expectedBottom
+      const boxTopFromTop = boxBottomFromTop - expectedMaxHeight
+      expect(boxBottomFromTop).toBeLessThanOrEqual(innerHeight - VIEWPORT_MARGIN)
+      expect(boxTopFromTop).toBeGreaterThanOrEqual(VIEWPORT_MARGIN)
+    })
+
+    it("sizes the menu to the larger side's available space on a realistically short viewport, staying fully inside it", async () => {
+      // A short-but-usable viewport (400px) with the trigger near the
+      // middle: neither side has the full ESTIMATED_MENU_HEIGHT (240),
+      // but both have real, positive room. This is the case that
+      // motivated the shift+size rewrite — unlike the previous test's
+      // degenerate 20px viewport, a viewport like this one is exactly
+      // where the old MIN_MENU_HEIGHT floor (96) could inflate maxHeight
+      // past what was actually available and push the box's far edge
+      // past the window edge, even though the trigger itself was nowhere
+      // near either border.
+      const TRIGGER_GAP = 4
+      const VIEWPORT_MARGIN = 8
+      const ESTIMATED_MENU_HEIGHT = 240
+      const innerHeight = 400
+      const rect = { left: 40, top: 162, right: 240, bottom: 178, width: 200, height: 16 }
+      vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(innerHeight)
+      renderSelect()
+      const trigger = screen.getByRole('combobox')
+      stubRect(trigger, rect)
+      await userEvent.click(trigger)
+      const listbox = screen.getByRole('listbox')
+
+      const spaceBelow = innerHeight - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN
+      const spaceAbove = rect.top - TRIGGER_GAP - VIEWPORT_MARGIN
+      // Sanity check on the fixture: neither side fits the full estimate,
+      // both have real positive room, and below has more of it — so
+      // "below" is the side the component should pick.
+      expect(spaceBelow).toBeLessThan(ESTIMATED_MENU_HEIGHT)
+      expect(spaceAbove).toBeLessThan(ESTIMATED_MENU_HEIGHT)
+      expect(spaceBelow).toBeGreaterThan(0)
+      expect(spaceAbove).toBeGreaterThan(0)
+      expect(spaceBelow).toBeGreaterThan(spaceAbove)
+
+      // Placed on the side with more room (below: top set, bottom unset).
+      expect(listbox.style.bottom).toBe('')
+      expect(listbox.style.top).toBe(`${rect.bottom + TRIGGER_GAP}px`)
+
+      // The trigger sits well clear of both edges here, so shift is a
+      // no-op — the rendered anchor is exactly the unclamped offset.
+      const top = parseFloat(listbox.style.top)
+      expect(top).toBe(rect.bottom + TRIGGER_GAP)
+
+      // Height equals that side's available space exactly, proving size
+      // still tracks the real room rather than snapping to a constant —
+      // neither the old MIN_MENU_HEIGHT floor nor the ESTIMATED_MENU_HEIGHT
+      // cap.
+      expect(listbox.style.maxHeight).toBe(`${spaceBelow}px`)
+
+      // The whole box stays inside [VIEWPORT_MARGIN, innerHeight -
+      // VIEWPORT_MARGIN]: the anchor itself clears the top margin, and
+      // the anchor plus height together do not cross the bottom margin.
+      // This is the assertion that would have caught the original
+      // overflow — a stale height floor inflates maxHeight independently
+      // of the anchor, so the anchor alone looking fine is not enough.
+      const maxHeight = parseFloat(listbox.style.maxHeight)
+      const boxBottomFromTop = top + maxHeight
+      expect(top).toBeGreaterThanOrEqual(VIEWPORT_MARGIN)
+      expect(boxBottomFromTop).toBeLessThanOrEqual(innerHeight - VIEWPORT_MARGIN)
     })
 
     it('recomputes the maxHeight clamp on resize and shrinks it when the viewport shrinks', async () => {
       const TRIGGER_GAP = 4
       const VIEWPORT_MARGIN = 8
-      const MIN_MENU_HEIGHT = 96
       const ESTIMATED_MENU_HEIGHT = 240
       const rect = { left: 40, top: 100, right: 240, bottom: 130, width: 200, height: 30 }
       const innerHeightSpy = vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(800)
@@ -858,7 +954,7 @@ describe('Select', () => {
       const spaceBelowTall = 800 - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN
       expect(spaceBelowTall).toBeGreaterThan(ESTIMATED_MENU_HEIGHT)
       expect(listbox.style.maxHeight).toBe(
-        `${Math.min(Math.max(spaceBelowTall, MIN_MENU_HEIGHT), ESTIMATED_MENU_HEIGHT)}px`,
+        `${Math.min(spaceBelowTall, ESTIMATED_MENU_HEIGHT)}px`,
       )
 
       innerHeightSpy.mockReturnValue(300)
@@ -867,14 +963,14 @@ describe('Select', () => {
       // menuRef, which jsdom reports as 0 — still enough to exercise the
       // same "clamp to available space" path, just recomputed against the
       // shrunk viewport. At innerHeight 300 the raw available space now
-      // lands inside the clamp band, so this leg proves the height
+      // lands strictly below the cap, so this leg proves the height
       // actually follows the shrunk viewport down instead of staying
       // pinned at the earlier cap.
       const spaceBelowShrunk = 300 - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN
-      expect(spaceBelowShrunk).toBeGreaterThan(MIN_MENU_HEIGHT)
+      expect(spaceBelowShrunk).toBeGreaterThan(0)
       expect(spaceBelowShrunk).toBeLessThan(ESTIMATED_MENU_HEIGHT)
       expect(listbox.style.maxHeight).toBe(
-        `${Math.min(Math.max(spaceBelowShrunk, MIN_MENU_HEIGHT), ESTIMATED_MENU_HEIGHT)}px`,
+        `${Math.min(spaceBelowShrunk, ESTIMATED_MENU_HEIGHT)}px`,
       )
     })
   })

--- a/ui/src/components/ui/Select.test.tsx
+++ b/ui/src/components/ui/Select.test.tsx
@@ -973,6 +973,59 @@ describe('Select', () => {
         `${Math.min(spaceBelowShrunk, ESTIMATED_MENU_HEIGHT)}px`,
       )
     })
+
+    it("flips to the roomier side using the menu's natural content height, not the previously clamped rendered height", async () => {
+      // Regression test: the tracking effect must measure the menu's
+      // natural content height (scrollHeight) when deciding whether to
+      // flip sides on re-measure, not the CSS-clamped rendered height. A
+      // menu that was shortened to fit below on a previous pass would
+      // otherwise always look like it still fits below, and never flip to
+      // a side with genuinely more room.
+      const innerHeight = 200
+      vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(innerHeight)
+      renderSelect()
+      const trigger = screen.getByRole('combobox')
+
+      // Trigger sits near the top: below has plenty of room relative to
+      // the pre-paint ESTIMATED_MENU_HEIGHT estimate used for this first,
+      // synchronous placement (so the menu opens below, unflipped), but
+      // not enough to fit the larger natural content height stubbed below.
+      stubRect(trigger, { left: 40, top: 50, right: 240, bottom: 80, width: 200, height: 30 })
+      await userEvent.click(trigger)
+      const listbox = screen.getByRole('listbox')
+      // Opened below, with its maxHeight clamped to the (smaller than a
+      // full 240px menu) space actually available below — this is the
+      // "clamped rendered height" the old code would have fed straight
+      // back into the next measurement.
+      expect(listbox.style.top).toBe('84px')
+      expect(listbox.style.bottom).toBe('')
+      expect(listbox.style.maxHeight).toBe('108px')
+
+      // jsdom performs no layout, so scrollHeight is always 0 on any
+      // element unless explicitly stubbed. Define it on the rendered
+      // listbox to stand in for its real (natural, unclamped) content
+      // height, which is what the flip decision is supposed to use.
+      Object.defineProperty(listbox, 'scrollHeight', {
+        configurable: true,
+        value: 150,
+      })
+
+      // Move the trigger down: below now has almost no room (5px) while
+      // above has plenty (141px) — clearly the roomier side.
+      stubRect(trigger, { left: 40, top: 153, right: 240, bottom: 183, width: 200, height: 30 })
+      fireEvent.resize(window)
+
+      // With the natural content height (150) fed into the flip decision,
+      // spaceBelow (5) no longer fits it, and spaceAbove (141), while also
+      // short of 150, is far roomier — so the menu flips above. Under the
+      // old rendered-height measurement, an unstubbed element's rect height
+      // is 0 in jsdom, which would make the clamped menu look like it still
+      // fits below (5 >= 0) and never flip, even though above has 28x more
+      // room.
+      expect(listbox.style.top).toBe('')
+      expect(listbox.style.bottom).toBe('51px')
+      expect(listbox.style.maxHeight).toBe('141px')
+    })
   })
 
   // ---------------------------------------------------------------------------

--- a/ui/src/components/ui/Select.test.tsx
+++ b/ui/src/components/ui/Select.test.tsx
@@ -1,6 +1,6 @@
 import { createRef } from 'react'
 import type { ComponentProps } from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, afterEach } from 'vitest'
 import { Select } from './Select'
@@ -651,6 +651,112 @@ describe('Select', () => {
       expect(listbox.style.top).toBe('134px')
       expect(listbox.style.bottom).toBe('')
     })
+
+    // -------------------------------------------------------------------
+    // maxHeight clamp (the menu's height must never exceed the space
+    // actually available on whichever side it renders — previously it
+    // kept the fixed max-h-60 class (240px) regardless, which could
+    // overflow a viewport a Dialog's body-scroll-lock made unreachable).
+    //
+    // TRIGGER_GAP (4) and VIEWPORT_MARGIN (8) below mirror the
+    // module-private constants of the same name in Select.tsx (not
+    // exported). Expected values are derived from the stubbed rect and
+    // these constants rather than hardcoded, so a future change to the
+    // margins fails these tests loudly instead of leaving them silently
+    // out of sync.
+    // -------------------------------------------------------------------
+
+    it('clamps the below-placed menu maxHeight to the measured space below, not an unbounded value', async () => {
+      const TRIGGER_GAP = 4
+      const VIEWPORT_MARGIN = 8
+      const innerHeight = 800
+      const rect = { left: 40, top: 100, right: 240, bottom: 130, width: 200, height: 30 }
+      vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(innerHeight)
+      renderSelect()
+      const trigger = screen.getByRole('combobox')
+      stubRect(trigger, rect)
+      await userEvent.click(trigger)
+      const listbox = screen.getByRole('listbox')
+
+      const spaceBelow = innerHeight - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN
+      expect(listbox.style.top).toBe(`${rect.bottom + TRIGGER_GAP}px`)
+      expect(listbox.style.maxHeight).toBe(`${spaceBelow}px`)
+    })
+
+    it('clamps the above-flipped menu maxHeight to the measured space above', async () => {
+      const TRIGGER_GAP = 4
+      const VIEWPORT_MARGIN = 8
+      const innerHeight = 400
+      const rect = { left: 40, top: 350, right: 240, bottom: 380, width: 200, height: 30 }
+      vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(innerHeight)
+      renderSelect()
+      const trigger = screen.getByRole('combobox')
+      stubRect(trigger, rect)
+      await userEvent.click(trigger)
+      const listbox = screen.getByRole('listbox')
+
+      const spaceAbove = rect.top - TRIGGER_GAP - VIEWPORT_MARGIN
+      expect(listbox.style.top).toBe('')
+      expect(listbox.style.bottom).toBe(`${innerHeight - rect.top + TRIGGER_GAP}px`)
+      expect(listbox.style.maxHeight).toBe(`${spaceAbove}px`)
+    })
+
+    it('flips above and clamps to that side when the menu fits on neither side', async () => {
+      // Both sides are smaller than the pre-paint height estimate, so
+      // under the previous logic ("above" was only chosen when space
+      // fit above that estimate) this would have fallen through to
+      // "below" with no clamp at all — a fixed max-h-60 (240px) menu
+      // inside a 200px-tall viewport, overflowing it.
+      const TRIGGER_GAP = 4
+      const VIEWPORT_MARGIN = 8
+      const innerHeight = 200
+      const rect = { left: 40, top: 100, right: 240, bottom: 110, width: 200, height: 10 }
+      vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(innerHeight)
+      renderSelect()
+      const trigger = screen.getByRole('combobox')
+      stubRect(trigger, rect)
+      await userEvent.click(trigger)
+      const listbox = screen.getByRole('listbox')
+
+      const spaceBelow = innerHeight - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN
+      const spaceAbove = rect.top - TRIGGER_GAP - VIEWPORT_MARGIN
+      // Sanity check on the fixture itself: this test only pins down the
+      // "neither fits, pick the bigger side" branch if above truly has
+      // more room than below.
+      expect(spaceAbove).toBeGreaterThan(spaceBelow)
+
+      // Flipped above (bottom set, top unset) ...
+      expect(listbox.style.top).toBe('')
+      expect(listbox.style.bottom).toBe(`${innerHeight - rect.top + TRIGGER_GAP}px`)
+      // ...and clamped to the larger (above) side's space, not left
+      // unbounded at the old fixed 240px.
+      expect(listbox.style.maxHeight).toBe(`${spaceAbove}px`)
+    })
+
+    it('recomputes the maxHeight clamp on resize and shrinks it when the viewport shrinks', async () => {
+      const TRIGGER_GAP = 4
+      const VIEWPORT_MARGIN = 8
+      const rect = { left: 40, top: 100, right: 240, bottom: 130, width: 200, height: 30 }
+      const innerHeightSpy = vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(800)
+      renderSelect()
+      const trigger = screen.getByRole('combobox')
+      stubRect(trigger, rect)
+      await userEvent.click(trigger)
+      const listbox = screen.getByRole('listbox')
+      expect(listbox.style.maxHeight).toBe(
+        `${800 - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN}px`,
+      )
+
+      innerHeightSpy.mockReturnValue(300)
+      fireEvent.resize(window)
+      // The re-measure reads the menu's real (unstubbed) height from
+      // menuRef, which jsdom reports as 0 — still enough to exercise the
+      // same "clamp to available space" path, just recomputed against the
+      // shrunk viewport.
+      expect(listbox.style.maxHeight).toBe(
+        `${300 - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN}px`,
+      )
+    })
   })
 
   // ---------------------------------------------------------------------------
@@ -749,6 +855,71 @@ describe('Select', () => {
       fireEvent.keyDown(searchInput, { key: 'Tab', shiftKey: true })
       expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
       expect(document.activeElement).toBe(trigger)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Dialog focus trap interaction (GitHub #183) — the searchable Select's
+  // Tab handler above closes the menu and focuses the trigger itself. Because
+  // the portalled search input is outside the Dialog panel's DOM subtree, the
+  // panel's own focusable-elements query never sees it — so when the menu is
+  // the last focusable thing in the panel, the trigger it hands focus back to
+  // *is* `last` from the panel's point of view. Dialog's own Tab trap must
+  // not then re-run and wrap that focus back to `first`. Covered here (not
+  // Dialog.test.tsx) because it needs both components wired together.
+  // ---------------------------------------------------------------------------
+
+  describe('Dialog focus trap interaction', () => {
+    it("Tab in a searchable Select as the last focusable element leaves focus on the Select trigger, not the dialog's first focusable", async () => {
+      render(
+        <Dialog open onClose={vi.fn()} title="Pick a fruit">
+          <button>First</button>
+          <Select options={options} value="" onChange={vi.fn()} searchable />
+        </Dialog>,
+      )
+      // Let the Dialog's own open-focus effect settle before we open the
+      // Select, so it isn't still pending when we make our assertions.
+      await act(async () => {
+        await new Promise((r) => requestAnimationFrame(r))
+      })
+
+      const trigger = screen.getByRole('combobox')
+      await userEvent.click(trigger)
+      const searchInput = screen.getByPlaceholderText('Search...')
+
+      fireEvent.keyDown(searchInput, { key: 'Tab' })
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+      expect(document.activeElement).toBe(trigger)
+      // The bug this guards against: without the defaultPrevented check,
+      // the Dialog's trap would see the Select's own focus move land on
+      // `last` (the trigger — the only Select-related element the panel's
+      // query can see) and wrap it straight back to `first`.
+      expect(document.activeElement).not.toBe(
+        screen.getByRole('button', { name: 'Close' }),
+      )
+    })
+
+    it('Tab still wraps from the last focusable to the first when a Select is present but closed (guard does not disable the trap in general)', async () => {
+      render(
+        <Dialog open onClose={vi.fn()} title="Pick a fruit">
+          <button>First</button>
+          <Select options={options} value="" onChange={vi.fn()} searchable />
+        </Dialog>,
+      )
+      await act(async () => {
+        await new Promise((r) => requestAnimationFrame(r))
+      })
+
+      const trigger = screen.getByRole('combobox')
+      trigger.focus()
+      expect(document.activeElement).toBe(trigger)
+
+      await userEvent.tab()
+
+      expect(document.activeElement).toBe(
+        screen.getByRole('button', { name: 'Close' }),
+      )
     })
   })
 })

--- a/ui/src/components/ui/Select.tsx
+++ b/ui/src/components/ui/Select.tsx
@@ -20,6 +20,13 @@ export interface SelectOption {
 // against the menu's real measured height once it is mounted.
 const ESTIMATED_MENU_HEIGHT = 240
 
+// Gap kept between the menu and the viewport edge when its height has to be
+// clamped, so the menu never sits flush against the window border.
+const VIEWPORT_MARGIN = 8
+
+// Distance between the trigger and the menu.
+const TRIGGER_GAP = 4
+
 interface MenuPosition {
   left: number
   width: number
@@ -27,6 +34,12 @@ interface MenuPosition {
   top: number | null
   /** Set when the menu renders above the trigger; null when it renders below. */
   bottom: number | null
+  /**
+   * Upper bound for the menu height, in pixels, derived from the space
+   * available on the chosen side. Caps the max-h-60 class so the menu scrolls
+   * internally instead of overflowing the viewport.
+   */
+  maxHeight: number
 }
 
 export interface SelectProps {
@@ -175,13 +188,22 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
       const el = internalRef.current
       if (!el) return
       const rect = el.getBoundingClientRect()
-      const spaceBelow = window.innerHeight - rect.bottom
-      const above = spaceBelow < menuHeight && rect.top > menuHeight
+      const spaceBelow = window.innerHeight - rect.bottom - TRIGGER_GAP - VIEWPORT_MARGIN
+      const spaceAbove = rect.top - TRIGGER_GAP - VIEWPORT_MARGIN
+      // Prefer below. Flip above when the menu does not fit below but does
+      // fit above; when it fits on neither side, take whichever side has more
+      // room and clamp the height to it rather than overflowing the viewport.
+      let above = false
+      if (spaceBelow < menuHeight) {
+        above = spaceAbove >= menuHeight || spaceAbove > spaceBelow
+      }
+      const available = above ? spaceAbove : spaceBelow
       setMenuPosition({
         left: rect.left,
         width: rect.width,
-        top: above ? null : rect.bottom + 4,
-        bottom: above ? window.innerHeight - rect.top + 4 : null,
+        top: above ? null : rect.bottom + TRIGGER_GAP,
+        bottom: above ? window.innerHeight - rect.top + TRIGGER_GAP : null,
+        maxHeight: Math.max(available, 0),
       })
     }, [])
 
@@ -373,6 +395,7 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
                 width: menuPosition.width,
                 top: menuPosition.top ?? undefined,
                 bottom: menuPosition.bottom ?? undefined,
+                maxHeight: menuPosition.maxHeight,
               }}
               onKeyDown={handleDropdownKeyDown}
               tabIndex={-1}

--- a/ui/src/components/ui/Select.tsx
+++ b/ui/src/components/ui/Select.tsx
@@ -116,6 +116,10 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
       setIsOpen(false)
       setSearch('')
       setHighlightIndex(0)
+      // Drop the measured position too. Every open path measures before it
+      // opens, so a stale value is never rendered today - clearing it keeps
+      // that true if a future path ever opens without measuring first.
+      setMenuPosition(null)
     }, [])
 
     // Stable ref so document listeners always call the latest version
@@ -384,11 +388,17 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
                       setHighlightIndex(0)
                     }}
                     onKeyDown={(e) => {
-                      // Trap 3: the portalled menu lives outside any ancestor
-                      // Dialog's focusable-elements query, so the Dialog's
-                      // Tab-trap cannot wrap focus back into it. Close and
-                      // return focus to the trigger (which the Dialog's trap
-                      // does track) instead of letting Tab escape the modal.
+                      // The portalled menu lives outside any ancestor Dialog's
+                      // focusable-elements query, so the Dialog's Tab-trap
+                      // cannot wrap focus back into it. Close and return focus
+                      // to the trigger (which the trap does track) instead of
+                      // letting Tab escape the modal.
+                      //
+                      // This deliberately diverges from the WAI-ARIA combobox
+                      // pattern, which has Tab close the popup and advance to
+                      // the next element in one press; here it takes a second
+                      // press. Do not "fix" that without also solving the
+                      // Dialog focus-trap problem above.
                       if (e.key === 'Tab') {
                         e.preventDefault()
                         closeDropdown()

--- a/ui/src/components/ui/Select.tsx
+++ b/ui/src/components/ui/Select.tsx
@@ -24,6 +24,11 @@ const ESTIMATED_MENU_HEIGHT = 240
 // clamped, so the menu never sits flush against the window border.
 const VIEWPORT_MARGIN = 8
 
+// Floor for the clamped height. On a viewport too short for either side, a
+// small scrollable menu is still usable; zero would leave the menu open but
+// invisible.
+const MIN_MENU_HEIGHT = 96
+
 // Distance between the trigger and the menu.
 const TRIGGER_GAP = 4
 
@@ -203,7 +208,14 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
         width: rect.width,
         top: above ? null : rect.bottom + TRIGGER_GAP,
         bottom: above ? window.innerHeight - rect.top + TRIGGER_GAP : null,
-        maxHeight: Math.max(available, 0),
+        // The inline value beats the max-h-60 class in the cascade in both
+        // directions, so ESTIMATED_MENU_HEIGHT has to be applied here as the
+        // upper bound or the menu would grow past it on tall viewports.
+        // MIN_MENU_HEIGHT keeps it usable when neither side has real room.
+        maxHeight: Math.min(
+          Math.max(available, MIN_MENU_HEIGHT),
+          ESTIMATED_MENU_HEIGHT,
+        ),
       })
     }, [])
 

--- a/ui/src/components/ui/Select.tsx
+++ b/ui/src/components/ui/Select.tsx
@@ -278,8 +278,13 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
           closeDropdownRef.current()
           return
         }
-        const menuHeight =
-          menuRef.current?.getBoundingClientRect().height ?? ESTIMATED_MENU_HEIGHT
+        // scrollHeight, not the rendered height: the rendered box is already
+        // capped by the maxHeight from the previous pass, so feeding it back
+        // in would make a menu that had been shortened to fit look as though
+        // it fits, and it would never flip to the roomier side. scrollHeight
+        // is the natural content height, which is what the flip decision
+        // needs.
+        const menuHeight = menuRef.current?.scrollHeight ?? ESTIMATED_MENU_HEIGHT
         positionMenu(menuHeight)
       }
 

--- a/ui/src/components/ui/Select.tsx
+++ b/ui/src/components/ui/Select.tsx
@@ -6,12 +6,27 @@ import React, {
   useRef,
   useState,
 } from 'react'
+import ReactDOM from 'react-dom'
 import { cn } from '../../lib/utils'
 
 export interface SelectOption {
   value: string
   label: string
   description?: string
+}
+
+// Height used to decide whether the menu should render above or below the
+// trigger before it has painted (matches max-h-60 = 15rem = 240px). Refined
+// against the menu's real measured height once it is mounted.
+const ESTIMATED_MENU_HEIGHT = 240
+
+interface MenuPosition {
+  left: number
+  width: number
+  /** Set when the menu renders below the trigger; null when it renders above. */
+  top: number | null
+  /** Set when the menu renders above the trigger; null when it renders below. */
+  bottom: number | null
 }
 
 export interface SelectProps {
@@ -51,12 +66,15 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
     const [isOpen, setIsOpen] = useState(false)
     const [search, setSearch] = useState('')
     const [highlightIndex, setHighlightIndex] = useState(0)
-    const [dropAbove, setDropAbove] = useState(false)
+    const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null)
 
     const containerRef = useRef<HTMLDivElement>(null)
     const searchInputRef = useRef<HTMLInputElement>(null)
     // Internal ref for the trigger — needed for focus-return and viewport flip
     const internalRef = useRef<HTMLButtonElement>(null)
+    // Portalled menu ref — needed so outside-click detection treats the menu
+    // (rendered under document.body, outside containerRef) as "inside"
+    const menuRef = useRef<HTMLDivElement>(null)
 
     // Merge the forwarded ref with our internal ref
     const mergedRef = useMemo(
@@ -106,13 +124,16 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
       closeDropdownRef.current = closeDropdown
     }, [closeDropdown])
 
-    // Outside click closes dropdown (no focus return — user clicked elsewhere)
+    // Outside click closes dropdown (no focus return — user clicked elsewhere).
+    // The menu is portalled to document.body, so a click inside it would not
+    // be "inside" containerRef — menuRef is checked too so option clicks land.
     useEffect(() => {
       if (!isOpen) return
       const handleMouseDown = (e: MouseEvent) => {
-        if (!containerRef.current?.contains(e.target as Node)) {
-          closeDropdownRef.current()
-        }
+        const target = e.target as Node
+        if (containerRef.current?.contains(target)) return
+        if (menuRef.current?.contains(target)) return
+        closeDropdownRef.current()
       }
       document.addEventListener('mousedown', handleMouseDown)
       return () => document.removeEventListener('mousedown', handleMouseDown)
@@ -142,25 +163,76 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
       }
     }, [isOpen, searchable])
 
-    // Fix 5: Check viewport space and flip dropdown above if needed.
-    // The setState call is deferred via rAF to avoid calling setState
-    // synchronously inside an effect body (react-hooks/set-state-in-effect).
-    useEffect(() => {
-      if (!isOpen || !internalRef.current) return
+    // Fix 5: Compute the portalled menu's fixed-viewport position from the
+    // trigger's current bounding rect, flipping above the trigger when there
+    // is not enough room below. `menuHeight` is either ESTIMATED_MENU_HEIGHT
+    // (before the menu has painted) or its real measured height.
+    const positionMenu = useCallback((menuHeight: number) => {
       const el = internalRef.current
-      const rafId = requestAnimationFrame(() => {
-        const rect = el.getBoundingClientRect()
-        const spaceBelow = window.innerHeight - rect.bottom
-        const dropdownHeight = 240 // max-h-60 = 15rem = 240px
-        setDropAbove(spaceBelow < dropdownHeight && rect.top > dropdownHeight)
+      if (!el) return
+      const rect = el.getBoundingClientRect()
+      const spaceBelow = window.innerHeight - rect.bottom
+      const above = spaceBelow < menuHeight && rect.top > menuHeight
+      setMenuPosition({
+        left: rect.left,
+        width: rect.width,
+        top: above ? null : rect.bottom + 4,
+        bottom: above ? window.innerHeight - rect.top + 4 : null,
       })
-      return () => cancelAnimationFrame(rafId)
-    }, [isOpen])
+    }, [])
+
+    // Keep the portalled menu anchored to the trigger while open. Refines
+    // placement against the menu's real height once mounted (superseding the
+    // ESTIMATED_MENU_HEIGHT guess used to open it), then re-measures on any
+    // resize or ancestor scroll. The scroll listener is registered on the
+    // capture phase so it catches scrolling from any ancestor scroll
+    // container (e.g. Table's overflow-x-auto, Dialog's overflow-y-auto),
+    // not just window — 'scroll' does not bubble, but capture still reaches
+    // it as the event travels down to its target. Closes the menu if the
+    // trigger scrolls out of the viewport entirely.
+    // The setState calls are deferred via rAF/listener callbacks rather than
+    // called synchronously inside the effect body (react-hooks/set-state-in-effect).
+    useEffect(() => {
+      if (!isOpen) return
+      const el = internalRef.current
+      if (!el) return
+
+      const measure = () => {
+        const rect = el.getBoundingClientRect()
+        // Strict inequalities: a rect flush against an edge (bottom/top/left/
+        // right exactly 0) still has a sliver of overlap with the viewport
+        // and should not be treated as fully scrolled out of view.
+        const outOfView =
+          rect.bottom < 0 ||
+          rect.top > window.innerHeight ||
+          rect.right < 0 ||
+          rect.left > window.innerWidth
+        if (outOfView) {
+          closeDropdownRef.current()
+          return
+        }
+        const menuHeight =
+          menuRef.current?.getBoundingClientRect().height ?? ESTIMATED_MENU_HEIGHT
+        positionMenu(menuHeight)
+      }
+
+      const rafId = requestAnimationFrame(measure)
+      window.addEventListener('resize', measure)
+      window.addEventListener('scroll', measure, true)
+      return () => {
+        cancelAnimationFrame(rafId)
+        window.removeEventListener('resize', measure)
+        window.removeEventListener('scroll', measure, true)
+      }
+    }, [isOpen, positionMenu])
 
     const handleTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
       if (disabled) return
       if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
         e.preventDefault()
+        // Position synchronously so the portalled menu is placed correctly
+        // on its very first paint, before the tracking effect's rAF fires.
+        positionMenu(ESTIMATED_MENU_HEIGHT)
         setIsOpen(true)
       }
     }
@@ -239,6 +311,9 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
             if (isOpen) {
               closeDropdown()
             } else {
+              // Position synchronously so the portalled menu is placed
+              // correctly on its very first paint.
+              positionMenu(ESTIMATED_MENU_HEIGHT)
               setIsOpen(true)
             }
           }}
@@ -274,72 +349,90 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
           </svg>
         </button>
 
-        {isOpen && (
-          <div
-            id={listboxId}
-            role="listbox"
-            aria-label={label}
-            // Fix 5: aria-activedescendant on search input when searchable
-            aria-activedescendant={
-              searchable && filteredOptions.length > 0
-                ? optionId(clampedHighlight)
-                : undefined
-            }
-            className={cn(
-              'absolute left-0 w-full bg-bg-secondary border border-border rounded-md shadow-lg z-40 max-h-60 overflow-y-auto',
-              // Fix 5: position above or below based on viewport space
-              dropAbove ? 'bottom-full mb-1' : 'top-full mt-1',
-            )}
-            onKeyDown={handleDropdownKeyDown}
-            tabIndex={-1}
-          >
-            {searchable && (
-              <div className="sticky top-0 bg-bg-secondary">
-                <input
-                  ref={searchInputRef}
-                  type="text"
-                  value={search}
-                  onChange={(e) => {
-                    setSearch(e.target.value)
-                    setHighlightIndex(0)
-                  }}
-                  placeholder="Search..."
-                  className="w-full px-3 py-2 text-sm bg-transparent border-b border-border text-text-primary placeholder:text-text-tertiary focus:outline-none"
-                />
-              </div>
-            )}
-
-            {filteredOptions.length > 0 ? (
-              filteredOptions.map((opt, i) => (
-                <div
-                  key={opt.value}
-                  id={optionId(i)}
-                  role="option"
-                  aria-selected={opt.value === value}
-                  onClick={() => handleOptionClick(opt.value)}
-                  onMouseEnter={() => setHighlightIndex(i)}
-                  className={cn(
-                    'px-3 py-2 text-sm cursor-pointer transition-colors',
-                    i === clampedHighlight && 'bg-bg-tertiary',
-                    opt.value === value && 'text-accent bg-accent/5',
-                    opt.value !== value && 'text-text-primary',
-                  )}
-                >
-                  {opt.label}
-                  {opt.description != null && (
-                    <span className="block text-xs text-text-tertiary mt-0.5">
-                      {opt.description}
-                    </span>
-                  )}
+        {isOpen &&
+          menuPosition != null &&
+          ReactDOM.createPortal(
+            <div
+              ref={menuRef}
+              id={listboxId}
+              role="listbox"
+              aria-label={label}
+              // Fix 5: aria-activedescendant on search input when searchable
+              aria-activedescendant={
+                searchable && filteredOptions.length > 0
+                  ? optionId(clampedHighlight)
+                  : undefined
+              }
+              className="fixed bg-bg-secondary border border-border rounded-md shadow-lg z-50 max-h-60 overflow-y-auto"
+              style={{
+                left: menuPosition.left,
+                width: menuPosition.width,
+                top: menuPosition.top ?? undefined,
+                bottom: menuPosition.bottom ?? undefined,
+              }}
+              onKeyDown={handleDropdownKeyDown}
+              tabIndex={-1}
+            >
+              {searchable && (
+                <div className="sticky top-0 bg-bg-secondary">
+                  <input
+                    ref={searchInputRef}
+                    type="text"
+                    value={search}
+                    onChange={(e) => {
+                      setSearch(e.target.value)
+                      setHighlightIndex(0)
+                    }}
+                    onKeyDown={(e) => {
+                      // Trap 3: the portalled menu lives outside any ancestor
+                      // Dialog's focusable-elements query, so the Dialog's
+                      // Tab-trap cannot wrap focus back into it. Close and
+                      // return focus to the trigger (which the Dialog's trap
+                      // does track) instead of letting Tab escape the modal.
+                      if (e.key === 'Tab') {
+                        e.preventDefault()
+                        closeDropdown()
+                        internalRef.current?.focus()
+                      }
+                    }}
+                    placeholder="Search..."
+                    className="w-full px-3 py-2 text-sm bg-transparent border-b border-border text-text-primary placeholder:text-text-tertiary focus:outline-none"
+                  />
                 </div>
-              ))
-            ) : (
-              <div className="px-3 py-2 text-sm text-text-tertiary">
-                No results
-              </div>
-            )}
-          </div>
-        )}
+              )}
+
+              {filteredOptions.length > 0 ? (
+                filteredOptions.map((opt, i) => (
+                  <div
+                    key={opt.value}
+                    id={optionId(i)}
+                    role="option"
+                    aria-selected={opt.value === value}
+                    onClick={() => handleOptionClick(opt.value)}
+                    onMouseEnter={() => setHighlightIndex(i)}
+                    className={cn(
+                      'px-3 py-2 text-sm cursor-pointer transition-colors',
+                      i === clampedHighlight && 'bg-bg-tertiary',
+                      opt.value === value && 'text-accent bg-accent/5',
+                      opt.value !== value && 'text-text-primary',
+                    )}
+                  >
+                    {opt.label}
+                    {opt.description != null && (
+                      <span className="block text-xs text-text-tertiary mt-0.5">
+                        {opt.description}
+                      </span>
+                    )}
+                  </div>
+                ))
+              ) : (
+                <div className="px-3 py-2 text-sm text-text-tertiary">
+                  No results
+                </div>
+              )}
+            </div>,
+            document.body,
+          )}
 
         {error != null && (
           <p id={errorId} role="alert" className="mt-1.5 text-xs text-error">

--- a/ui/src/components/ui/Select.tsx
+++ b/ui/src/components/ui/Select.tsx
@@ -20,14 +20,10 @@ export interface SelectOption {
 // against the menu's real measured height once it is mounted.
 const ESTIMATED_MENU_HEIGHT = 240
 
-// Gap kept between the menu and the viewport edge when its height has to be
-// clamped, so the menu never sits flush against the window border.
+// Gap kept between the menu and the viewport edge: the anchored edge is
+// shifted to stay at least this far from the border, and the free edge's
+// maxHeight is capped so it does not cross into this margin either.
 const VIEWPORT_MARGIN = 8
-
-// Floor for the clamped height. On a viewport too short for either side, a
-// small scrollable menu is still usable; zero would leave the menu open but
-// invisible.
-const MIN_MENU_HEIGHT = 96
 
 // Distance between the trigger and the menu.
 const TRIGGER_GAP = 4
@@ -41,7 +37,8 @@ interface MenuPosition {
   bottom: number | null
   /**
    * Upper bound for the menu height, in pixels, derived from the space
-   * available on the chosen side. Caps the max-h-60 class so the menu scrolls
+   * actually available at the final (shifted) anchor position, capped at
+   * ESTIMATED_MENU_HEIGHT. Caps the max-h-60 class so the menu scrolls
    * internally instead of overflowing the viewport.
    */
   maxHeight: number
@@ -186,9 +183,13 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
     }, [isOpen, searchable])
 
     // Fix 5: Compute the portalled menu's fixed-viewport position from the
-    // trigger's current bounding rect, flipping above the trigger when there
-    // is not enough room below. `menuHeight` is either ESTIMATED_MENU_HEIGHT
-    // (before the menu has painted) or its real measured height.
+    // trigger's current bounding rect. Runs the standard anchor-positioning
+    // pipeline: offset (TRIGGER_GAP) -> flip (prefer below, flip above when
+    // it does not fit) -> shift (pull the anchored edge back inside the
+    // viewport, keeping VIEWPORT_MARGIN from the border) -> size (cap the
+    // height to whatever room is left at that final, shifted position).
+    // `menuHeight` is either ESTIMATED_MENU_HEIGHT (before the menu has
+    // painted) or its real measured height.
     const positionMenu = useCallback((menuHeight: number) => {
       const el = internalRef.current
       if (!el) return
@@ -197,26 +198,54 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
       const spaceAbove = rect.top - TRIGGER_GAP - VIEWPORT_MARGIN
       // Prefer below. Flip above when the menu does not fit below but does
       // fit above; when it fits on neither side, take whichever side has more
-      // room and clamp the height to it rather than overflowing the viewport.
+      // room.
       let above = false
       if (spaceBelow < menuHeight) {
         above = spaceAbove >= menuHeight || spaceAbove > spaceBelow
       }
-      const available = above ? spaceAbove : spaceBelow
-      setMenuPosition({
-        left: rect.left,
-        width: rect.width,
-        top: above ? null : rect.bottom + TRIGGER_GAP,
-        bottom: above ? window.innerHeight - rect.top + TRIGGER_GAP : null,
-        // The inline value beats the max-h-60 class in the cascade in both
-        // directions, so ESTIMATED_MENU_HEIGHT has to be applied here as the
-        // upper bound or the menu would grow past it on tall viewports.
-        // MIN_MENU_HEIGHT keeps it usable when neither side has real room.
-        maxHeight: Math.min(
-          Math.max(available, MIN_MENU_HEIGHT),
-          ESTIMATED_MENU_HEIGHT,
-        ),
-      })
+
+      // Shift: clamp the anchored edge into [VIEWPORT_MARGIN, innerHeight -
+      // VIEWPORT_MARGIN] before sizing. This is a no-op whenever the trigger
+      // itself is comfortably on-screen (the normal case) - it only moves
+      // the anchor when the trigger sits close enough to an edge that a bare
+      // offset would place the menu past the window border.
+      //
+      // Size: cap maxHeight to whatever room remains between the shifted
+      // anchor and the opposite margin, capped at ESTIMATED_MENU_HEIGHT. No
+      // floor - since the anchor is already shifted into the viewport, this
+      // is always >= 0. A cramped viewport yields a small, fully visible,
+      // internally-scrollable menu instead of an overflowing one.
+      if (above) {
+        const bottom = Math.min(
+          Math.max(window.innerHeight - rect.top + TRIGGER_GAP, VIEWPORT_MARGIN),
+          window.innerHeight - VIEWPORT_MARGIN,
+        )
+        setMenuPosition({
+          left: rect.left,
+          width: rect.width,
+          top: null,
+          bottom,
+          maxHeight: Math.min(
+            window.innerHeight - VIEWPORT_MARGIN - bottom,
+            ESTIMATED_MENU_HEIGHT,
+          ),
+        })
+      } else {
+        const top = Math.min(
+          Math.max(rect.bottom + TRIGGER_GAP, VIEWPORT_MARGIN),
+          window.innerHeight - VIEWPORT_MARGIN,
+        )
+        setMenuPosition({
+          left: rect.left,
+          width: rect.width,
+          top,
+          bottom: null,
+          maxHeight: Math.min(
+            window.innerHeight - VIEWPORT_MARGIN - top,
+            ESTIMATED_MENU_HEIGHT,
+          ),
+        })
+      }
     }, [])
 
     // Keep the portalled menu anchored to the trigger while open. Refines


### PR DESCRIPTION
Closes #183.

`Table` wraps its content in `overflow-x-auto`, and CSS turns that into a scroll container on **both** axes, so a dropdown opened from a table cell was cut off. A higher `z-index` cannot help - the clipping comes from an ancestor scrollport, not from stacking. The visible cases were the role editors in the team and org member tables; the dialog body and the Playground config panel clip the same way.

The menu now renders into `document.body` and is positioned against the trigger's viewport rect, following it on scroll and resize the way the common component libraries do.

## Three things this could have broken

`Select` has 34 usages across 13 files, 24 of them inside a `Dialog`, so all three were real risks rather than theoretical:

- **Outside-click detection** had to learn that the portalled menu counts as inside. Without that, every option click closes the menu before the selection lands - six tests fail if the check is removed, four of them pre-existing.
- **z-index**: the menu moved to the portal tier, otherwise the two dozen Selects inside dialogs would have rendered behind the backdrop and been invisible.
- **Focus**: Tab inside a searchable menu now returns focus to the trigger, since the portalled input sits outside a Dialog's focus trap. The Dialog's trap in turn learned to bow out when a descendant has already handled Tab - the same guard its own Escape handler always had.

## Positioning

The first version of the positioning was hand-rolled and got two things wrong: an inline `maxHeight` silently defeated the 240px cap every menu previously had, and an invented minimum height pushed the menu out of the window when neither side had room.

Both are gone. It now runs the pipeline every component library runs - offset, flip, shift, size - where **shift** is the piece that was missing: the anchor is clamped into the viewport before the height is derived from it, so the box is always fully visible and the height can never come out negative. The flip decision uses the menu's natural content height rather than its already-capped rendered height, so a menu shortened to fit one side still moves to the roomier one when the geometry changes.

## Verification

384 UI tests, 34 of them new. Every central claim was mutation-checked - the outside-click term, the capture-phase scroll listener, the height cap, the viewport shift, the dialog Tab guard and the natural-height flip each turn tests red when removed.

Five review rounds. One finding was left deliberately: non-searchable Selects cannot be operated by keyboard, because the trigger and the listbox are siblings so trigger keydowns never reach the listbox handler. That is pre-existing, unaffected by this change, and tracked as #191.