### PR TITLE
chore: release 0.0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to VoidLLM are documented in this file.
 
+## [0.0.25] - 2026-07-26
+
+### Features
+- Cached prompt tokens are tracked and priced. Every major provider bills tokens served from a prompt cache differently from fresh input, and cache writes differently again, so a single input rate drifted from the real bill the better a customer's cache hit rate was. Models gain optional cached-input and cache-write prices; when they are unset the cost is calculated exactly as before (#188)
+
+### Fixes
+- A `429` from an upstream deployment now fails over to the next one instead of being returned to the client. It is also no longer recorded as a circuit-breaker success, which previously reset the accumulated failure count for that deployment. The deployment enters a short cooldown derived from `Retry-After`, and model-level fallback treats a rate limit as a reason to fall back (#185)
+- Anthropic prompt and total token counts were under-reported whenever prompt caching was used, because the separate cache-read and cache-write counters were discarded. That also under-consumed token budgets, since those read the total (#188)
+- Health probes are built the way each provider expects. They were OpenAI-shaped for every upstream, so probes against Anthropic, Gemini, Azure and Vertex failed permanently, showing a wrong "degraded" status and spending a billable request on every interval. The same applied to the admin connection test, where an operator adding a correctly configured model was told it was broken (#190)
+- Probes with no equivalent for a provider, such as a model list on Azure, now report as not applicable rather than as a failure. Skipped model types previously reported success for a probe that never ran (#190)
+- Dropdowns opened from a table are no longer clipped by the table's scroll container, and they follow the trigger on scroll and resize (#192)
+- Dropdowns can be operated by keyboard. Arrow keys, Home, End and Enter did nothing unless the dropdown had a search box, which affects nearly every dropdown in the UI (#193)
+
+### Security
+- Dependency update addressing an advisory in the frontend build toolchain
+
+### Internal
+- The Helm chart is now published by the release workflow after the container image is built, so it can never reference an image that does not exist yet (#194)
+- CI caches Go and npm dependencies (#186)
+
+---
+
 ## [0.0.24] - 2026-07-24
 
 ### Fixes

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
 COPY --from=ui-builder /app/ui/dist ./ui/dist
-ARG VERSION=0.0.24
+ARG VERSION=0.0.25
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build \
     -ldflags="-s -w -X 'github.com/voidmind-io/voidllm/internal/api/health.Version=${VERSION}'" \
     -o /voidllm ./cmd/voidllm

--- a/chart/voidllm/Chart.yaml
+++ b/chart/voidllm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: voidllm
 description: Privacy-first LLM proxy and AI gateway with load balancing, RBAC, MCP gateway, and built-in admin UI. Self-hosted, single binary, sub-500us overhead.
 type: application
-version: 0.0.24
-appVersion: "0.0.24"
+version: 0.0.25
+appVersion: "0.0.25"
 home: https://voidllm.ai
 icon: https://voidllm.ai/logo.svg
 sources:

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -89,5 +89,5 @@ The Docker image sets `VOIDLLM_DATABASE_DSN=/data/voidllm.db` by default. Overri
 
 ```bash
 curl http://localhost:8080/healthz
-# {"status":"ok","uptime_seconds":42,"version":"0.0.24"}
+# {"status":"ok","uptime_seconds":42,"version":"0.0.25"}
 ```

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -2305,16 +2305,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {


### PR DESCRIPTION
Version bump for 0.0.25: CHANGELOG, Dockerfile `ARG VERSION`, Helm chart `version`/`appVersion`, and the `/healthz` example in the Docker deployment guide.

A fifth file rides along: `ui/package-lock.json`, carrying an `npm audit fix` for the `brace-expansion` DoS advisory. Small enough not to warrant its own cycle, and noted here because the release PR normally touches exactly four files.

## What is in it

Two real production defects:

- **A `429` from an upstream did not fail over**, and worse, was recorded as a circuit-breaker *success*, which reset the accumulated failure count for that deployment. Running several deployments across provider accounts is the standard way to stay under per-account limits, and that setup did nothing for the most common upstream failure.
- **Anthropic token counts were under-reported** whenever prompt caching was used, because the separate cache-read and cache-write counters were discarded. That skewed cost estimates and under-consumed token budgets, since those read the total.

Plus health probes that were OpenAI-shaped for every provider - so probes against Anthropic, Gemini, Azure and Vertex failed permanently, showed a wrong "degraded" status and spent a billable request on every interval - cached-token pricing, and two UI fixes: dropdowns clipped inside tables, and dropdowns that could not be operated by keyboard at all unless they had a search box.

The Helm chart ordering change from #194 takes effect with this release: the chart job runs after the image is built, so the window in which the chart pointed at an image that did not exist yet is gone.

## Note for the release

The tag goes on only after this is merged and `main` is green. The chart job now marks the `voidllm-0.0.25` release as a pre-release by itself - that manual step is retired.
