### PR TITLE
docs: document max_stream_duration and correct streaming-cutoff guidance

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,9 +23,12 @@ server:
   proxy:
     port: 8080              # Proxy port — LLM clients connect here
     read_timeout: 30s
-    write_timeout: 120s     # High for streaming responses
+    write_timeout: 120s     # Absolute response write deadline; raise for longer streams
     idle_timeout: 60s
     drain_timeout: 25s      # Graceful shutdown drain window (5s–120s)
+    # Hard cap on a single streaming response, used when the model sets no
+    # timeout of its own. Default 5m; accepted range 10s–1h inclusive.
+    max_stream_duration: 5m
 
   # Optional: separate admin port for UI + Admin API
   admin:
@@ -35,6 +38,34 @@ server:
       cert: /certs/tls.crt
       key: /certs/tls.key
 ```
+
+**Streaming and timeouts.** Several independent settings can end a streaming response, and
+whichever is reached first wins.
+
+`max_stream_duration` is a hard wall-clock cap on a single streaming response, measured from
+when VoidLLM begins streaming the upstream response to the client. It is not reset by
+activity: a stream still producing tokens is aborted once the cap is reached. When it fires,
+VoidLLM cancels the upstream request and logs `stream timeout exceeded, aborting upstream
+connection`. Depending on the provider, the upstream's own logs may then show only a client
+cancellation, or no error at all, which can make the cutoff look like a model failure.
+
+A per-model `timeout` **replaces** this global value rather than combining with it. A model
+with `timeout: 30s` is capped at 30 seconds even when `max_stream_duration` is an hour, and a
+model with `timeout: 10m` streams for ten minutes despite a 5m global cap.
+
+`write_timeout` is a separate absolute deadline on writing the response, and it is likewise
+not refreshed by streaming activity, so it can truncate a stream on its own. Raising it does
+not extend a stream beyond the effective duration cap, and raising that cap does not help
+while `write_timeout` is shorter, so a long stream needs both to be large enough.
+
+`idle_timeout` governs idle keep-alive connections, not the duration of an active streaming
+response.
+
+Reasoning-heavy models and long agentic completions can exceed the 5m default. When serving
+them, raise `max_stream_duration` (or set a per-model `timeout`) together with `write_timeout`.
+Requests issued through the admin UI's playground are tunneled in-process, and they may be
+capped slightly below the hosting server's `write_timeout` no matter how the settings above
+are configured.
 
 ## Database
 
@@ -68,7 +99,9 @@ models:
     provider: ollama              # openai, anthropic, azure, vllm, ollama, custom
     base_url: http://localhost:11434/v1
     api_key: ${OLLAMA_KEY}        # Optional, depends on provider
-    timeout: 30s                  # Per-model upstream timeout (default: 5min)
+    # timeout: 10m                # Optional. Replaces server.proxy.max_stream_duration
+                                  # for this model, for both streaming and non-streaming
+                                  # requests. Omit to use the global cap.
     aliases:                      # Alternative names clients can use
       - dolphin
       - default

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -56,9 +56,19 @@ If you missed them, delete the database and restart to re-bootstrap.
 - Most-restrictive-wins: the tightest limit anywhere in the hierarchy applies
 
 ### Streaming responses cut off
+- Check the logs for `stream timeout exceeded, aborting upstream connection`. This log
+  identifies the effective stream-duration cap as the cause: the model's `timeout` when one is
+  configured, otherwise `server.proxy.max_stream_duration` (default 5m, maximum 1h). Note that
+  a per-model `timeout` replaces the global cap rather than combining with it, so a low
+  per-model value overrides a high global one.
+- `write_timeout` is a separate absolute write deadline, and it can truncate an active stream
+  on its own. Raising it does not lift the duration cap, and raising that cap does not help
+  while `write_timeout` is shorter, so a long stream needs both to be large enough.
 - Reverse proxy may be buffering responses - set `proxy_buffering off` in Nginx
-- Upstream timeout may be too short - increase `write_timeout` in server config
-- Check per-model timeout if set
+
+When a stream is cut this way the upstream request is cancelled, so depending on the provider
+its logs may show only a client cancellation or no error at all, which can make the cutoff
+look like a model failure.
 
 ## MCP Issues
 


### PR DESCRIPTION
## The problem

`server.proxy.max_stream_duration` caps every streaming response at 5 minutes by default (`internal/proxy/handler.go:122`), but it is documented nowhere. It appears in neither `docs/configuration.md`, `docs/troubleshooting.md`, nor `README.md`. Its only occurrence outside `internal/` is the Helm chart (`chart/voidllm/values.yaml:33`), so anyone deploying via plain YAML or Docker has no way to learn the setting exists.

The troubleshooting entry titled **"Streaming responses cut off"** made this worse rather than better. It recommended increasing `write_timeout`, which does not lift the cap. An operator hitting a real cutoff and following the documented advice leaves the actual cause untouched.

That is not hypothetical. Serving a local vLLM backend, long agentic completions were being cut mid-generation with `stream aborted` client-side and no error at all from the model. Raising `write_timeout` from 600s to 3600s per the docs changed nothing. The gateway log showed the real cause:

```
WARN stream timeout exceeded, aborting upstream connection
```

## The change

Documentation only. No code changes.

**`docs/configuration.md`**
- Add `max_stream_duration` to the `server.proxy` example with its default and its accepted 10s–1h inclusive range.
- Add a "Streaming and timeouts" section explaining how the settings relate: a per-model `timeout` **replaces** the global cap rather than combining with it (`internal/proxy/handler.go:852-870`); `write_timeout` is an independent absolute write deadline that is not refreshed by streaming activity and can truncate a stream by itself (`internal/app/routes.go:62-75`); `idle_timeout` does not govern active streams.
- Replace `write_timeout: 120s  # High for streaming responses`. At 120s it is *shorter* than the 5m stream cap, so it is not high for streaming.
- Comment out the per-model `timeout: 30s` example. Because a per-model timeout replaces the global value, copying that block silently capped the model at 30 seconds regardless of `max_stream_duration`.

**`docs/troubleshooting.md`**
- Lead with the `stream timeout exceeded, aborting upstream connection` log line, which identifies the cause unambiguously.
- Correct the `write_timeout` bullet to state what it does and does not do.
- Note that the upstream request is cancelled, so a provider may log only a client cancellation or nothing at all, which makes the cutoff look like a model failure.

## Verification

Every claim was checked against the source rather than inferred from behaviour: the 300s default and its `<= 0` fallback (`handler.go:122`, `handler.go:845-848`, `config.go:765-767`), the inclusive 10s–1h validation bounds (`internal/config/validate.go:91-97`), the timer being a hard wall-clock cap never reset by activity (`handler.go:1215-1224`, and the existing regression test `internal/proxy/stream_duration_abort_test.go` which sends chunks every 20ms and still observes cancellation at the cap), the byte-exact log string, and the per-model override semantics.

The draft was then adversarially reviewed against the source, which caught three material errors in it: an initial claim that `write_timeout` was simply unrelated to stream cutoffs (it is an independent cap that can also truncate), the omission of the per-model override entirely, and an overstated claim that upstream providers never log an error. All three are corrected above.