### PR TITLE
fix(ui): make a non-searchable Select operable by keyboard

### DIFF
--- a/ui/src/components/ui/Select.test.tsx
+++ b/ui/src/components/ui/Select.test.tsx
@@ -466,8 +466,18 @@ describe('Select', () => {
       expect(activeEl).not.toBeNull()
       expect(activeEl).toHaveTextContent('Apple')
 
+      // The step that was missing: a further ArrowDown must actually move
+      // the highlight, not silently no-op because it stepped from the raw
+      // (still -1) state instead of the clamped, on-screen one.
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      const secondActiveId = trigger.getAttribute('aria-activedescendant')
+      expect(secondActiveId).toBeTruthy()
+      const secondActiveEl = document.getElementById(secondActiveId!)
+      expect(secondActiveEl).not.toBeNull()
+      expect(secondActiveEl).toHaveTextContent('Banana')
+
       fireEvent.keyDown(trigger, { key: 'Enter' })
-      expect(onChange).toHaveBeenCalledWith('apple')
+      expect(onChange).toHaveBeenCalledWith('banana')
       expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
     })
   })

--- a/ui/src/components/ui/Select.test.tsx
+++ b/ui/src/components/ui/Select.test.tsx
@@ -435,6 +435,41 @@ describe('Select', () => {
       expect(screen.queryByRole('listbox')).toBeNull()
       expect(notPrevented).toBe(true)
     })
+
+    it('recovers when options arrive after ArrowDown was pressed against an empty list, keeping the trigger operable', async () => {
+      // Every Select in this app is fed from an in-flight query, so it
+      // routinely opens with an empty `options` array before results land.
+      // ArrowDown against that empty list drives highlightIndex to -1
+      // (Math.min(0 + 1, filteredOptions.length - 1) is Math.min(1, -1) with
+      // zero options) — clampedHighlight's lower bound is what stops that -1
+      // from surviving once options arrive on a rerender. Without it,
+      // aria-activedescendant would reference a nonexistent option id and
+      // Enter would index filteredOptions with -1, selecting nothing.
+      const onChange = vi.fn()
+      const { rerender } = render(
+        <Select options={[]} value="" onChange={onChange} />,
+      )
+      const trigger = screen.getByRole('combobox')
+
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
+      expect(screen.getByText('No results')).toBeInTheDocument()
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+
+      // Options arrive — the menu stays open, highlightIndex is untouched by
+      // the rerender itself.
+      rerender(<Select options={options} value="" onChange={onChange} />)
+
+      const activeId = trigger.getAttribute('aria-activedescendant')
+      expect(activeId).toBeTruthy()
+      const activeEl = document.getElementById(activeId!)
+      expect(activeEl).not.toBeNull()
+      expect(activeEl).toHaveTextContent('Apple')
+
+      fireEvent.keyDown(trigger, { key: 'Enter' })
+      expect(onChange).toHaveBeenCalledWith('apple')
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    })
   })
 
   // ---------------------------------------------------------------------------

--- a/ui/src/components/ui/Select.test.tsx
+++ b/ui/src/components/ui/Select.test.tsx
@@ -231,10 +231,58 @@ describe('Select', () => {
       expect(screen.getAllByRole('option')).toHaveLength(options.length)
       expect(screen.getByPlaceholderText('Search...')).toHaveValue('')
     })
+
+    it('ArrowDown and Enter still work while focus is in the search input', async () => {
+      // The searchable path was always reachable — focus genuinely sits in
+      // the search input (auto-focused on open), and these keydowns bubble
+      // from the input up to the listbox's own onKeyDown. This is the one
+      // path the trigger-keyboard fix did not need to touch; kept covered
+      // here to prove it wasn't disturbed.
+      const onChange = vi.fn()
+      renderSelect({ searchable: true, onChange })
+      await userEvent.click(screen.getByRole('combobox'))
+      const searchInput = screen.getByPlaceholderText('Search...')
+
+      fireEvent.keyDown(searchInput, { key: 'ArrowDown' })
+      const opts = screen.getAllByRole('option')
+      expect(opts[1].className).toContain('bg-bg-tertiary')
+
+      fireEvent.keyDown(searchInput, { key: 'Enter' })
+      expect(onChange).toHaveBeenCalledWith('banana')
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    })
+
+    it('Space in the search input types a space instead of selecting the highlighted option', async () => {
+      // This is the reason Space is handled on the trigger only
+      // (handleTriggerKeyDown) and deliberately left out of the shared
+      // handleNavigationKeyDown that the search input's keydowns bubble
+      // into — here Space must stay ordinary text entry.
+      const onChange = vi.fn()
+      renderSelect({ searchable: true, onChange })
+      await userEvent.click(screen.getByRole('combobox'))
+      const searchInput = screen.getByPlaceholderText('Search...')
+
+      await userEvent.type(searchInput, 'a a')
+
+      expect(searchInput).toHaveValue('a a')
+      expect(onChange).not.toHaveBeenCalled()
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
+    })
   })
 
   // ---------------------------------------------------------------------------
   // Keyboard Navigation
+  //
+  // Every keydown below is dispatched to the trigger (getByRole('combobox')),
+  // never to the listbox. When `searchable` is false the menu is a portalled
+  // sibling of the trigger, not a descendant — a real user has no way to
+  // move focus onto it, so a test that fires keys at getByRole('listbox')
+  // would pass whether or not the trigger actually forwards those keys to
+  // navigation. Open/close and highlight movement while the menu is open
+  // live on handleTriggerKeyDown, which delegates to the shared
+  // handleNavigationKeyDown; the listbox's own onKeyDown only matters for
+  // the searchable path, where focus genuinely sits in the search input
+  // inside the menu — that path is covered separately in Searchable below.
   // ---------------------------------------------------------------------------
 
   describe('Keyboard Navigation', () => {
@@ -256,80 +304,111 @@ describe('Select', () => {
       expect(screen.getByRole('listbox')).toBeInTheDocument()
     })
 
-    it('ArrowDown moves highlight to next option', async () => {
+    it('ArrowDown on the trigger moves highlight to next option', async () => {
       renderSelect()
-      await userEvent.click(screen.getByRole('combobox'))
-      const listbox = screen.getByRole('listbox')
+      const trigger = screen.getByRole('combobox')
+      await userEvent.click(trigger)
       // Initially highlight index is 0 (Apple). Move down to Banana (index 1).
-      fireEvent.keyDown(listbox, { key: 'ArrowDown' })
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
       const opts = screen.getAllByRole('option')
       // Index 1 (Banana) should now have the highlighted background class
       expect(opts[1].className).toContain('bg-bg-tertiary')
     })
 
-    it('ArrowUp moves highlight to previous option', async () => {
+    it('ArrowUp on the trigger moves highlight to previous option', async () => {
       renderSelect()
-      await userEvent.click(screen.getByRole('combobox'))
-      const listbox = screen.getByRole('listbox')
+      const trigger = screen.getByRole('combobox')
+      await userEvent.click(trigger)
       // Move down twice then back up once
-      fireEvent.keyDown(listbox, { key: 'ArrowDown' })
-      fireEvent.keyDown(listbox, { key: 'ArrowDown' })
-      fireEvent.keyDown(listbox, { key: 'ArrowUp' })
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      fireEvent.keyDown(trigger, { key: 'ArrowUp' })
       const opts = screen.getAllByRole('option')
       expect(opts[1].className).toContain('bg-bg-tertiary')
     })
 
-    it('Enter selects highlighted option and closes dropdown', async () => {
+    it('Enter on the trigger selects highlighted option and closes dropdown', async () => {
       const onChange = vi.fn()
       renderSelect({ onChange })
-      await userEvent.click(screen.getByRole('combobox'))
-      const listbox = screen.getByRole('listbox')
+      const trigger = screen.getByRole('combobox')
+      await userEvent.click(trigger)
       // Highlight index starts at 0 (Apple)
-      fireEvent.keyDown(listbox, { key: 'Enter' })
+      fireEvent.keyDown(trigger, { key: 'Enter' })
       expect(onChange).toHaveBeenCalledWith('apple')
       expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
     })
 
-    it('Home highlights first option', async () => {
+    it('Space on the trigger selects the highlighted option when the menu is open', async () => {
+      // Space stays trigger-only (handleTriggerKeyDown), distinct from
+      // handleNavigationKeyDown which every other case here goes through —
+      // see the Searchable describe for the contrasting case where Space
+      // must NOT select because it is ordinary typing in the search input.
+      const onChange = vi.fn()
+      renderSelect({ onChange })
+      const trigger = screen.getByRole('combobox')
+      await userEvent.click(trigger)
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      fireEvent.keyDown(trigger, { key: ' ' })
+      expect(onChange).toHaveBeenCalledWith('banana')
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+      expect(document.activeElement).toBe(trigger)
+    })
+
+    it('Home on the trigger highlights first option', async () => {
       renderSelect()
-      await userEvent.click(screen.getByRole('combobox'))
-      const listbox = screen.getByRole('listbox')
+      const trigger = screen.getByRole('combobox')
+      await userEvent.click(trigger)
       // Move to last, then Home back to first
-      fireEvent.keyDown(listbox, { key: 'End' })
-      fireEvent.keyDown(listbox, { key: 'Home' })
+      fireEvent.keyDown(trigger, { key: 'End' })
+      fireEvent.keyDown(trigger, { key: 'Home' })
       const opts = screen.getAllByRole('option')
       expect(opts[0].className).toContain('bg-bg-tertiary')
     })
 
-    it('End highlights last option', async () => {
+    it('End on the trigger highlights last option', async () => {
       renderSelect()
-      await userEvent.click(screen.getByRole('combobox'))
-      const listbox = screen.getByRole('listbox')
-      fireEvent.keyDown(listbox, { key: 'End' })
+      const trigger = screen.getByRole('combobox')
+      await userEvent.click(trigger)
+      fireEvent.keyDown(trigger, { key: 'End' })
       const opts = screen.getAllByRole('option')
       expect(opts[opts.length - 1].className).toContain('bg-bg-tertiary')
     })
 
-    it('ArrowDown does not move highlight past the last option', async () => {
+    it('ArrowDown on the trigger does not move highlight past the last option', async () => {
       renderSelect()
-      await userEvent.click(screen.getByRole('combobox'))
-      const listbox = screen.getByRole('listbox')
+      const trigger = screen.getByRole('combobox')
+      await userEvent.click(trigger)
       // Press ArrowDown many times beyond the list length
       for (let i = 0; i < 10; i++) {
-        fireEvent.keyDown(listbox, { key: 'ArrowDown' })
+        fireEvent.keyDown(trigger, { key: 'ArrowDown' })
       }
       const opts = screen.getAllByRole('option')
       expect(opts[opts.length - 1].className).toContain('bg-bg-tertiary')
     })
 
-    it('ArrowUp does not move highlight before the first option', async () => {
+    it('ArrowUp on the trigger does not move highlight before the first option', async () => {
       renderSelect()
-      await userEvent.click(screen.getByRole('combobox'))
-      const listbox = screen.getByRole('listbox')
-      fireEvent.keyDown(listbox, { key: 'ArrowUp' })
-      fireEvent.keyDown(listbox, { key: 'ArrowUp' })
+      const trigger = screen.getByRole('combobox')
+      await userEvent.click(trigger)
+      fireEvent.keyDown(trigger, { key: 'ArrowUp' })
+      fireEvent.keyDown(trigger, { key: 'ArrowUp' })
       const opts = screen.getAllByRole('option')
       expect(opts[0].className).toContain('bg-bg-tertiary')
+    })
+
+    it('opens and navigates entirely from the keyboard, without ever clicking the trigger', () => {
+      // ArrowDown on the closed trigger both opens the menu and is the same
+      // key a user keeps pressing to move the highlight afterwards — this
+      // exercises the whole open-then-navigate flow without a single mouse
+      // interaction anywhere in the test.
+      renderSelect()
+      const trigger = screen.getByRole('combobox')
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      const opts = screen.getAllByRole('option')
+      expect(opts[2].className).toContain('bg-bg-tertiary')
     })
 
     it('disabled trigger ignores keyboard open keys', () => {
@@ -416,8 +495,10 @@ describe('Select', () => {
       renderSelect()
       const trigger = screen.getByRole('combobox')
       await userEvent.click(trigger)
-      const listbox = screen.getByRole('listbox')
-      fireEvent.keyDown(listbox, { key: 'Enter' })
+      // Enter is dispatched to the trigger — see the Keyboard Navigation
+      // describe above for why the listbox is never a legitimate keydown
+      // target for the non-searchable path.
+      fireEvent.keyDown(trigger, { key: 'Enter' })
       expect(document.activeElement).toBe(trigger)
     })
 
@@ -449,7 +530,7 @@ describe('Select', () => {
   // ---------------------------------------------------------------------------
 
   describe('aria-activedescendant', () => {
-    it('trigger has aria-activedescendant pointing to first option when opened', async () => {
+    it('trigger has aria-activedescendant pointing to first option when opened with no value selected', async () => {
       renderSelect()
       const trigger = screen.getByRole('combobox')
       await userEvent.click(trigger)
@@ -467,16 +548,79 @@ describe('Select', () => {
       )
     })
 
-    it('aria-activedescendant updates when highlight changes via ArrowDown', async () => {
+    it('aria-activedescendant updates when highlight changes via ArrowDown on the trigger', async () => {
       renderSelect()
       const trigger = screen.getByRole('combobox')
       await userEvent.click(trigger)
-      const listbox = screen.getByRole('listbox')
-      fireEvent.keyDown(listbox, { key: 'ArrowDown' })
+      // Dispatched to the trigger, not the listbox — see the Keyboard
+      // Navigation describe above for why.
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
       const activeId = trigger.getAttribute('aria-activedescendant')
       expect(activeId).toBeTruthy()
       const activeEl = document.getElementById(activeId!)
       expect(activeEl).toHaveTextContent('Banana')
+    })
+
+    it('tracks the highlight on the trigger through a fully keyboard-driven open-and-navigate interaction', () => {
+      renderSelect()
+      const trigger = screen.getByRole('combobox')
+      const activeOption = () =>
+        document.getElementById(trigger.getAttribute('aria-activedescendant')!)
+
+      // Open via ArrowDown on the closed trigger — no mouse involved at any
+      // point in this test. Starts on Apple (index 0).
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      expect(activeOption()).toHaveTextContent('Apple')
+
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      expect(activeOption()).toHaveTextContent('Cherry')
+
+      fireEvent.keyDown(trigger, { key: 'ArrowUp' })
+      expect(activeOption()).toHaveTextContent('Banana')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Initial highlight seeding (getInitialHighlightIndex) — opening the menu
+  // seeds the highlight on the currently selected option instead of always
+  // starting at index 0, on both paths that can open the menu: a mouse click
+  // on the trigger and a keyboard open key (ArrowDown/Enter/Space) on the
+  // closed trigger. Falls back to the first option when `value` is empty or
+  // does not match any option.
+  // ---------------------------------------------------------------------------
+
+  describe('Initial highlight seeding', () => {
+    it('click-opening seeds the highlight on the option matching the current value', async () => {
+      renderSelect({ value: 'banana' })
+      const trigger = screen.getByRole('combobox')
+      await userEvent.click(trigger)
+      const activeId = trigger.getAttribute('aria-activedescendant')
+      expect(document.getElementById(activeId!)).toHaveTextContent('Banana')
+    })
+
+    it('keyboard-opening (ArrowDown on the closed trigger) seeds the highlight on the option matching the current value', () => {
+      renderSelect({ value: 'cherry' })
+      const trigger = screen.getByRole('combobox')
+      fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+      const activeId = trigger.getAttribute('aria-activedescendant')
+      expect(document.getElementById(activeId!)).toHaveTextContent('Cherry')
+    })
+
+    it('falls back to the first option when value does not match any option (click-open)', async () => {
+      renderSelect({ value: 'durian' })
+      const trigger = screen.getByRole('combobox')
+      await userEvent.click(trigger)
+      const activeId = trigger.getAttribute('aria-activedescendant')
+      expect(document.getElementById(activeId!)).toHaveTextContent('Apple')
+    })
+
+    it('falls back to the first option when value is empty (keyboard-open)', () => {
+      renderSelect({ value: '' })
+      const trigger = screen.getByRole('combobox')
+      fireEvent.keyDown(trigger, { key: 'Enter' })
+      const activeId = trigger.getAttribute('aria-activedescendant')
+      expect(document.getElementById(activeId!)).toHaveTextContent('Apple')
     })
   })
 

--- a/ui/src/components/ui/Select.test.tsx
+++ b/ui/src/components/ui/Select.test.tsx
@@ -416,6 +416,25 @@ describe('Select', () => {
       fireEvent.keyDown(screen.getByRole('combobox'), { key: 'ArrowDown' })
       expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
     })
+
+    // Deliberate asymmetry with "Tab in searchable menu" below: the trigger
+    // is already inside an ancestor Dialog's focus trap, so this Tab handler
+    // only has to close the menu, not intercept the key — leaving
+    // preventDefault uncalled lets the browser move focus on as normal
+    // instead of stranding the menu open behind it. Contrast the searchable
+    // path, which does call preventDefault because its search input lives in
+    // the portal, outside the trap's reach.
+    it('Tab on the trigger closes the dropdown without preventing default', async () => {
+      renderSelect()
+      const trigger = screen.getByRole('combobox')
+      await userEvent.click(trigger)
+      expect(screen.getByRole('listbox')).toBeInTheDocument()
+      // fireEvent.keyDown returns the result of dispatchEvent: true unless
+      // preventDefault() was called on the (cancelable) event.
+      const notPrevented = fireEvent.keyDown(trigger, { key: 'Tab' })
+      expect(screen.queryByRole('listbox')).toBeNull()
+      expect(notPrevented).toBe(true)
+    })
   })
 
   // ---------------------------------------------------------------------------

--- a/ui/src/components/ui/Select.tsx
+++ b/ui/src/components/ui/Select.tsx
@@ -374,6 +374,16 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
         selectHighlighted()
         return
       }
+      // Tab closes the menu and then lets focus move on normally. Note the
+      // deliberate absence of preventDefault here: the searchable path has to
+      // trap Tab because its search input sits in the portal, outside an
+      // ancestor Dialog's focus trap. The trigger is inside that trap, so
+      // nothing needs intercepting - leaving the menu open behind a moved
+      // focus is the only thing to avoid.
+      if (e.key === 'Tab') {
+        closeDropdown()
+        return
+      }
       handleNavigationKeyDown(e)
     }
 

--- a/ui/src/components/ui/Select.tsx
+++ b/ui/src/components/ui/Select.tsx
@@ -117,16 +117,16 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
       [options, search, searchable],
     )
 
-    // Clamp highlightIndex so stale values never point out of bounds. The
-    // lower bound matters: pressing ArrowDown against an empty list drives
-    // highlightIndex to -1, and options routinely arrive from an in-flight
+    // Clamp an index into the valid range for a list of the given length. The
+    // lower bound matters: pressing ArrowDown against an empty list drives the
+    // stored index to -1, and options routinely arrive from an in-flight
     // query, so without it a negative index survives into a populated list -
     // aria-activedescendant would reference a nonexistent option and Enter
     // would select nothing.
-    const clampedHighlight = Math.min(
-      Math.max(highlightIndex, 0),
-      Math.max(filteredOptions.length - 1, 0),
-    )
+    const clampIndex = (index: number, length: number) =>
+      Math.min(Math.max(index, 0), Math.max(length - 1, 0))
+
+    const clampedHighlight = clampIndex(highlightIndex, filteredOptions.length)
 
     // Helper to generate stable option ids for aria-activedescendant (Fix 6)
     const optionId = (index: number) => `${generatedId}-option-${index}`
@@ -335,19 +335,22 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
     // deliberately not handled here — see handleTriggerKeyDown.
     const handleNavigationKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
       switch (e.key) {
-        // Step from clampedHighlight, not from the raw state. The raw value can
-        // sit outside the valid range - ArrowDown against an empty list leaves
-        // it at -1 - and the display already reflects the clamped one, so
-        // stepping from the raw value would silently swallow the first press.
+        // Clamp the previous value inside the updater rather than stepping
+        // from the render-scoped clampedHighlight. Two reasons, and both are
+        // needed: the raw state can sit outside the valid range (ArrowDown
+        // against an empty list leaves it at -1) while the display already
+        // shows the clamped one, so an unclamped base swallows a press; and
+        // the functional form keeps the base current when several key events
+        // land in the same batch, which a render-scoped value would not.
         case 'ArrowDown':
           e.preventDefault()
-          setHighlightIndex(
-            Math.min(clampedHighlight + 1, filteredOptions.length - 1),
+          setHighlightIndex((i) =>
+            Math.min(clampIndex(i, filteredOptions.length) + 1, filteredOptions.length - 1),
           )
           break
         case 'ArrowUp':
           e.preventDefault()
-          setHighlightIndex(Math.max(clampedHighlight - 1, 0))
+          setHighlightIndex((i) => Math.max(clampIndex(i, filteredOptions.length) - 1, 0))
           break
         case 'Enter':
           e.preventDefault()

--- a/ui/src/components/ui/Select.tsx
+++ b/ui/src/components/ui/Select.tsx
@@ -335,13 +335,19 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
     // deliberately not handled here — see handleTriggerKeyDown.
     const handleNavigationKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
       switch (e.key) {
+        // Step from clampedHighlight, not from the raw state. The raw value can
+        // sit outside the valid range - ArrowDown against an empty list leaves
+        // it at -1 - and the display already reflects the clamped one, so
+        // stepping from the raw value would silently swallow the first press.
         case 'ArrowDown':
           e.preventDefault()
-          setHighlightIndex((i) => Math.min(i + 1, filteredOptions.length - 1))
+          setHighlightIndex(
+            Math.min(clampedHighlight + 1, filteredOptions.length - 1),
+          )
           break
         case 'ArrowUp':
           e.preventDefault()
-          setHighlightIndex((i) => Math.max(i - 1, 0))
+          setHighlightIndex(Math.max(clampedHighlight - 1, 0))
           break
         case 'Enter':
           e.preventDefault()

--- a/ui/src/components/ui/Select.tsx
+++ b/ui/src/components/ui/Select.tsx
@@ -117,9 +117,14 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
       [options, search, searchable],
     )
 
-    // Fix 2: Clamp highlightIndex so stale values never point out-of-bounds
+    // Clamp highlightIndex so stale values never point out of bounds. The
+    // lower bound matters: pressing ArrowDown against an empty list drives
+    // highlightIndex to -1, and options routinely arrive from an in-flight
+    // query, so without it a negative index survives into a populated list -
+    // aria-activedescendant would reference a nonexistent option and Enter
+    // would select nothing.
     const clampedHighlight = Math.min(
-      highlightIndex,
+      Math.max(highlightIndex, 0),
       Math.max(filteredOptions.length - 1, 0),
     )
 

--- a/ui/src/components/ui/Select.tsx
+++ b/ui/src/components/ui/Select.tsx
@@ -298,18 +298,37 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
       }
     }, [isOpen, positionMenu])
 
-    const handleTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
-      if (disabled) return
-      if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault()
-        // Position synchronously so the portalled menu is placed correctly
-        // on its very first paint, before the tracking effect's rAF fires.
-        positionMenu(ESTIMATED_MENU_HEIGHT)
-        setIsOpen(true)
+    // Highlight the currently selected option when the menu opens, falling
+    // back to the first option when nothing is selected or the value is not
+    // in the list. Read from `options`, not `filteredOptions` — every path
+    // that opens the menu does so with `search` already reset to '' (either
+    // it was never touched, or the prior close reset it), so the two are
+    // equivalent at open time and `options` avoids depending on a value that
+    // is about to be recomputed.
+    const getInitialHighlightIndex = () => {
+      const idx = options.findIndex((o) => o.value === value)
+      return idx >= 0 ? idx : 0
+    }
+
+    // Commits the highlighted option, shared by Enter (trigger and listbox)
+    // and Space (trigger only, menu open).
+    const selectHighlighted = () => {
+      const opt = filteredOptions[clampedHighlight]
+      if (opt != null) {
+        onChange(opt.value)
+        closeDropdown()
+        // Fix 4: Return focus to trigger after selection via keyboard
+        internalRef.current?.focus()
       }
     }
 
-    const handleDropdownKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    // Shared arrow/Home/End/Enter navigation, operating on filteredOptions
+    // and clampedHighlight. Used by the trigger while the menu is open (the
+    // WAI-ARIA combobox pattern — focus stays on the trigger) and by the
+    // listbox in searchable mode, where focus sits in the search input and
+    // these events reach the listbox's onKeyDown by bubbling. Space is
+    // deliberately not handled here — see handleTriggerKeyDown.
+    const handleNavigationKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
       switch (e.key) {
         case 'ArrowDown':
           e.preventDefault()
@@ -319,17 +338,10 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
           e.preventDefault()
           setHighlightIndex((i) => Math.max(i - 1, 0))
           break
-        case 'Enter': {
+        case 'Enter':
           e.preventDefault()
-          const opt = filteredOptions[clampedHighlight]
-          if (opt != null) {
-            onChange(opt.value)
-            closeDropdown()
-            // Fix 4: Return focus to trigger after selection via keyboard
-            internalRef.current?.focus()
-          }
+          selectHighlighted()
           break
-        }
         case 'Home':
           e.preventDefault()
           setHighlightIndex(0)
@@ -339,6 +351,34 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
           setHighlightIndex(Math.max(filteredOptions.length - 1, 0))
           break
       }
+    }
+
+    const handleTriggerKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (disabled) return
+      if (!isOpen) {
+        if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          // Position synchronously so the portalled menu is placed correctly
+          // on its very first paint, before the tracking effect's rAF fires.
+          positionMenu(ESTIMATED_MENU_HEIGHT)
+          setHighlightIndex(getInitialHighlightIndex())
+          setIsOpen(true)
+        }
+        return
+      }
+      // Menu open: Space selects like a native <select>, everything else
+      // delegates to the shared navigation handler. Space stays trigger-only
+      // — in the listbox it is ordinary typing in the search input.
+      if (e.key === ' ') {
+        e.preventDefault()
+        selectHighlighted()
+        return
+      }
+      handleNavigationKeyDown(e)
+    }
+
+    const handleDropdownKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+      handleNavigationKeyDown(e)
     }
 
     const handleOptionClick = (optValue: string) => {
@@ -386,6 +426,7 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
               // Position synchronously so the portalled menu is placed
               // correctly on its very first paint.
               positionMenu(ESTIMATED_MENU_HEIGHT)
+              setHighlightIndex(getInitialHighlightIndex())
               setIsOpen(true)
             }
           }}

--- a/ui/src/components/ui/Select.tsx
+++ b/ui/src/components/ui/Select.tsx
@@ -335,22 +335,23 @@ export const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
     // deliberately not handled here — see handleTriggerKeyDown.
     const handleNavigationKeyDown = (e: React.KeyboardEvent<HTMLElement>) => {
       switch (e.key) {
-        // Clamp the previous value inside the updater rather than stepping
-        // from the render-scoped clampedHighlight. Two reasons, and both are
-        // needed: the raw state can sit outside the valid range (ArrowDown
-        // against an empty list leaves it at -1) while the display already
-        // shows the clamped one, so an unclamped base swallows a press; and
-        // the functional form keeps the base current when several key events
-        // land in the same batch, which a render-scoped value would not.
+        // Clamp inside the updater, on both the previous value and the result.
+        // The functional form keeps the base current when several key events
+        // land in the same batch, which a render-scoped value would not;
+        // clamping the base stops an out-of-range value from swallowing a
+        // press; and clamping the result keeps the stored index valid even for
+        // an empty list, where stepping down would otherwise land on -1 again.
         case 'ArrowDown':
           e.preventDefault()
           setHighlightIndex((i) =>
-            Math.min(clampIndex(i, filteredOptions.length) + 1, filteredOptions.length - 1),
+            clampIndex(clampIndex(i, filteredOptions.length) + 1, filteredOptions.length),
           )
           break
         case 'ArrowUp':
           e.preventDefault()
-          setHighlightIndex((i) => Math.max(clampIndex(i, filteredOptions.length) - 1, 0))
+          setHighlightIndex((i) =>
+            clampIndex(clampIndex(i, filteredOptions.length) - 1, filteredOptions.length),
+          )
           break
         case 'Enter':
           e.preventDefault()


### PR DESCRIPTION
Closes #191.

Focus stays on the trigger when a `Select` is not searchable, and all navigation lived on the listbox div. The two are siblings - in the DOM and, since the menu is portalled, in the React tree - so trigger keydowns never reached it. Arrows and Home/End did nothing, and Enter merely re-opened. That is 33 of the component's 34 usages, including every model and key creation dialog.

The keys are handled on the trigger now, which is the WAI-ARIA combobox pattern the component already half-declared by putting `aria-activedescendant` there. Space selects like a native select but only from the trigger, since inside the search box it is ordinary typing. Opening seeds the highlight on the current value rather than the top of the list, and Tab closes the menu instead of leaving it standing behind a moved focus.

## The tests were the actual problem

The existing keyboard tests dispatched keydowns straight at the listbox - an element no user can focus. They passed against the broken code and proved nothing. They now drive the trigger, and **nine of them fail if the delegation is removed**. That rewrite is the real evidence here, more than the fix itself.

## What review turned up

Three follow-on defects, each found after the previous fix:

- The highlight clamp bounded only the upper end, so ArrowDown against an empty list left the index at -1 and it survived into a later populated list - and since every Select here is fed from an in-flight query, options routinely arrive while the menu is open. `aria-activedescendant` then referenced an option that does not exist and Enter selected nothing.
- Clamping only the derived value left the raw state free to diverge, and the arrows stepped from the raw one, so the first press after recovery was swallowed. The first attempt at fixing that stepped from the render-scoped value instead - which gave up the very reason the functional setter form exists, since several key events in one batch would all read the same stale base. The clamp lives inside the updater now, which keeps both properties.
- Stepping down from a clamped base still stored -1 for an empty list. No visible effect, but the comment above it promised an invariant the code did not hold.

## Verification

395 UI tests. Every central claim is mutation-checked: the trigger delegation, the Space case, the initial highlight seed, the Tab close, the lower bound and the post-recovery advance each turn tests red when removed.

Three review rounds; the last reported the branch sound apart from the invariant note above, which this branch closes.